### PR TITLE
feat+docs: agent guide, parallel tool calls (closes #12, #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,38 @@ while let Some(chunk) = stream.next().await {
 }
 ```
 
+### Building an Agent
+
+Chains answer questions. *Agents* loop over a model, call tools, and decide what to do next. Don't hand-roll the loop — `AgentExecutor` drives it for you:
+
+```rust
+use std::sync::Arc;
+use cognis::agents::AgentExecutor;
+use cognis_core::messages::Message;
+use cognis_core::tools::base::BaseTool;
+use cognis_core::tools::simple::SimpleTool;
+
+let search = SimpleTool::new(
+    "search",
+    "Search for information about a topic",
+    |query: &str| Ok(format!("Results for '{query}': ...")),
+);
+
+let executor = AgentExecutor::builder()
+    .model(model)
+    .tool(Arc::new(search) as Arc<dyn BaseTool>)
+    .max_iterations(10)
+    .handle_parsing_errors(true)
+    .build();
+
+let result = executor.run(&[Message::human("What is Rust?")]).await?;
+println!("{}", result.output);
+```
+
+No JSON parser, no scratchpad formatting, no per-provider tool-call handling. The executor appends `ToolMessage`s with correct `tool_call_id`s, stops on `max_iterations`, and supports callbacks for streaming intermediate steps.
+
+For the full walk-through — `SimpleTool` vs `StructuredTool` vs custom `BaseTool`, `with_structured_output`, `OutputFixingParser`, `CallbackHandler`, and the graph-based `create_react_agent` — see **[docs/building-an-agent.md](docs/building-an-agent.md)**.
+
 ## What's Included
 
 | Layer              | Crate         | What it does                                                                                                               |

--- a/crates/cognis-core/src/callbacks/events.rs
+++ b/crates/cognis-core/src/callbacks/events.rs
@@ -25,6 +25,12 @@ pub struct ToolStartEvent {
     pub tags: Vec<String>,
     /// Run-scoped metadata.
     pub metadata: HashMap<String, Value>,
+    /// Whether this tool invocation was dispatched in parallel with siblings
+    /// from the same assistant turn. `false` for serial dispatch.
+    pub parallel: bool,
+    /// Size of the dispatch batch (number of tool calls in the same assistant
+    /// turn). Always `1` in serial mode; `>= 1` in parallel mode.
+    pub batch_size: usize,
 }
 
 /// Emitted when a tool invocation completes successfully.

--- a/crates/cognis-core/src/callbacks/manager.rs
+++ b/crates/cognis-core/src/callbacks/manager.rs
@@ -367,6 +367,8 @@ mod tests {
             parent_run_id: None,
             tags: vec![],
             metadata: HashMap::new(),
+            parallel: false,
+            batch_size: 1,
         }
     }
 

--- a/crates/cognis-core/src/tracers/event_stream.rs
+++ b/crates/cognis-core/src/tracers/event_stream.rs
@@ -921,6 +921,8 @@ mod tests {
             parent_run_id: parent,
             tags: vec![],
             metadata: HashMap::new(),
+            parallel: false,
+            batch_size: 1,
         }
     }
 
@@ -1064,6 +1066,8 @@ mod tests {
                 parent_run_id: None,
                 tags: vec![],
                 metadata: HashMap::new(),
+                parallel: false,
+                batch_size: 1,
             })
             .await
             .unwrap();

--- a/crates/cognis-core/src/tracers/langsmith.rs
+++ b/crates/cognis-core/src/tracers/langsmith.rs
@@ -547,6 +547,8 @@ mod tests {
             parent_run_id: parent,
             tags: vec![],
             metadata: HashMap::new(),
+            parallel: false,
+            batch_size: 1,
         }
     }
 

--- a/crates/cognis-core/src/tracers/otel.rs
+++ b/crates/cognis-core/src/tracers/otel.rs
@@ -349,6 +349,8 @@ mod tests {
             parent_run_id: None,
             tags: vec![],
             metadata: std::collections::HashMap::new(),
+            parallel: false,
+            batch_size: 1,
         }
     }
 

--- a/crates/cognis/src/agents/executor.rs
+++ b/crates/cognis/src/agents/executor.rs
@@ -247,6 +247,19 @@ impl Default for AgentExecutorBuilder {
 }
 
 /// Executes an agent loop: model generates, tools execute, repeat until done.
+///
+/// # Tool-call dispatch
+///
+/// When the model emits multiple `tool_calls` in a single assistant turn
+/// (common with `gpt-4o`, `claude-3.5+`, and other parallel-tool-capable
+/// models), the executor dispatches them **serially** by default: each call
+/// awaits the previous one's completion before starting. For workloads that
+/// routinely call 3–5 independent tools per turn, this multiplies latency.
+///
+/// Set [`AgentExecutorBuilder::parallel_tool_calls(true)`] to opt into
+/// parallel dispatch via [`futures::future::try_join_all`]. Tool order in the
+/// resulting `ToolMessage` sequence is preserved regardless of completion
+/// order, so downstream correlation by `tool_call_id` is unaffected.
 pub struct AgentExecutor {
     /// The chat model used for generation.
     pub model: Arc<dyn BaseChatModel>,
@@ -470,6 +483,8 @@ impl AgentExecutor {
                         parent_run_id: Some(chain_run_id),
                         tags: vec![],
                         metadata: Default::default(),
+                        parallel: false,
+                        batch_size: 1,
                     })
                     .await;
 

--- a/crates/cognis/src/agents/executor.rs
+++ b/crates/cognis/src/agents/executor.rs
@@ -28,6 +28,7 @@ use cognis_core::callbacks::manager::CallbackManager;
 use cognis_core::callbacks::{ToolEndEvent, ToolErrorEvent, ToolErrorKind, ToolStartEvent};
 use cognis_core::error::{CognisError, Result};
 use cognis_core::language_models::chat_model::BaseChatModel;
+use cognis_core::messages::tool_types::ToolCall;
 use cognis_core::messages::{Message, ToolMessage};
 use cognis_core::runnables::base::Runnable;
 use cognis_core::runnables::config::RunnableConfig;
@@ -122,6 +123,7 @@ pub struct AgentExecutorBuilder {
     return_intermediate_steps: bool,
     early_stopping_method: Option<EarlyStoppingMethod>,
     handle_parsing_errors: bool,
+    parallel_tool_calls: bool,
     callbacks: Vec<Arc<dyn CallbackHandler>>,
 }
 
@@ -137,6 +139,7 @@ impl AgentExecutorBuilder {
             return_intermediate_steps: false,
             early_stopping_method: None,
             handle_parsing_errors: false,
+            parallel_tool_calls: false,
             callbacks: Vec::new(),
         }
     }
@@ -201,6 +204,24 @@ impl AgentExecutorBuilder {
         self
     }
 
+    /// Dispatch multi-tool-call turns in parallel (default: false).
+    ///
+    /// When the model emits more than one tool call in a single assistant
+    /// turn and this is `true`, the executor runs them concurrently via
+    /// [`futures::future::try_join_all`] instead of awaiting each in turn.
+    /// Output ordering in the resulting `ToolMessage` sequence is preserved,
+    /// so correlation by `tool_call_id` remains deterministic.
+    ///
+    /// Leave at the default (`false`) for tools with shared mutable state
+    /// or ordering dependencies. Turn on when tools are independent
+    /// (DB reads, API fetches, computations) — the model already decided
+    /// to call all of them without seeing each other's output, so parallel
+    /// execution is semantically equivalent.
+    pub fn parallel_tool_calls(mut self, yes: bool) -> Self {
+        self.parallel_tool_calls = yes;
+        self
+    }
+
     /// Add a single callback handler.
     pub fn callback(mut self, handler: Arc<dyn CallbackHandler>) -> Self {
         self.callbacks.push(handler);
@@ -235,6 +256,7 @@ impl AgentExecutorBuilder {
             return_intermediate_steps: self.return_intermediate_steps,
             early_stopping_method: self.early_stopping_method,
             handle_parsing_errors: self.handle_parsing_errors,
+            parallel_tool_calls: self.parallel_tool_calls,
             callbacks: self.callbacks,
         }
     }
@@ -279,6 +301,8 @@ pub struct AgentExecutor {
     pub early_stopping_method: Option<EarlyStoppingMethod>,
     /// Whether to handle parsing errors by feeding the error back to the model.
     pub handle_parsing_errors: bool,
+    /// Whether to dispatch multi-tool-call turns in parallel.
+    pub parallel_tool_calls: bool,
     /// Callback handlers for observability events.
     pub callbacks: Vec<Arc<dyn CallbackHandler>>,
 }
@@ -465,147 +489,49 @@ impl AgentExecutor {
                 });
             }
 
-            // Execute each tool call
-            for tool_call in &ai_msg.tool_calls {
-                let tool_call_id_opt = tool_call.id.clone();
-                let tool_run_id = Uuid::new_v4();
-                let args_value = serde_json::to_value(&tool_call.args).unwrap_or_default();
-                let tool_input_str = serde_json::to_string(&args_value).unwrap_or_default();
+            // Dispatch tool calls — parallel or serial, per builder config.
+            let batch_size = ai_msg.tool_calls.len();
+            let parallel = self.parallel_tool_calls && batch_size > 1;
 
-                let _ = cb
-                    .on_tool_start(ToolStartEvent {
-                        tool: tool_call.name.clone(),
-                        serialized: serde_json::json!({ "name": &tool_call.name }),
-                        input_str: tool_input_str.clone(),
-                        inputs: args_value.clone(),
-                        tool_call_id: tool_call_id_opt.clone(),
-                        run_id: tool_run_id,
-                        parent_run_id: Some(chain_run_id),
-                        tags: vec![],
-                        metadata: Default::default(),
-                        parallel: false,
-                        batch_size: 1,
-                    })
-                    .await;
-
-                let (result_text, result_artifact) = match self.tools.get(&tool_call.name) {
-                    Some(tool) => {
-                        let input = value_to_tool_input(&args_value);
-                        let tool_result = tokio::select! {
-                            biased;
-                            _ = cancel.cancelled() => {
-                                let reason = "cancelled during tool call";
-                                let _ = cb
-                                    .on_tool_error(ToolErrorEvent {
-                                        tool: tool_call.name.clone(),
-                                        error: reason.into(),
-                                        error_kind: ToolErrorKind::Other,
-                                        tool_call_id: tool_call_id_opt.clone(),
-                                        run_id: tool_run_id,
-                                        parent_run_id: Some(chain_run_id),
-                                    })
-                                    .await;
+            let tool_results: Vec<(AgentStep, Message)> = if parallel {
+                let futures = ai_msg.tool_calls.iter().map(|tc| {
+                    self.execute_one_tool_call(tc, chain_run_id, &cb, &cancel, parallel, batch_size)
+                });
+                match futures::future::try_join_all(futures).await {
+                    Ok(results) => results,
+                    Err(e) => {
+                        // Any tool returning Cancelled short-circuits the
+                        // batch; surface agent-level cancel events once.
+                        if let CognisError::Cancelled(reason) = &e {
+                            let _ = cb.on_agent_cancelled(reason, chain_run_id).await;
+                            let _ = cb.on_chain_error(reason, chain_run_id).await;
+                        }
+                        return Err(e);
+                    }
+                }
+            } else {
+                let mut results = Vec::with_capacity(batch_size);
+                for tc in &ai_msg.tool_calls {
+                    match self
+                        .execute_one_tool_call(tc, chain_run_id, &cb, &cancel, parallel, batch_size)
+                        .await
+                    {
+                        Ok(r) => results.push(r),
+                        Err(e) => {
+                            if let CognisError::Cancelled(reason) = &e {
                                 let _ = cb.on_agent_cancelled(reason, chain_run_id).await;
                                 let _ = cb.on_chain_error(reason, chain_run_id).await;
-                                return Err(CognisError::Cancelled(reason.into()));
                             }
-                            r = tool._run(input) => r,
-                        };
-                        match tool_result {
-                            Ok(output) => {
-                                let (content, artifact) = match output {
-                                    ToolOutput::Content(v) => (v, None),
-                                    ToolOutput::ContentAndArtifact { content, artifact } => {
-                                        (content, Some(artifact))
-                                    }
-                                };
-                                let text = value_to_observation_str(&content);
-                                let _ = cb
-                                    .on_tool_end(ToolEndEvent {
-                                        tool: tool_call.name.clone(),
-                                        output_str: text.clone(),
-                                        output_value: content,
-                                        artifact: artifact.clone(),
-                                        tool_call_id: tool_call_id_opt.clone(),
-                                        run_id: tool_run_id,
-                                        parent_run_id: Some(chain_run_id),
-                                    })
-                                    .await;
-                                (text, artifact)
-                            }
-                            Err(e) => {
-                                let kind = match &e {
-                                    CognisError::ToolException(_)
-                                    | CognisError::ToolValidationError(_) => {
-                                        ToolErrorKind::Execution
-                                    }
-                                    _ => ToolErrorKind::Other,
-                                };
-                                // Apply the tool's configured error-handler policy.
-                                let handler_policy = match &e {
-                                    CognisError::ToolValidationError(_) => {
-                                        tool.handle_validation_error().clone()
-                                    }
-                                    _ => tool.handle_tool_error().clone(),
-                                };
-                                let err_fallback = format!("Error: {e}");
-                                let observation = apply_error_handler(&handler_policy, e)
-                                    .unwrap_or_else(|_| Value::String(err_fallback.clone()));
-                                let err_text = match &observation {
-                                    Value::String(s) => s.clone(),
-                                    other => other.to_string(),
-                                };
-                                let _ = cb
-                                    .on_tool_error(ToolErrorEvent {
-                                        tool: tool_call.name.clone(),
-                                        error: err_text.clone(),
-                                        error_kind: kind,
-                                        tool_call_id: tool_call_id_opt.clone(),
-                                        run_id: tool_run_id,
-                                        parent_run_id: Some(chain_run_id),
-                                    })
-                                    .await;
-                                (err_text, None)
-                            }
+                            return Err(e);
                         }
                     }
-                    None => {
-                        let err_text = format!("Error: tool '{}' not found", tool_call.name);
-                        let _ = cb
-                            .on_tool_error(ToolErrorEvent {
-                                tool: tool_call.name.clone(),
-                                error: err_text.clone(),
-                                error_kind: ToolErrorKind::NotFound,
-                                tool_call_id: tool_call_id_opt.clone(),
-                                run_id: tool_run_id,
-                                parent_run_id: Some(chain_run_id),
-                            })
-                            .await;
-                        (err_text, None)
-                    }
-                };
+                }
+                results
+            };
 
-                // Record intermediate step
-                intermediate_steps.push(AgentStep {
-                    action: AgentAction::new(
-                        tool_call.name.clone(),
-                        args_value.clone(),
-                        format!(
-                            "Calling tool `{}` with args: {}",
-                            tool_call.name, tool_input_str
-                        ),
-                    ),
-                    observation: result_text.clone(),
-                });
-
-                let tool_call_id = tool_call_id_opt.unwrap_or_default();
-                let tm = match result_artifact {
-                    Some(artifact) => {
-                        ToolMessage::with_artifact(&result_text, &tool_call_id, artifact)
-                    }
-                    None => ToolMessage::new(&result_text, &tool_call_id),
-                };
-                messages.push(Message::Tool(tm));
+            for (step, tool_message) in tool_results {
+                intermediate_steps.push(step);
+                messages.push(tool_message);
             }
         }
 
@@ -631,6 +557,168 @@ impl AgentExecutor {
                 Err(err)
             }
         }
+    }
+
+    /// Execute a single tool call end-to-end: emit `on_tool_start`, invoke
+    /// the tool (honouring `cancel`), emit `on_tool_end` / `on_tool_error`,
+    /// and return the resulting `AgentStep` + `ToolMessage` ready to be
+    /// appended to the conversation.
+    ///
+    /// Tool-level errors (including validation failures and missing-tool)
+    /// are converted to observation strings via `apply_error_handler` and
+    /// returned as `Ok` — matching the existing non-cancelling error model.
+    /// The only `Err` path is `CognisError::Cancelled`, which the caller
+    /// is responsible for surfacing as agent-level `on_agent_cancelled` /
+    /// `on_chain_error` events (fired once per batch in parallel mode).
+    ///
+    /// `parallel` and `batch_size` are threaded through to
+    /// [`ToolStartEvent`] so UIs can render "running N tools" groups.
+    async fn execute_one_tool_call(
+        &self,
+        tool_call: &ToolCall,
+        chain_run_id: Uuid,
+        cb: &CallbackManager,
+        cancel: &CancellationToken,
+        parallel: bool,
+        batch_size: usize,
+    ) -> Result<(AgentStep, Message)> {
+        let tool_call_id_opt = tool_call.id.clone();
+        let tool_run_id = Uuid::new_v4();
+        let args_value = serde_json::to_value(&tool_call.args).unwrap_or_default();
+        let tool_input_str = serde_json::to_string(&args_value).unwrap_or_default();
+
+        let _ = cb
+            .on_tool_start(ToolStartEvent {
+                tool: tool_call.name.clone(),
+                serialized: serde_json::json!({ "name": &tool_call.name }),
+                input_str: tool_input_str.clone(),
+                inputs: args_value.clone(),
+                tool_call_id: tool_call_id_opt.clone(),
+                run_id: tool_run_id,
+                parent_run_id: Some(chain_run_id),
+                tags: vec![],
+                metadata: Default::default(),
+                parallel,
+                batch_size,
+            })
+            .await;
+
+        let (result_text, result_artifact) = match self.tools.get(&tool_call.name) {
+            Some(tool) => {
+                let input = value_to_tool_input(&args_value);
+                let tool_result = tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => {
+                        let reason = "cancelled during tool call";
+                        let _ = cb
+                            .on_tool_error(ToolErrorEvent {
+                                tool: tool_call.name.clone(),
+                                error: reason.into(),
+                                error_kind: ToolErrorKind::Other,
+                                tool_call_id: tool_call_id_opt.clone(),
+                                run_id: tool_run_id,
+                                parent_run_id: Some(chain_run_id),
+                            })
+                            .await;
+                        return Err(CognisError::Cancelled(reason.into()));
+                    }
+                    r = tool._run(input) => r,
+                };
+                match tool_result {
+                    Ok(output) => {
+                        let (content, artifact) = match output {
+                            ToolOutput::Content(v) => (v, None),
+                            ToolOutput::ContentAndArtifact { content, artifact } => {
+                                (content, Some(artifact))
+                            }
+                        };
+                        let text = value_to_observation_str(&content);
+                        let _ = cb
+                            .on_tool_end(ToolEndEvent {
+                                tool: tool_call.name.clone(),
+                                output_str: text.clone(),
+                                output_value: content,
+                                artifact: artifact.clone(),
+                                tool_call_id: tool_call_id_opt.clone(),
+                                run_id: tool_run_id,
+                                parent_run_id: Some(chain_run_id),
+                            })
+                            .await;
+                        (text, artifact)
+                    }
+                    Err(e) => {
+                        let kind = match &e {
+                            CognisError::ToolException(_) | CognisError::ToolValidationError(_) => {
+                                ToolErrorKind::Execution
+                            }
+                            _ => ToolErrorKind::Other,
+                        };
+                        let handler_policy = match &e {
+                            CognisError::ToolValidationError(_) => {
+                                tool.handle_validation_error().clone()
+                            }
+                            _ => tool.handle_tool_error().clone(),
+                        };
+                        let err_fallback = format!("Error: {e}");
+                        let observation = apply_error_handler(&handler_policy, e)
+                            .unwrap_or_else(|_| Value::String(err_fallback.clone()));
+                        let err_text = match &observation {
+                            Value::String(s) => s.clone(),
+                            other => other.to_string(),
+                        };
+                        let _ = cb
+                            .on_tool_error(ToolErrorEvent {
+                                tool: tool_call.name.clone(),
+                                error: err_text.clone(),
+                                error_kind: kind,
+                                tool_call_id: tool_call_id_opt.clone(),
+                                run_id: tool_run_id,
+                                parent_run_id: Some(chain_run_id),
+                            })
+                            .await;
+                        (err_text, None)
+                    }
+                }
+            }
+            None => {
+                let err_text = format!("Error: tool '{}' not found", tool_call.name);
+                let _ = cb
+                    .on_tool_error(ToolErrorEvent {
+                        tool: tool_call.name.clone(),
+                        error: err_text.clone(),
+                        error_kind: ToolErrorKind::NotFound,
+                        tool_call_id: tool_call_id_opt.clone(),
+                        run_id: tool_run_id,
+                        parent_run_id: Some(chain_run_id),
+                    })
+                    .await;
+                (err_text, None)
+            }
+        };
+
+        let step = AgentStep {
+            action: AgentAction::new(
+                tool_call.name.clone(),
+                args_value,
+                format!(
+                    "Calling tool `{}` with args: {}",
+                    tool_call.name, tool_input_str
+                ),
+            ),
+            observation: result_text.clone(),
+        };
+
+        let tool_call_id = tool_call_id_opt.unwrap_or_default();
+        let tool_message = match result_artifact {
+            Some(artifact) => Message::Tool(ToolMessage::with_artifact(
+                &result_text,
+                &tool_call_id,
+                artifact,
+            )),
+            None => Message::Tool(ToolMessage::new(&result_text, &tool_call_id)),
+        };
+
+        Ok((step, tool_message))
     }
 
     /// Handle early stopping when the iteration or time limit is reached.
@@ -765,6 +853,7 @@ impl AgentExecutor {
             return_intermediate_steps: self.return_intermediate_steps,
             early_stopping_method: self.early_stopping_method,
             handle_parsing_errors: self.handle_parsing_errors,
+            parallel_tool_calls: self.parallel_tool_calls,
             callbacks,
         };
 

--- a/crates/cognis/tests/parallel_tool_dispatch.rs
+++ b/crates/cognis/tests/parallel_tool_dispatch.rs
@@ -1,0 +1,200 @@
+//! Integration tests for `AgentExecutor::parallel_tool_calls`.
+//!
+//! Covers (1) opt-in parallel dispatch beats serial latency, (2) tool-message
+//! ordering matches `tool_calls` order regardless of completion order, and
+//! (3) default serial dispatch is preserved when the knob is left off.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+
+use cognis::agents::AgentExecutor;
+use cognis_core::error::Result;
+use cognis_core::language_models::chat_model::BaseChatModel;
+use cognis_core::messages::tool_types::ToolCall;
+use cognis_core::messages::{AIMessage, Message};
+use cognis_core::outputs::{ChatGeneration, ChatResult};
+use cognis_core::tools::base::BaseTool;
+use cognis_core::tools::types::{ToolInput, ToolOutput};
+
+/// A chat model that, on the first call, emits N `tool_calls` naming each of
+/// `tool_names` (with no args), and on the second call returns a final text.
+struct BatchToolModel {
+    tool_names: Vec<String>,
+    call_count: AtomicU32,
+}
+
+impl BatchToolModel {
+    fn new(tool_names: Vec<&str>) -> Self {
+        Self {
+            tool_names: tool_names.into_iter().map(String::from).collect(),
+            call_count: AtomicU32::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl BaseChatModel for BatchToolModel {
+    async fn _generate(
+        &self,
+        _messages: &[Message],
+        _stop: Option<&[String]>,
+    ) -> Result<ChatResult> {
+        let n = self.call_count.fetch_add(1, Ordering::SeqCst);
+        let ai = if n == 0 {
+            let calls: Vec<ToolCall> = self
+                .tool_names
+                .iter()
+                .enumerate()
+                .map(|(i, name)| ToolCall {
+                    name: name.clone(),
+                    args: HashMap::new(),
+                    id: Some(format!("call_{i}")),
+                })
+                .collect();
+            AIMessage::new("").with_tool_calls(calls)
+        } else {
+            AIMessage::new("done")
+        };
+        Ok(ChatResult {
+            generations: vec![ChatGeneration::new(ai)],
+            llm_output: None,
+        })
+    }
+
+    fn llm_type(&self) -> &str {
+        "batch-tool-model"
+    }
+}
+
+/// A tool that sleeps for `delay` before returning its name.
+struct SleepyTool {
+    name: &'static str,
+    delay: Duration,
+}
+
+#[async_trait]
+impl BaseTool for SleepyTool {
+    fn name(&self) -> &str {
+        self.name
+    }
+    fn description(&self) -> &str {
+        "Sleeps then returns its name."
+    }
+    fn args_schema(&self) -> Option<Value> {
+        Some(json!({ "type": "object", "properties": {} }))
+    }
+    async fn _run(&self, _input: ToolInput) -> Result<ToolOutput> {
+        tokio::time::sleep(self.delay).await;
+        Ok(ToolOutput::Content(json!({ "from": self.name })))
+    }
+}
+
+fn tool(name: &'static str, delay_ms: u64) -> Arc<dyn BaseTool> {
+    Arc::new(SleepyTool {
+        name,
+        delay: Duration::from_millis(delay_ms),
+    })
+}
+
+#[tokio::test]
+async fn parallel_dispatch_runs_concurrently() {
+    let model = Arc::new(BatchToolModel::new(vec!["a", "b", "c"]));
+    let executor = AgentExecutor::builder()
+        .model(model)
+        .tool(tool("a", 120))
+        .tool(tool("b", 120))
+        .tool(tool("c", 120))
+        .parallel_tool_calls(true)
+        .max_iterations(5)
+        .build();
+
+    let start = Instant::now();
+    let result = executor.run(&[Message::human("go")]).await.unwrap();
+    let elapsed = start.elapsed();
+
+    // Serial would be >= 360ms (3 × 120ms). Parallel should land well under
+    // that — allow a generous 250ms ceiling to absorb scheduler jitter.
+    assert!(
+        elapsed < Duration::from_millis(250),
+        "parallel dispatch took {elapsed:?}, expected < 250ms",
+    );
+    assert_eq!(result.output, "done");
+}
+
+#[tokio::test]
+async fn serial_default_is_preserved() {
+    let model = Arc::new(BatchToolModel::new(vec!["a", "b", "c"]));
+    let executor = AgentExecutor::builder()
+        .model(model)
+        .tool(tool("a", 80))
+        .tool(tool("b", 80))
+        .tool(tool("c", 80))
+        .max_iterations(5)
+        .build();
+
+    let start = Instant::now();
+    let _ = executor.run(&[Message::human("go")]).await.unwrap();
+    let elapsed = start.elapsed();
+
+    // Serial: three sequential 80ms sleeps → >= ~240ms. Use 200ms as a safe
+    // lower bound to avoid flaking if timers underrun slightly.
+    assert!(
+        elapsed >= Duration::from_millis(200),
+        "serial dispatch took {elapsed:?}, expected >= 200ms",
+    );
+}
+
+#[tokio::test]
+async fn parallel_dispatch_preserves_tool_call_order() {
+    // Reverse delays so "a" finishes last — if we appended by completion
+    // order, "a" would appear after "b"/"c". We must see the original order.
+    let model = Arc::new(BatchToolModel::new(vec!["a", "b", "c"]));
+    let executor = AgentExecutor::builder()
+        .model(model)
+        .tool(tool("a", 150))
+        .tool(tool("b", 50))
+        .tool(tool("c", 10))
+        .parallel_tool_calls(true)
+        .return_intermediate_steps(true)
+        .build();
+
+    let result = executor.run(&[Message::human("go")]).await.unwrap();
+
+    let observed: Vec<&str> = result
+        .intermediate_steps
+        .iter()
+        .map(|s| s.action.tool_name.as_str())
+        .collect();
+    assert_eq!(observed, vec!["a", "b", "c"]);
+
+    // ToolMessage sequence in messages should match too.
+    let tool_msgs: Vec<&str> = result
+        .messages
+        .iter()
+        .filter_map(|m| match m {
+            Message::Tool(t) => Some(t.tool_call_id.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(tool_msgs, vec!["call_0", "call_1", "call_2"]);
+}
+
+#[tokio::test]
+async fn parallel_flag_is_a_noop_for_single_tool_call() {
+    // Single tool call: batch_size == 1, parallel branch is skipped per
+    // the `batch_size > 1` guard. Just verify it still runs to completion.
+    let model = Arc::new(BatchToolModel::new(vec!["a"]));
+    let executor = AgentExecutor::builder()
+        .model(model)
+        .tool(tool("a", 30))
+        .parallel_tool_calls(true)
+        .build();
+
+    let result = executor.run(&[Message::human("go")]).await.unwrap();
+    assert_eq!(result.output, "done");
+}

--- a/docs/building-an-agent.md
+++ b/docs/building-an-agent.md
@@ -129,7 +129,7 @@ Do this when you need custom error types, retries inside the tool, access to per
 
 > **Built-ins** — `cognis` ships `calculator`, `shell`, `filesystem`, HTTP, and more. Check `cognis::tools::*` before writing your own.
 >
-> **Derive** — `cognis-macros` provides `#[derive(Tool)]` which generates `BaseTool` from a struct. See [`examples/tools/derive_tool.rs`](../examples/tools/derive_tool.rs).
+> **Derive helpers** — `cognis-macros` provides `#[derive(JsonSchema)]` and `#[derive(ToolSchema)]` to auto-generate the args schema from a Rust struct, which you then return from `args_schema()` in your `BaseTool` impl. See [`examples/tools/derive_tool.rs`](../examples/tools/derive_tool.rs).
 
 ---
 
