### PR TITLE
feat: P0 refactors — deprecate AgentMiddleware, add TypedRunnable<I,O>

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,8 @@ crates/
 - `cognisgraph` depends only on `cognis-core`
 - `cognis` depends only on `cognis-core`
 - `cognisagent` depends on `cognis-core`, `cognis`, and `cognisgraph`
-- Agent-level middleware (filesystem, memory, subagent, planning, skills) belongs **only** in `cognisagent`, never in `cognis`
+- Agent **orchestration** middleware (filesystem, memory, subagent, planning, skills, todo, prompt caching) belongs in `cognisagent`
+- Agent **policy** building blocks (retry, rate limiting, PII, redaction, model fallback) live in `cognis` — these implement the deprecated `AgentMiddleware` trait and will migrate to `cognisagent::Middleware` in a future release
 - `cognis` contains **provider implementations, data utilities, and composable building blocks** — not agent orchestration
 
 ## Feature Flags

--- a/crates/cognis-core/src/runnables/mod.rs
+++ b/crates/cognis-core/src/runnables/mod.rs
@@ -30,6 +30,7 @@ pub mod sequence;
 pub mod serialization;
 pub mod timeout;
 pub mod tracing;
+pub mod typed;
 
 use std::pin::Pin;
 
@@ -113,6 +114,7 @@ pub use tracing::{
     CompactTraceFormatter, JsonTraceFormatter, SpanResult, TextTraceFormatter, TraceCollector,
     TraceEntry, TraceExporter, TraceFormatter, TraceLevel, TraceSpan,
 };
+pub use typed::{DynRunnable, FromDynRunnable, TypedRunnable, TypedSequence};
 
 /// Creates a `RunnableSequence` from a list of runnables.
 ///