@@ -269,7 +269,7 @@ let executor = AgentExecutor::builder()
     .build();
 ```
 
-Per-phase hooks available: `on_llm_start/new_token/end/error`, `on_chain_start/end/error`, `on_tool_start/end/error`, `on_agent_action/finish`, `on_retriever_start/end/error`. Filter flags (`ignore_llm`, `ignore_tool`, etc.) let a handler opt out of categories. For token streaming specifically, pair this with FR-1 once it lands — `on_llm_new_token` is already wired.
+Per-phase hooks available: `on_llm_start/new_token/end/error`, `on_chain_start/end/error`, `on_tool_start/end/error`, `on_agent_action/finish`, `on_retriever_start/end/error`. Filter flags (`ignore_llm`, `ignore_chain`, `ignore_agent`, `ignore_retriever`, `ignore_chat_model`, `ignore_retry`, `ignore_custom_event`) let a handler opt out of categories — tool events are delivered unconditionally. For token streaming specifically, pair this with FR-1 once it lands — `on_llm_new_token` is already wired.
 
 ---
 
@@ -306,13 +306,19 @@ let result = structured._generate(&messages, None).await?;
 If the model still hands you a malformed blob (trailing commas, stray prose), wrap your parser in `OutputFixingParser`:
 
 ```rust
+use serde_json::Value;
 use cognis::output_parsers::OutputFixingParser;
+use cognis_core::runnables::base::Runnable;
 
 let robust = OutputFixingParser::builder()
     .parser(json_parser)
     .llm(model.clone())
     .build();
-// robust.parse() retries malformed output through the LLM with the error attached.
+
+// Use the async Runnable interface — it tries the inner parser first, and on
+// failure feeds the malformed text + error back to the LLM asking for a fix.
+// (The sync `parse()` method only runs the inner parser and does NOT fix.)
+let fixed: Value = robust.invoke(Value::String(raw_text), None).await?;
 ```
 
 ---

--- a/docs/building-an-agent.md
+++ b/docs/building-an-agent.md
@@ -42,7 +42,37 @@ The rest of this guide is the *why* and *when* behind each knob.
 
 ## 1. Authoring a `BaseTool`
 
-Three ways to define a tool, from easiest to most expressive:
+Four ways to define a tool, from most ergonomic to most expressive. **Start with `#[cognis::tool]`** unless a lower-level form fits better.
+
+### `#[cognis::tool]` — typed args via attribute macro (recommended)
+
+```rust
+use cognis_core::error::Result;
+use cognis_core::tool;
+use cognis_core::tools::ToolOutput;
+use serde_json::json;
+
+/// Search a mock knowledge base.
+#[tool(name = "search_kb")]
+async fn search_kb(
+    /// The search query — must be 1-200 chars.
+    #[schema(length(min = 1, max = 200))]
+    query: String,
+    /// Max results to return (1-50).
+    #[schema(range(min = 1, max = 50))]
+    limit: Option<u32>,
+) -> Result<ToolOutput> {
+    let limit = limit.unwrap_or(3);
+    Ok(ToolOutput::Content(json!({ "query": query, "limit": limit })))
+}
+
+// The macro emits a `SearchKb` unit struct implementing `BaseTool`.
+// Use it like any other tool: `Arc::new(SearchKb) as Arc<dyn BaseTool>`.
+```
+
+The macro generates the args struct, JSON Schema, validators (`length`, `range`, `pattern`, `enum_values`, `format`), input deserialization, and the `BaseTool` impl. Doc comments on parameters become schema `description`s. The function name becomes a PascalCase struct (`search_kb` → `SearchKb`), or set `#[tool(name = "...")]` to override.
+
+Also works on an inherent `impl` block for stateful tools (shared HTTP client, DB pool, etc.) — see [`examples/tools/stateful_http.rs`](../examples/tools/stateful_http.rs).
 
 ### `SimpleTool` — one string input, sync closure
 