--- a/crates/cognis-core/src/runnables/typed.rs
+++ b/crates/cognis-core/src/runnables/typed.rs
@@ -1,0 +1,260 @@
+//! Type-safe runnable trait for compile-time checked pipelines.
+//!
+//! [`TypedRunnable<I, O>`] provides the same semantics as [`Runnable`] but
+//! with concrete input/output types. Use it when types flowing through a
+//! pipeline are known at compile time.
+//!
+//! For heterogeneous composition (mixing different I/O types), use
+//! [`DynRunnable`] to erase types back to `Value`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::error::{CognisError, Result};
+
+use super::base::Runnable;
+use super::config::RunnableConfig;
+
+/// A runnable with concrete input and output types.
+#[async_trait]
+pub trait TypedRunnable<I, O>: Send + Sync
+where
+    I: Serialize + Send + 'static,
+    O: DeserializeOwned + Send + 'static,
+{
+    /// Returns the name of this runnable.
+    fn name(&self) -> &str;
+
+    /// Invoke with a typed input, returning a typed output.
+    async fn invoke(&self, input: I, config: Option<&RunnableConfig>) -> Result<O>;
+
+    /// Process multiple inputs sequentially.
+    async fn batch(&self, inputs: Vec<I>, config: Option<&RunnableConfig>) -> Result<Vec<O>> {
+        let mut results = Vec::with_capacity(inputs.len());
+        for input in inputs {
+            results.push(self.invoke(input, config).await?);
+        }
+        Ok(results)
+    }
+}
+
+/// Wraps a [`TypedRunnable<I, O>`] as a [`Runnable`] (Value-based).
+pub struct DynRunnable<I, O>
+where
+    I: DeserializeOwned + Serialize + Send + 'static,
+    O: Serialize + DeserializeOwned + Send + 'static,
+{
+    inner: Arc<dyn TypedRunnable<I, O>>,
+}
+
+impl<I, O> DynRunnable<I, O>
+where
+    I: DeserializeOwned + Serialize + Send + 'static,
+    O: Serialize + DeserializeOwned + Send + 'static,
+{
+    /// Wrap a typed runnable for dynamic composition.
+    pub fn new(inner: Arc<dyn TypedRunnable<I, O>>) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl<I, O> Runnable for DynRunnable<I, O>
+where
+    I: DeserializeOwned + Serialize + Send + Sync + 'static,
+    O: Serialize + DeserializeOwned + Send + Sync + 'static,
+{
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    async fn invoke(&self, input: Value, config: Option<&RunnableConfig>) -> Result<Value> {
+        let typed_input: I = serde_json::from_value(input)
+            .map_err(|e| CognisError::Other(format!("input deserialization: {}", e)))?;
+        let typed_output = self.inner.invoke(typed_input, config).await?;
+        serde_json::to_value(typed_output)
+            .map_err(|e| CognisError::Other(format!("output serialization: {}", e)))
+    }
+}
+
+/// Wraps a [`Runnable`] as a [`TypedRunnable<I, O>`].
+pub struct FromDynRunnable<I, O> {
+    inner: Arc<dyn Runnable>,
+    _phantom: std::marker::PhantomData<(I, O)>,
+}
+
+impl<I, O> FromDynRunnable<I, O> {
+    /// Wrap a dynamic runnable for typed consumption.
+    pub fn new(inner: Arc<dyn Runnable>) -> Self {
+        Self {
+            inner,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+#[async_trait]
+impl<I, O> TypedRunnable<I, O> for FromDynRunnable<I, O>
+where
+    I: Serialize + Send + Sync + 'static,
+    O: DeserializeOwned + Send + Sync + 'static,
+{
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    async fn invoke(&self, input: I, config: Option<&RunnableConfig>) -> Result<O> {
+        let value_input = serde_json::to_value(input)
+            .map_err(|e| CognisError::Other(format!("input serialization: {}", e)))?;
+        let value_output = self.inner.invoke(value_input, config).await?;
+        serde_json::from_value(value_output)
+            .map_err(|e| CognisError::Other(format!("output deserialization: {}", e)))
+    }
+}
+
+/// Composes two typed runnables in sequence.
+pub struct TypedSequence<A, B, Mid> {
+    first: Arc<dyn TypedRunnable<A, Mid>>,
+    second: Arc<dyn TypedRunnable<Mid, B>>,
+}
+
+impl<A, B, Mid> TypedSequence<A, B, Mid>
+where
+    A: Serialize + Send + 'static,
+    B: DeserializeOwned + Send + 'static,
+    Mid: Serialize + DeserializeOwned + Send + 'static,
+{
+    /// Compose two typed runnables.
+    pub fn new(
+        first: Arc<dyn TypedRunnable<A, Mid>>,
+        second: Arc<dyn TypedRunnable<Mid, B>>,
+    ) -> Self {
+        Self { first, second }
+    }
+}
+
+#[async_trait]
+impl<A, B, Mid> TypedRunnable<A, B> for TypedSequence<A, B, Mid>
+where
+    A: Serialize + Send + Sync + 'static,
+    B: DeserializeOwned + Send + Sync + 'static,
+    Mid: Serialize + DeserializeOwned + Send + Sync + 'static,
+{
+    fn name(&self) -> &str {
+        "TypedSequence"
+    }
+
+    async fn invoke(&self, input: A, config: Option<&RunnableConfig>) -> Result<B> {
+        let mid = self.first.invoke(input, config).await?;
+        self.second.invoke(mid, config).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    struct AddOne;
+
+    #[async_trait]
+    impl TypedRunnable<i64, i64> for AddOne {
+        fn name(&self) -> &str {
+            "add_one"
+        }
+        async fn invoke(&self, input: i64, _config: Option<&RunnableConfig>) -> Result<i64> {
+            Ok(input + 1)
+        }
+    }
+
+    struct Double;
+
+    #[async_trait]
+    impl TypedRunnable<i64, i64> for Double {
+        fn name(&self) -> &str {
+            "double"
+        }
+        async fn invoke(&self, input: i64, _config: Option<&RunnableConfig>) -> Result<i64> {
+            Ok(input * 2)
+        }
+    }
+
+    struct IntToString;
+
+    #[async_trait]
+    impl TypedRunnable<i64, String> for IntToString {
+        fn name(&self) -> &str {
+            "to_string"
+        }
+        async fn invoke(&self, input: i64, _config: Option<&RunnableConfig>) -> Result<String> {
+            Ok(format!("result: {}", input))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_typed_invoke() {
+        let result = AddOne.invoke(5, None).await.unwrap();
+        assert_eq!(result, 6);
+    }
+
+    #[tokio::test]
+    async fn test_typed_batch() {
+        let results = AddOne.batch(vec![1, 2, 3], None).await.unwrap();
+        assert_eq!(results, vec![2, 3, 4]);
+    }
+
+    #[tokio::test]
+    async fn test_typed_sequence() {
+        let seq = TypedSequence::new(
+            Arc::new(AddOne) as Arc<dyn TypedRunnable<i64, i64>>,
+            Arc::new(Double) as Arc<dyn TypedRunnable<i64, i64>>,
+        );
+        let result = seq.invoke(5, None).await.unwrap();
+        assert_eq!(result, 12); // (5 + 1) * 2
+    }
+
+    #[tokio::test]
+    async fn test_typed_sequence_mixed_types() {
+        let seq = TypedSequence::new(
+            Arc::new(Double) as Arc<dyn TypedRunnable<i64, i64>>,
+            Arc::new(IntToString) as Arc<dyn TypedRunnable<i64, String>>,
+        );
+        let result = seq.invoke(7, None).await.unwrap();
+        assert_eq!(result, "result: 14");
+    }
+
+    #[tokio::test]
+    async fn test_dyn_runnable_bridge() {
+        let typed: Arc<dyn TypedRunnable<i64, i64>> = Arc::new(AddOne);
+        let dynamic: Arc<dyn Runnable> = Arc::new(DynRunnable::new(typed));
+        let result = dynamic.invoke(json!(10), None).await.unwrap();
+        assert_eq!(result, json!(11));
+    }
+
+    #[tokio::test]
+    async fn test_from_dyn_runnable_bridge() {
+        let dynamic = Arc::new(crate::runnables::lambda::RunnableLambda::new(
+            "add_ten",
+            |v: Value| async move {
+                let n = v.as_i64().unwrap_or(0);
+                Ok(json!(n + 10))
+            },
+        )) as Arc<dyn Runnable>;
+        let typed: FromDynRunnable<i64, i64> = FromDynRunnable::new(dynamic);
+        let result = typed.invoke(5, None).await.unwrap();
+        assert_eq!(result, 15);
+    }
+
+    #[tokio::test]
+    async fn test_dyn_runnable_bad_input_error() {
+        let typed: Arc<dyn TypedRunnable<i64, i64>> = Arc::new(AddOne);
+        let dynamic: Arc<dyn Runnable> = Arc::new(DynRunnable::new(typed));
+        let result = dynamic.invoke(json!("not a number"), None).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("deserialization"));
+    }
+}

--- a/crates/cognis/src/agents/executor.rs
+++ b/crates/cognis/src/agents/executor.rs
@@ -33,6 +33,7 @@ use cognis_core::runnables::config::RunnableConfig;
 use cognis_core::tools::base::BaseTool;
 use uuid::Uuid;
 
+#[allow(deprecated)]
 use super::middleware::types::AgentMiddleware;
 
 /// What to do when the agent hits the iteration or time limit.
@@ -111,6 +112,7 @@ pub struct AgentResult {
 pub struct AgentExecutorBuilder {
     model: Option<Arc<dyn BaseChatModel>>,
     tools: Vec<Arc<dyn BaseTool>>,
+    #[allow(deprecated)]
     middleware: Vec<Arc<dyn AgentMiddleware>>,
     max_iterations: usize,
     max_execution_time_secs: Option<u64>,
@@ -155,6 +157,7 @@ impl AgentExecutorBuilder {
     }
 
     /// Add a middleware.
+    #[allow(deprecated)]
     pub fn middleware(mut self, mw: Arc<dyn AgentMiddleware>) -> Self {
         self.middleware.push(mw);
         self
@@ -247,6 +250,7 @@ pub struct AgentExecutor {
     /// Available tools keyed by name.
     pub tools: HashMap<String, Arc<dyn BaseTool>>,
     /// Middleware pipeline (currently stored but not invoked in the base loop).
+    #[allow(deprecated)]
     pub middleware: Vec<Arc<dyn AgentMiddleware>>,
     /// Maximum iterations before stopping.
     pub max_iterations: usize,

--- a/crates/cognis/src/agents/middleware/mod.rs
+++ b/crates/cognis/src/agents/middleware/mod.rs
@@ -1,7 +1,18 @@
-//! Agent middleware system.
+//! Agent middleware building blocks.
 //!
-//! Provides middleware hooks for intercepting and modifying agent behavior
-//! at various points in the execution loop.
+//! # Deprecation Notice
+//!
+//! The [`AgentMiddleware`](types::AgentMiddleware) trait defined here is
+//! **deprecated**. For agent orchestration middleware, use
+//! `cognisagent::middleware::Middleware` instead.
+//!
+//! The concrete middleware implementations in this module (retry, rate
+//! limiting, PII detection, model fallback, etc.) are **reusable policy
+//! building blocks**. They currently implement the deprecated
+//! `AgentMiddleware` trait but their logic can be adapted for use with
+//! `cognisagent::Middleware`.
+
+#![allow(deprecated)]
 
 pub mod context_editing;
 pub mod execution;

--- a/crates/cognis/src/agents/middleware/types.rs
+++ b/crates/cognis/src/agents/middleware/types.rs
@@ -231,6 +231,10 @@ pub type AsyncModelHandler = Box<
 /// - `wrap_tool_call` — intercept tool execution
 ///
 /// All methods have default no-op implementations.
+#[deprecated(
+    since = "0.2.0",
+    note = "Use cognisagent::middleware::Middleware instead. AgentMiddleware is not invoked by the executor and will be removed in a future release."
+)]
 #[async_trait]
 pub trait AgentMiddleware: Send + Sync {
     /// The name of this middleware.

--- a/crates/cognis/src/agents/mod.rs
+++ b/crates/cognis/src/agents/mod.rs
@@ -22,6 +22,7 @@ pub use executor::{
     AgentResult, AgentStep, EarlyStoppingMethod, ExecutorConfig, ExecutorResult,
     PlannerAgentExecutor, PlannerAgentStep, ToolExecutor,
 };
+#[allow(deprecated)]
 pub use middleware::types::{
     AgentMiddleware, AgentState, JumpTo, ModelCallResult, ModelRequest, ModelResponse,
 };

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -341,3 +341,7 @@ path = "../../examples/resilience/rate_limiter.rs"
 [[example]]
 name = "ollama_tool_calling"
 path = "../../examples/tools/ollama_tool_calling.rs"
+
+[[example]]
+name = "typed_runnable_demo"
+path = "../../examples/chains/typed_runnable_demo.rs"

--- a/examples/chains/typed_runnable_demo.rs
+++ b/examples/chains/typed_runnable_demo.rs
@@ -1,0 +1,260 @@
+//! Typed Runnable Demo
+//!
+//! Demonstrates compile-time type-safe runnable composition using
+//! `TypedRunnable<I, O>` alongside the dynamic `Runnable` (Value-based) system.
+//!
+//! Shows:
+//! - Defining typed runnables with concrete I/O types
+//! - Composing them with `TypedSequence`
+//! - Bridging typed->dynamic with `DynRunnable` for use with `|` operator
+//! - Bridging dynamic->typed with `FromDynRunnable`
+//!
+//! Run with: `cargo run -p cognis-examples --example typed_runnable_demo`
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use cognis_core::error::Result;
+use cognis_core::runnables::base::Runnable;
+use cognis_core::runnables::config::RunnableConfig;
+use cognis_core::runnables::lambda::RunnableLambda;
+use cognis_core::runnables::pipe::RunnableRef;
+use cognis_core::runnables::typed::{DynRunnable, FromDynRunnable, TypedRunnable, TypedSequence};
+
+// --- Typed Runnables ---------------------------------------------------------
+
+/// Parses a raw text query into a structured request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SearchRequest {
+    query: String,
+    max_results: usize,
+}
+
+struct ParseQuery;
+
+#[async_trait]
+impl TypedRunnable<String, SearchRequest> for ParseQuery {
+    fn name(&self) -> &str {
+        "parse_query"
+    }
+
+    async fn invoke(
+        &self,
+        input: String,
+        _config: Option<&RunnableConfig>,
+    ) -> Result<SearchRequest> {
+        Ok(SearchRequest {
+            query: input,
+            max_results: 5,
+        })
+    }
+}
+
+/// Simulates a search, returning scored results.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SearchResult {
+    title: String,
+    score: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SearchResponse {
+    results: Vec<SearchResult>,
+    total: usize,
+}
+
+struct ExecuteSearch;
+
+#[async_trait]
+impl TypedRunnable<SearchRequest, SearchResponse> for ExecuteSearch {
+    fn name(&self) -> &str {
+        "execute_search"
+    }
+
+    async fn invoke(
+        &self,
+        input: SearchRequest,
+        _config: Option<&RunnableConfig>,
+    ) -> Result<SearchResponse> {
+        // Simulate search results
+        let results = vec![
+            SearchResult {
+                title: format!("Best practices for {}", input.query),
+                score: 0.95,
+            },
+            SearchResult {
+                title: format!("{} tutorial", input.query),
+                score: 0.87,
+            },
+            SearchResult {
+                title: format!("Advanced {} techniques", input.query),
+                score: 0.82,
+            },
+        ];
+        let total = results.len();
+        Ok(SearchResponse { results, total })
+    }
+}
+
+/// Formats search results as a readable string.
+struct FormatResults;
+
+#[async_trait]
+impl TypedRunnable<SearchResponse, String> for FormatResults {
+    fn name(&self) -> &str {
+        "format_results"
+    }
+
+    async fn invoke(
+        &self,
+        input: SearchResponse,
+        _config: Option<&RunnableConfig>,
+    ) -> Result<String> {
+        let mut output = format!("Found {} results:\n", input.total);
+        for (i, r) in input.results.iter().enumerate() {
+            output.push_str(&format!(
+                "  {}. {} (score: {:.2})\n",
+                i + 1,
+                r.title,
+                r.score
+            ));
+        }
+        Ok(output)
+    }
+}
+
+// --- Numeric pipeline --------------------------------------------------------
+
+struct AddOne;
+
+#[async_trait]
+impl TypedRunnable<i64, i64> for AddOne {
+    fn name(&self) -> &str {
+        "add_one"
+    }
+    async fn invoke(&self, input: i64, _config: Option<&RunnableConfig>) -> Result<i64> {
+        Ok(input + 1)
+    }
+}
+
+struct Double;
+
+#[async_trait]
+impl TypedRunnable<i64, i64> for Double {
+    fn name(&self) -> &str {
+        "double"
+    }
+    async fn invoke(&self, input: i64, _config: Option<&RunnableConfig>) -> Result<i64> {
+        Ok(input * 2)
+    }
+}
+
+#[tokio::main]
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    println!("=== Typed Runnable Demo ===\n");
+
+    // -- 1. Type-safe composition with TypedSequence --------------------------
+
+    println!("--- 1. TypedSequence: Compile-Time Type Safety ---\n");
+
+    // String -> SearchRequest -> SearchResponse
+    let search_pipeline = TypedSequence::new(
+        Arc::new(ParseQuery) as Arc<dyn TypedRunnable<String, SearchRequest>>,
+        Arc::new(ExecuteSearch) as Arc<dyn TypedRunnable<SearchRequest, SearchResponse>>,
+    );
+
+    let response = search_pipeline
+        .invoke("Rust async".to_string(), None)
+        .await?;
+    println!("Search for 'Rust async': {} results found", response.total);
+
+    // Chain further: String -> SearchRequest -> SearchResponse -> String
+    let full_pipeline = TypedSequence::new(
+        Arc::new(search_pipeline) as Arc<dyn TypedRunnable<String, SearchResponse>>,
+        Arc::new(FormatResults) as Arc<dyn TypedRunnable<SearchResponse, String>>,
+    );
+
+    let formatted = full_pipeline
+        .invoke("Rust ownership".to_string(), None)
+        .await?;
+    println!("{}", formatted);
+
+    // -- 2. Numeric pipeline --------------------------------------------------
+
+    println!("--- 2. Numeric Pipeline: (x + 1) * 2 ---\n");
+
+    let numeric = TypedSequence::new(
+        Arc::new(AddOne) as Arc<dyn TypedRunnable<i64, i64>>,
+        Arc::new(Double) as Arc<dyn TypedRunnable<i64, i64>>,
+    );
+
+    let result = numeric.invoke(5, None).await?;
+    println!("(5 + 1) * 2 = {}", result);
+
+    let batch_results = numeric.batch(vec![1, 2, 3, 4, 5], None).await?;
+    println!("Batch: {:?}\n", batch_results);
+
+    // -- 3. Bridge: Typed -> Dynamic (for | operator) -------------------------
+
+    println!("--- 3. DynRunnable Bridge: Typed -> Dynamic ---\n");
+
+    let typed_add: Arc<dyn TypedRunnable<i64, i64>> = Arc::new(AddOne);
+    let dynamic_add: Arc<dyn Runnable> = Arc::new(DynRunnable::new(typed_add));
+
+    // Now usable with the | pipe operator
+    let dynamic_double = RunnableRef::new(Arc::new(RunnableLambda::new(
+        "double",
+        |v: Value| async move {
+            let n = v.as_i64().unwrap_or(0);
+            Ok(json!(n * 2))
+        },
+    )));
+
+    let chain = RunnableRef::new(dynamic_add) | dynamic_double;
+    let result = chain.runnable().invoke(json!(10), None).await?;
+    println!("Typed AddOne | Dynamic Double: 10 -> {}\n", result);
+
+    // -- 4. Bridge: Dynamic -> Typed ------------------------------------------
+
+    println!("--- 4. FromDynRunnable Bridge: Dynamic -> Typed ---\n");
+
+    let dyn_runnable = Arc::new(RunnableLambda::new(
+        "multiply_by_3",
+        |v: Value| async move {
+            let n = v.as_i64().unwrap_or(0);
+            Ok(json!(n * 3))
+        },
+    )) as Arc<dyn Runnable>;
+
+    let typed_mul3: FromDynRunnable<i64, i64> = FromDynRunnable::new(dyn_runnable);
+    let result = typed_mul3.invoke(7, None).await?;
+    println!("Dynamic multiply_by_3 as typed: 7 -> {}", result);
+
+    // Compose the typed wrapper with another typed runnable
+    let pipeline = TypedSequence::new(
+        Arc::new(typed_mul3) as Arc<dyn TypedRunnable<i64, i64>>,
+        Arc::new(AddOne) as Arc<dyn TypedRunnable<i64, i64>>,
+    );
+    let result = pipeline.invoke(10, None).await?;
+    println!("(10 * 3) + 1 = {}\n", result);
+
+    // -- 5. Type error demonstration ------------------------------------------
+
+    println!("--- 5. Type Safety: Bad Input Detection ---\n");
+
+    let typed_add: Arc<dyn TypedRunnable<i64, i64>> = Arc::new(AddOne);
+    let dynamic = Arc::new(DynRunnable::new(typed_add)) as Arc<dyn Runnable>;
+
+    // This will fail at runtime with a clear deserialization error
+    let bad_result = dynamic.invoke(json!("not a number"), None).await;
+    match bad_result {
+        Ok(_) => println!("Unexpected success"),
+        Err(e) => println!("Caught type error: {}", e),
+    }
+
+    println!("\n=== Done ===");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- **Deprecate `AgentMiddleware`** in cognis — the trait was stored by `AgentExecutor` but never invoked. Replaced by `cognisagent::middleware::Middleware` for agent orchestration
- **Add `TypedRunnable<I, O>`** trait for compile-time type-safe pipeline composition
- **Add `DynRunnable`** bridge — typed runnables can be used with `|` pipe operator and `RunnableSequence`
- **Add `FromDynRunnable`** bridge — dynamic `Runnable` can be consumed in typed pipelines
- **Add `TypedSequence<A, B, Mid>`** — compose two typed runnables where types must match at compile time
- **New example** `typed_runnable_demo` showing all composition patterns

## Crate boundary clarification

| Layer | Crate | What lives here |
|-------|-------|-----------------|
| Orchestration middleware | `cognisagent` | filesystem, memory, subagent, planning, skills, todo, prompt caching |
| Policy building blocks | `cognis` | retry, rate limiting, PII, redaction, model fallback (deprecated `AgentMiddleware` trait) |

## Test plan

- [x] 7 new tests for TypedRunnable (invoke, batch, sequence, mixed types, bridges, error handling)
- [x] All workspace tests pass (0 failures)
- [x] `cargo clippy --workspace --features all-providers -- -D warnings` clean
- [x] `cubic review --base origin/main` — no issues found
- [x] `typed_runnable_demo` example runs correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecates the unused `AgentMiddleware` in `cognis` and adds a compile-time type-safe runnable system with bridges to compose with existing `Runnable` pipelines. Clarifies crate boundaries: orchestration middleware lives in `cognisagent`; policy blocks stay in `cognis`.

- **New Features**
  - `TypedRunnable<I, O>` for type-safe invoke and batch.
  - `TypedSequence<A, B, Mid>` for compile-time checked composition.
  - Bridges: `DynRunnable` (typed → `Runnable`) and `FromDynRunnable` (`Runnable` → typed).
  - Exports added in `cognis-core::runnables`.
  - New example: `typed_runnable_demo` showing typed, dynamic, and mixed pipelines.
  - 7 tests covering invoke, batch, sequences, bridges, and errors.

- **Refactors**
  - Deprecated `cognis::agents::middleware::AgentMiddleware` (it was stored but never invoked); use `cognisagent::middleware::Middleware` for orchestration.
  - Updated `CLAUDE.md` to document crate boundaries: orchestration in `cognisagent`, policy building blocks (retry, rate limit, PII, redaction, fallback) in `cognis`.
  - Suppressed deprecation warnings in internal `cognis` uses while keeping the field for backward compatibility.

<sup>Written for commit e223e66f42e5c2a423d22c26bd1322955e25af2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