@@ -129,7 +159,7 @@ Do this when you need custom error types, retries inside the tool, access to per
 
 > **Built-ins** — `cognis` ships `calculator`, `shell`, `filesystem`, HTTP, and more. Check `cognis::tools::*` before writing your own.
 >
-> **Derive helpers** — `cognis-macros` provides `#[derive(JsonSchema)]` and `#[derive(ToolSchema)]` to auto-generate the args schema from a Rust struct, which you then return from `args_schema()` in your `BaseTool` impl. See [`examples/tools/derive_tool.rs`](../examples/tools/derive_tool.rs).
+> **Derive helpers** — when you're implementing `BaseTool` by hand and want a Rust struct to drive the schema instead of a hand-written `json!({...})`, `cognis-macros` provides `#[derive(JsonSchema)]` and `#[derive(ToolSchema)]`. Return the generated schema from `args_schema()`. See [`examples/tools/derive_tool.rs`](../examples/tools/derive_tool.rs). Most users should reach for `#[cognis::tool]` first — these derives are the building blocks underneath.
 
 ---
 
@@ -223,6 +253,24 @@ let result = executor.run(&[Message::human("What's 42 * 7?")]).await?;
 | `early_stopping_method(..)` | What happens on limit hit: `Force` returns what you have; `GenerateResponse` asks the model for a final answer; unset returns `Err(RecursionLimitExceeded)`. |
 
 `AgentResult` gives you `messages` (full conversation), `output` (final string), and `intermediate_steps` (if requested).
+
+**Cooperative cancellation** — pass a `CancellationToken` for user-initiated cancel (a Stop button, a parent request being dropped, etc.):
+
+```rust
+use cognis_core::CancellationToken;
+
+let cancel = CancellationToken::new();
+let bg_cancel = cancel.clone();
+tokio::spawn(async move {
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    bg_cancel.cancel();  // user hit Stop
+});
+
+let result = executor.run_with_cancel(&messages, cancel).await;
+// On cancel: fires on_agent_cancelled on every callback, returns Err(CognisError::Cancelled).
+```
+
+The token is honoured at three points: iteration boundaries, around the model call (via `tokio::select!` — drops the in-flight `_generate` future and any `reqwest` request), and around each tool execution. Tools can read it from `RunnableConfig::cancellation_token` for their own cleanup.
 
 ---
 
@@ -372,17 +420,22 @@ See [`examples/agents/react_agent.rs`](../examples/agents/react_agent.rs) for a 
 | Multi-step loop with iteration cap | `cognis::agents::AgentExecutor` with `max_iterations` |
 | Tool-call history shoved into user messages | `Message::Tool(ToolMessage)` with `tool_call_id` |
 | Hand-written `parse_lenient` for malformed JSON | `cognis::output_parsers::OutputFixingParser` |
-| `mpsc::Sender<Thought>` for progress | `CallbackHandler` with per-phase hooks |
+| `mpsc::Sender<Thought>` for progress | `CallbackHandler` with per-phase hooks, or `AgentExecutor::astream_events` |
 | Hand-parsed `{"action": "tool", "tool": "..."}` | `cognis::agents::parse_ai_message_to_agent_output` (consumes native `tool_calls`) |
 | Domain-specific stringification of tool calls | `cognis::agents::format_to_tool_messages` |
 | Domain-specific JSON-shaped prompts | `cognis::chat_models::structured::with_structured_output(schema)` |
+| `BaseTool` + args struct + `args_schema()` + `_run` deserialization, by hand | `#[cognis::tool]` on an async fn with `#[schema(...)]` validators |
+| `tokio::select!` + ad-hoc cancel flags around the agent loop | `AgentExecutor::run_with_cancel` with `CancellationToken` |
 
 ---
 
 ## Where to go next
 
+- [`examples/tools/typed_search.rs`](../examples/tools/typed_search.rs) — `#[cognis::tool]` on a standalone async fn with `#[schema(...)]` validators
+- [`examples/tools/stateful_http.rs`](../examples/tools/stateful_http.rs) — `#[cognis::tool]` on an impl block sharing an HTTP client
 - [`examples/tools/tool_calling_agent.rs`](../examples/tools/tool_calling_agent.rs) — `SimpleTool`, `StructuredTool`, `CachedTool`, `AgentExecutor` together
 - [`examples/agents/react_agent.rs`](../examples/agents/react_agent.rs) — graph-based ReAct with Ollama
+- [`examples/agents/streaming_agent_events.rs`](../examples/agents/streaming_agent_events.rs) — `AgentExecutor::astream_events` for UI-ready progress
 - [`examples/agents/conversational_agent.rs`](../examples/agents/conversational_agent.rs) — memory + tools
 - [`examples/agents/plan_and_execute.rs`](../examples/agents/plan_and_execute.rs) — planner/executor split
 - [`examples/agents/execution_hooks.rs`](../examples/agents/execution_hooks.rs) — callback-driven observability

--- a/docs/building-an-agent.md
+++ b/docs/building-an-agent.md
@@ -231,7 +231,7 @@ let result = executor.run(&[Message::human("What's 42 * 7?")]).await?;
 ```rust
 use async_trait::async_trait;
 use uuid::Uuid;
-use cognis_core::callbacks::CallbackHandler;
+use cognis_core::callbacks::{CallbackHandler, ToolEndEvent};
 use cognis_core::agents::{AgentAction, AgentFinish};
 
 struct StepLogger;
@@ -247,10 +247,8 @@ impl CallbackHandler for StepLogger {
         Ok(())
     }
 
-    async fn on_tool_end(
-        &self, output: &str, _run_id: Uuid, _parent: Option<Uuid>,
-    ) -> cognis_core::error::Result<()> {
-        println!("← observation: {output}");
+    async fn on_tool_end(&self, event: ToolEndEvent) -> cognis_core::error::Result<()> {
+        println!("← [{}] {}", event.tool, event.output_str);
         Ok(())
     }
 
@@ -269,7 +267,9 @@ let executor = AgentExecutor::builder()
     .build();
 ```
 
-Per-phase hooks available: `on_llm_start/new_token/end/error`, `on_chain_start/end/error`, `on_tool_start/end/error`, `on_agent_action/finish`, `on_retriever_start/end/error`. Filter flags (`ignore_llm`, `ignore_chain`, `ignore_agent`, `ignore_retriever`, `ignore_chat_model`, `ignore_retry`, `ignore_custom_event`) let a handler opt out of categories — tool events are delivered unconditionally. For token streaming specifically, pair this with FR-1 once it lands — `on_llm_new_token` is already wired.
+Per-phase hooks available: `on_llm_start/new_token/end/error`, `on_chain_start/end/error`, `on_tool_start/end/error` (struct-based events: `ToolStartEvent`, `ToolEndEvent`, `ToolErrorEvent` — preserve the typed `output_value` and any `artifact`), `on_agent_action/finish`, `on_retriever_start/end/error`. Filter flags (`ignore_llm`, `ignore_chain`, `ignore_agent`, `ignore_retriever`, `ignore_chat_model`, `ignore_retry`, `ignore_custom_event`) let a handler opt out of categories — tool events are delivered unconditionally.
+
+> **Prefer a stream over a handler?** `AgentExecutor::astream_events(messages)` returns a `Stream<Item = Result<StreamEvent>>` that emits the same lifecycle events without the callback-trait boilerplate. See [`examples/agents/streaming_agent_events.rs`](../examples/agents/streaming_agent_events.rs). Callbacks are the underlying primitive; `astream_events` is the UI-ready wrapper.
 
 ---
 

--- a/docs/building-an-agent.md
+++ b/docs/building-an-agent.md
@@ -272,6 +272,24 @@ let result = executor.run_with_cancel(&messages, cancel).await;
 
 The token is honoured at three points: iteration boundaries, around the model call (via `tokio::select!` — drops the in-flight `_generate` future and any `reqwest` request), and around each tool execution. Tools can read it from `RunnableConfig::cancellation_token` for their own cleanup.
 
+**Parallel tool calls** — when the model emits multiple `tool_calls` in a single turn (common with `gpt-4o`, `claude-3.5+`, and other parallel-tool-capable models), the executor dispatches them **serially by default**. For agents that routinely fan out to 3–5 independent tools per turn, that multiplies latency. Opt into concurrent dispatch:
+
+```rust
+let executor = AgentExecutor::builder()
+    .model(model)
+    .tools(vec![search, fetch, summarize])
+    .parallel_tool_calls(true)      // opt-in — default is serial
+    .build();
+```
+
+Semantics when enabled:
+
+- Multi-tool turns run via `futures::future::try_join_all`; single-tool turns use the serial path (no wasted fan-out).
+- **Tool order is preserved** in the resulting `ToolMessage` sequence regardless of completion order, so correlation by `tool_call_id` stays deterministic.
+- `ToolStartEvent` gains `parallel: true` and `batch_size: N` so callback handlers (or `astream_events` consumers) can render a "running N tools" UI group.
+- Any branch returning `CognisError::Cancelled` short-circuits the batch; other in-flight branches are dropped. Agent-level `on_agent_cancelled` / `on_chain_error` fire once.
+- Leave serial (the default) if your tools share mutable state, hit the same rate-limited endpoint, or have ordering dependencies. The model already decided to call all of them without seeing each other's output, so independent tools are the typical case — but the safe default is serial.
+
 ---
 
 ## 5. Streaming intermediate steps with `CallbackHandler`
@@ -426,6 +444,7 @@ See [`examples/agents/react_agent.rs`](../examples/agents/react_agent.rs) for a 
 | Domain-specific JSON-shaped prompts | `cognis::chat_models::structured::with_structured_output(schema)` |
 | `BaseTool` + args struct + `args_schema()` + `_run` deserialization, by hand | `#[cognis::tool]` on an async fn with `#[schema(...)]` validators |
 | `tokio::select!` + ad-hoc cancel flags around the agent loop | `AgentExecutor::run_with_cancel` with `CancellationToken` |
+| `tokio::join!`-ing tool futures yourself to avoid 3× latency on multi-call turns | `AgentExecutor::builder().parallel_tool_calls(true)` |
 
 ---
 

--- a/docs/building-an-agent.md
+++ b/docs/building-an-agent.md
@@ -1,0 +1,383 @@
+# Building an Agent Application
+
+The README's Quick Start covers *chains* (`prompt → model → parser`). Agents are different: they loop, call tools, and decide what to do next. This guide walks through the happy path end-to-end using what cognis already ships — so you don't hand-roll the ReAct loop, a JSON parser, or a scratchpad formatter.
+
+If you've read the README and now want to build something that can actually *do things*, start here.
+
+> All snippets are adapted from runnable examples in [`examples/`](../examples/). If a snippet elides setup for brevity, the filename at the top of each section points to the full version.
+
+---
+
+## TL;DR: the smallest working agent
+
+```rust
+use std::sync::Arc;
+use cognis::agents::AgentExecutor;
+use cognis_core::language_models::chat_model::BaseChatModel;
+use cognis_core::messages::Message;
+use cognis_core::tools::base::BaseTool;
+use cognis_core::tools::simple::SimpleTool;
+
+let search = SimpleTool::new(
+    "search",
+    "Search for information about a topic",
+    |q: &str| Ok(format!("Results for '{q}': ...")),
+);
+
+let executor = AgentExecutor::builder()
+    .model(model)                                   // Arc<dyn BaseChatModel>
+    .tool(Arc::new(search) as Arc<dyn BaseTool>)
+    .max_iterations(10)
+    .build();
+
+let result = executor.run(&[Message::human("What is Rust?")]).await?;
+println!("{}", result.output);
+```
+
+That's it. No hand-written loop, no JSON parser, no scratchpad formatting. The executor drives the model, executes tool calls, appends `ToolMessage`s to history, and stops when the model returns a final answer (or you hit `max_iterations`).
+
+The rest of this guide is the *why* and *when* behind each knob.
+
+---
+
+## 1. Authoring a `BaseTool`
+
+Three ways to define a tool, from easiest to most expressive:
+
+### `SimpleTool` — one string input, sync closure
+
+```rust
+use cognis_core::tools::simple::SimpleTool;
+
+let search = SimpleTool::new(
+    "search",
+    "Search for information about a topic",
+    |query: &str| Ok(format!("Results for '{query}': ...")),
+);
+```
+
+Use when your tool takes a single string and returns a string. Zero ceremony.
+
+### `StructuredTool` — typed args, async closure, schema
+
+```rust
+use std::collections::HashMap;
+use serde_json::{json, Value};
+use cognis_core::tools::structured::StructuredTool;
+
+let calculator = StructuredTool::new(
+    "calculator",
+    "Perform arithmetic between two numbers",
+    json!({
+        "type": "object",
+        "properties": {
+            "a":  { "type": "number" },
+            "b":  { "type": "number" },
+            "op": { "type": "string", "enum": ["add", "sub", "mul", "div"] }
+        },
+        "required": ["a", "b", "op"]
+    }),
+    |args: HashMap<String, Value>| async move {
+        let a  = args.get("a").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        let b  = args.get("b").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        let op = args.get("op").and_then(|v| v.as_str()).unwrap_or("add");
+        let result = match op {
+            "add" => a + b, "sub" => a - b, "mul" => a * b,
+            "div" if b != 0.0 => a / b,
+            _ => return Ok(json!({ "error": "bad op" })),
+        };
+        Ok(json!({ "result": result }))
+    },
+);
+```
+
+The schema is shipped to the model as the tool's parameter definition. The model will call your tool with args that match it.
+
+### Implementing `BaseTool` directly — full control
+
+```rust
+use async_trait::async_trait;
+use cognis_core::tools::BaseTool;
+use cognis_core::tools::types::{ToolInput, ToolOutput};
+
+struct GetCurrentTimeTool;
+
+#[async_trait]
+impl BaseTool for GetCurrentTimeTool {
+    fn name(&self) -> &str { "get_current_time" }
+
+    fn description(&self) -> &str {
+        "Get the current date and time in a given timezone."
+    }
+
+    fn args_schema(&self) -> Option<serde_json::Value> {
+        Some(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "timezone": { "type": "string", "description": "IANA tz name" }
+            }
+        }))
+    }
+
+    async fn _run(&self, input: ToolInput) -> cognis_core::error::Result<ToolOutput> {
+        // ...pull `timezone` out of input, call chrono, return ToolOutput::Content(json!(...))
+    }
+}
+```
+
+Do this when you need custom error types, retries inside the tool, access to per-tool resources (DB pool, HTTP client), or async work that doesn't fit a closure.
+
+> **Built-ins** — `cognis` ships `calculator`, `shell`, `filesystem`, HTTP, and more. Check `cognis::tools::*` before writing your own.
+>
+> **Derive** — `cognis-macros` provides `#[derive(Tool)]` which generates `BaseTool` from a struct. See [`examples/tools/derive_tool.rs`](../examples/tools/derive_tool.rs).
+
+---
+
+## 2. Binding tools to the model
+
+Every `BaseChatModel` exposes `bind_tools`. You usually don't call it directly — `AgentExecutor` and `create_react_agent` do it for you — but it's the primitive underneath.
+
+```rust
+use cognis_core::tools::base::ToolSchema;
+use cognis_core::language_models::chat_model::ToolChoice;
+
+let schema = ToolSchema {
+    name:        "calculator".into(),
+    description: "Arithmetic".into(),
+    parameters:  calculator.args_schema(),
+    extras:      None,
+};
+
+let bound: Box<dyn BaseChatModel> = model.bind_tools(
+    &[schema],
+    Some(ToolChoice::Auto),     // Auto | Any | Tool(name) | None
+)?;
+```
+
+`bound` is a new model that will emit `tool_calls` on its `AIMessage` when the model decides to call a tool. Works across `ChatOpenAI`, `ChatAnthropic`, `ChatGoogleGenAI`, and `ChatOllama` — the provider-specific serialization is handled for you.
+
+---
+
+## 3. Reading `AIMessage.tool_calls` directly
+
+If you want raw control — debugging, custom routing, non-standard tool execution — skip the executor and read tool calls yourself:
+
+```rust
+use cognis_core::messages::Message;
+
+let messages = vec![Message::human("What is 6 * 7?")];
+let result = bound._generate(&messages, None).await?;
+let gen = result.generations.first().expect("at least one generation");
+
+if let Message::Ai(ai) = &gen.message {
+    for tc in &ai.tool_calls {
+        println!("model wants to call {} with {:?}", tc.name, tc.args);
+        // dispatch however you like
+    }
+}
+```
+
+`tc.name` is the tool name, `tc.args` is `HashMap<String, Value>`, `tc.id` is the call id — pass it back as `ToolMessage { tool_call_id, .. }` so the model can correlate the observation to the call.
+
+For the structured version that returns `AgentOutput::Actions(..)` or `AgentOutput::Finish(..)`:
+
+```rust
+use cognis::agents::{parse_ai_message_to_agent_output, AgentOutput};
+
+let ai_json = serde_json::to_value(&gen.message)?;
+match parse_ai_message_to_agent_output(&ai_json)? {
+    AgentOutput::Actions(actions) => { /* call tools */ }
+    AgentOutput::Finish(finish)   => { /* done */ }
+}
+```
+
+---
+
+## 4. `AgentExecutor` — the loop you don't have to write
+
+```rust
+use cognis::agents::{AgentExecutor, EarlyStoppingMethod};
+
+let executor = AgentExecutor::builder()
+    .model(model)
+    .tools(vec![
+        Arc::new(search)     as Arc<dyn BaseTool>,
+        Arc::new(calculator) as Arc<dyn BaseTool>,
+    ])
+    .max_iterations(10)
+    .max_execution_time_secs(60)
+    .return_intermediate_steps(true)
+    .handle_parsing_errors(true)
+    .early_stopping_method(EarlyStoppingMethod::GenerateResponse)
+    .build();
+
+let result = executor.run(&[Message::human("What's 42 * 7?")]).await?;
+```
+
+| Knob | What it does |
+|---|---|
+| `max_iterations(n)` | Hard cap on model↔tool round-trips. Default 10. |
+| `max_execution_time_secs(n)` | Wall-clock budget. |
+| `return_intermediate_steps(true)` | Populate `result.intermediate_steps` with every `(AgentAction, observation)` pair. |
+| `handle_parsing_errors(true)` | On malformed output, feed the error back to the model and retry instead of bailing. |
+| `early_stopping_method(..)` | What happens on limit hit: `Force` returns what you have; `GenerateResponse` asks the model for a final answer; unset returns `Err(RecursionLimitExceeded)`. |
+
+`AgentResult` gives you `messages` (full conversation), `output` (final string), and `intermediate_steps` (if requested).
+
+---
+
+## 5. Streaming intermediate steps with `CallbackHandler`
+
+```rust
+use async_trait::async_trait;
+use uuid::Uuid;
+use cognis_core::callbacks::CallbackHandler;
+use cognis_core::agents::{AgentAction, AgentFinish};
+
+struct StepLogger;
+
+#[async_trait]
+impl CallbackHandler for StepLogger {
+    fn name(&self) -> &str { "step-logger" }
+
+    async fn on_agent_action(
+        &self, action: &AgentAction, _run_id: Uuid, _parent: Option<Uuid>,
+    ) -> cognis_core::error::Result<()> {
+        println!("→ calling {} with {}", action.tool, action.tool_input);
+        Ok(())
+    }
+
+    async fn on_tool_end(
+        &self, output: &str, _run_id: Uuid, _parent: Option<Uuid>,
+    ) -> cognis_core::error::Result<()> {
+        println!("← observation: {output}");
+        Ok(())
+    }
+
+    async fn on_agent_finish(
+        &self, finish: &AgentFinish, _run_id: Uuid, _parent: Option<Uuid>,
+    ) -> cognis_core::error::Result<()> {
+        println!("✓ final: {:?}", finish.return_values.get("output"));
+        Ok(())
+    }
+}
+
+let executor = AgentExecutor::builder()
+    .model(model)
+    .tool(Arc::new(search) as Arc<dyn BaseTool>)
+    .callback(Arc::new(StepLogger))
+    .build();
+```
+
+Per-phase hooks available: `on_llm_start/new_token/end/error`, `on_chain_start/end/error`, `on_tool_start/end/error`, `on_agent_action/finish`, `on_retriever_start/end/error`. Filter flags (`ignore_llm`, `ignore_tool`, etc.) let a handler opt out of categories. For token streaming specifically, pair this with FR-1 once it lands — `on_llm_new_token` is already wired.
+
+---
+
+## 6. Structured JSON output with `with_structured_output`
+
+When you want the model to return JSON that matches a schema instead of freeform text:
+
+```rust
+use serde_json::json;
+use cognis::chat_models::structured::with_structured_output;
+
+let structured = with_structured_output(
+    Box::new(model),
+    json!({
+        "title": "Person",
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" },
+            "age":  { "type": "integer" }
+        },
+        "required": ["name", "age"]
+    }),
+    Some("tool_calling"),   // or "json_mode"
+    false,                  // include_raw
+)?;
+
+let messages = vec![Message::human("Alice is 30")];
+let result = structured._generate(&messages, None).await?;
+// result.generations[0].text is valid JSON matching the schema
+```
+
+`tool_calling` binds a synthetic tool with your schema and forces the model to call it — works everywhere. `json_mode` uses native JSON mode (OpenAI etc.) when you want to preserve normal `tool_calls` alongside structured output.
+
+If the model still hands you a malformed blob (trailing commas, stray prose), wrap your parser in `OutputFixingParser`:
+
+```rust
+use cognis::output_parsers::OutputFixingParser;
+
+let robust = OutputFixingParser::builder()
+    .parser(json_parser)
+    .llm(model.clone())
+    .build();
+// robust.parse() retries malformed output through the LLM with the error attached.
+```
+
+---
+
+## 7. `format_to_tool_messages` — scratchpad formatting
+
+If you're running your own loop (not using `AgentExecutor`), you still need to turn the list of `(AgentAction, observation)` pairs into messages the model can see. Don't hand-roll this — use:
+
+```rust
+use cognis::agents::format_to_tool_messages;
+
+let scratchpad = format_to_tool_messages(&intermediate_steps);
+let messages: Vec<Message> = initial_messages.iter()
+    .cloned()
+    .chain(scratchpad)
+    .collect();
+let result = model._generate(&messages, None).await?;
+```
+
+This emits one `ToolMessage` per observation with the correct `tool_call_id` — which is what every provider actually expects and what lets the model correlate calls to results. Shoving observations into user messages breaks tool-call chaining on most providers.
+
+---
+
+## Alternative: `create_react_agent` (graph-based)
+
+`AgentExecutor` is a linear loop. If you want checkpointing, interrupts, or to compose the agent into a larger `StateGraph`, use the graph-based ReAct agent from `cognisgraph`:
+
+```rust
+use cognisgraph::prebuilt::create_react_agent;
+
+let tools: Vec<Arc<dyn BaseTool>> = vec![Arc::new(GetCurrentTimeTool), Arc::new(CalculatorTool)];
+let graph = create_react_agent(model, tools)?;
+
+let input = serde_json::json!({
+    "messages": [{ "type": "human", "content": "What time is it in IST?" }]
+});
+let result = graph.invoke(input).await?;
+```
+
+`graph` is a `CompiledStateGraph` — you get `invoke`, `stream`, `get_state`, `update_state`, and checkpointer integration for free. Same mental model, different substrate.
+
+See [`examples/agents/react_agent.rs`](../examples/agents/react_agent.rs) for a full working version with Ollama auto-detection.
+
+---
+
+## What you avoided re-implementing
+
+| If you were about to hand-roll | Use this instead |
+|---|---|
+| ReAct decision JSON + parser | `cognis::agents::ReActOutputParser`, `cognisgraph::prebuilt::create_react_agent` |
+| Multi-step loop with iteration cap | `cognis::agents::AgentExecutor` with `max_iterations` |
+| Tool-call history shoved into user messages | `Message::Tool(ToolMessage)` with `tool_call_id` |
+| Hand-written `parse_lenient` for malformed JSON | `cognis::output_parsers::OutputFixingParser` |
+| `mpsc::Sender<Thought>` for progress | `CallbackHandler` with per-phase hooks |
+| Hand-parsed `{"action": "tool", "tool": "..."}` | `cognis::agents::parse_ai_message_to_agent_output` (consumes native `tool_calls`) |
+| Domain-specific stringification of tool calls | `cognis::agents::format_to_tool_messages` |
+| Domain-specific JSON-shaped prompts | `cognis::chat_models::structured::with_structured_output(schema)` |
+
+---
+
+## Where to go next
+
+- [`examples/tools/tool_calling_agent.rs`](../examples/tools/tool_calling_agent.rs) — `SimpleTool`, `StructuredTool`, `CachedTool`, `AgentExecutor` together
+- [`examples/agents/react_agent.rs`](../examples/agents/react_agent.rs) — graph-based ReAct with Ollama
+- [`examples/agents/conversational_agent.rs`](../examples/agents/conversational_agent.rs) — memory + tools
+- [`examples/agents/plan_and_execute.rs`](../examples/agents/plan_and_execute.rs) — planner/executor split
+- [`examples/agents/execution_hooks.rs`](../examples/agents/execution_hooks.rs) — callback-driven observability
+- [`cognisagent`](../crates/cognisagent/) — high-level `create_deep_agent` factory when you want the batteries included (filesystem, memory, subagents, planning)


### PR DESCRIPTION
## Summary

- **#12** — adds `docs/building-an-agent.md`, an end-to-end guide to building agent applications with cognis (tool authoring, `bind_tools`, `AgentExecutor`, callbacks + `astream_events`, `with_structured_output`, `OutputFixingParser`, `format_to_tool_messages`, graph-based `create_react_agent`). Also adds a short "Building an Agent" subsection to the README Quick Start with a link to the full guide.
- **#11** — makes multi-tool-call dispatch behavior explicit and opt-in-able:
  - `AgentExecutor` rustdoc now documents serial-by-default dispatch.
  - New `AgentExecutorBuilder::parallel_tool_calls(bool)` knob. When enabled, multi-tool batches fan out via `futures::future::try_join_all` over an extracted `execute_one_tool_call` helper. Single-call turns stay on the serial path.
  - `ToolStartEvent` gains `parallel: bool` and `batch_size: usize` so callback handlers (and `astream_events` consumers) can render "running N tools" UI groups.
  - Tool-message order matches `tool_calls` order regardless of completion order; `tool_call_id` correlation is deterministic.
  - Integration tests cover: concurrency (3x120ms tools < 250ms), serial default preserved, order preserved under reversed delays, single-call no-op.

## Commits

1. `docs: add "Building an Agent" guide and README section` — initial #12 work
2. `docs: fix incorrect API references in agent guide` — cubic-review fixes (derive macro, `ignore_tool`, `OutputFixingParser::parse`)
3. `docs: update agent guide for upstream API changes` — rebased for #14 `astream_events` + #15 struct-based tool callbacks
4. `docs: cover #[cognis::tool] and run_with_cancel in agent guide` — rebased for #18 tool macro + #19 cancellation token
5. `feat(callbacks): add parallel/batch_size fields to ToolStartEvent` — event shape + serial rustdoc (#11)
6. `feat(cognis): opt-in parallel tool-call dispatch on AgentExecutor` — feature + tests (#11)
7. `docs: cover parallel tool-call dispatch in agent guide` — guide update (#11)

## Test plan

- [x] `cargo test --workspace --features all-providers` passes (exit 0, no FAILED/compile errors)
- [x] `cargo clippy --workspace --features all-providers -- -D warnings` passes
- [x] `cargo fmt --all` clean
- [x] New `tests/parallel_tool_dispatch.rs` — 4/4 tests pass
- [ ] `docs/building-an-agent.md` renders correctly on GitHub
- [ ] Each example link in the guide resolves to an existing file in `examples/`

Closes #12, closes #11.