### PR TITLE
feat: add AgentExecutor::astream_events (closes #5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "toml",
  "uuid",
 ]

--- a/crates/cognis-core/src/tracers/event_stream.rs
+++ b/crates/cognis-core/src/tracers/event_stream.rs
@@ -15,6 +15,7 @@ use serde_json::Value;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
+use crate::agents::{AgentAction, AgentFinish};
 use crate::callbacks::CallbackHandler;
 use crate::documents::Document;
 use crate::error::Result;
@@ -79,6 +80,18 @@ pub enum EventType {
     /// Retriever error.
     #[serde(rename = "on_retriever_error")]
     OnRetrieverError,
+    /// Agent execution started.
+    #[serde(rename = "on_agent_start")]
+    OnAgentStart,
+    /// Agent decided to take an action (invoke a tool).
+    #[serde(rename = "on_agent_action")]
+    OnAgentAction,
+    /// Agent finished (produced final answer).
+    #[serde(rename = "on_agent_finish")]
+    OnAgentFinish,
+    /// Agent execution ended (loop exited).
+    #[serde(rename = "on_agent_end")]
+    OnAgentEnd,
     /// Custom event.
     #[serde(rename = "on_custom_event")]
     OnCustomEvent,
@@ -714,6 +727,61 @@ impl CallbackHandler for EventStreamCallbackHandler {
         Ok(())
     }
 
+    async fn on_agent_action(
+        &self,
+        action: &AgentAction,
+        run_id: Uuid,
+        parent_run_id: Option<Uuid>,
+    ) -> Result<()> {
+        // Record parent link so get_parent_ids() works.
+        {
+            let mut parent_map = self.parent_map.lock().unwrap();
+            parent_map.insert(run_id, parent_run_id);
+        }
+        let event = StreamEvent {
+            event: EventType::OnAgentAction,
+            name: action.tool.clone(),
+            data: EventData {
+                input: Some(action.tool_input.clone()),
+                ..Default::default()
+            },
+            run_id: run_id.to_string(),
+            parent_ids: self.get_parent_ids(run_id),
+            tags: Vec::new(),
+            metadata: HashMap::new(),
+        };
+        self.send_event(event, "agent");
+        Ok(())
+    }
+
+    async fn on_agent_finish(
+        &self,
+        finish: &AgentFinish,
+        run_id: Uuid,
+        parent_run_id: Option<Uuid>,
+    ) -> Result<()> {
+        {
+            let mut parent_map = self.parent_map.lock().unwrap();
+            parent_map.insert(run_id, parent_run_id);
+        }
+        let output_value =
+            serde_json::to_value(&finish.return_values).unwrap_or(serde_json::Value::Null);
+        let event = StreamEvent {
+            event: EventType::OnAgentFinish,
+            name: "AgentExecutor".to_string(),
+            data: EventData {
+                output: Some(output_value),
+                ..Default::default()
+            },
+            run_id: run_id.to_string(),
+            parent_ids: self.get_parent_ids(run_id),
+            tags: Vec::new(),
+            metadata: HashMap::new(),
+        };
+        self.send_event(event, "agent");
+        Ok(())
+    }
+
     async fn on_retriever_start(
         &self,
         serialized: &Value,
@@ -1291,5 +1359,71 @@ mod tests {
         assert_eq!(deserialized.event, EventType::OnChainEnd);
         assert_eq!(deserialized.name, "my-chain");
         assert_eq!(deserialized.data.output, Some(json!({"answer": 42})));
+    }
+
+    #[test]
+    fn test_agent_event_types_serialize() {
+        assert_eq!(
+            serde_json::to_string(&EventType::OnAgentStart).unwrap(),
+            "\"on_agent_start\""
+        );
+        assert_eq!(
+            serde_json::to_string(&EventType::OnAgentAction).unwrap(),
+            "\"on_agent_action\""
+        );
+        assert_eq!(
+            serde_json::to_string(&EventType::OnAgentFinish).unwrap(),
+            "\"on_agent_finish\""
+        );
+        assert_eq!(
+            serde_json::to_string(&EventType::OnAgentEnd).unwrap(),
+            "\"on_agent_end\""
+        );
+    }
+
+    #[test]
+    fn test_agent_event_types_display() {
+        assert_eq!(EventType::OnAgentAction.to_string(), "on_agent_action");
+    }
+
+    #[tokio::test]
+    async fn test_handler_receives_agent_events() {
+        use crate::agents::{AgentAction, AgentFinish};
+        use std::collections::HashMap;
+
+        let handler = EventStreamCallbackHandler::with_defaults();
+        let mut rx = handler.take_receiver().unwrap();
+        let run_id = Uuid::new_v4();
+
+        let action = AgentAction::new(
+            "calculator",
+            serde_json::json!({"a": 1, "b": 2}),
+            "thought: use calculator",
+        );
+        handler
+            .on_agent_action(&action, run_id, None)
+            .await
+            .unwrap();
+
+        let mut rv = HashMap::new();
+        rv.insert("output".to_string(), serde_json::json!("done"));
+        let finish = AgentFinish::new(rv, "final answer");
+        handler
+            .on_agent_finish(&finish, run_id, None)
+            .await
+            .unwrap();
+
+        // Drop handler to close sender so rx.recv() returns None at end.
+        drop(handler);
+
+        let ev1 = rx.recv().await.unwrap();
+        assert_eq!(ev1.event, EventType::OnAgentAction);
+        assert_eq!(ev1.name, "calculator");
+        assert_eq!(ev1.data.input, Some(serde_json::json!({"a": 1, "b": 2})));
+
+        let ev2 = rx.recv().await.unwrap();
+        assert_eq!(ev2.event, EventType::OnAgentFinish);
+        assert_eq!(ev2.name, "AgentExecutor");
+        assert!(ev2.data.output.is_some());
     }
 }

--- a/crates/cognis-core/src/tracers/event_stream.rs
+++ b/crates/cognis-core/src/tracers/event_stream.rs
@@ -80,18 +80,17 @@ pub enum EventType {
     /// Retriever error.
     #[serde(rename = "on_retriever_error")]
     OnRetrieverError,
-    /// Agent execution started.
-    #[serde(rename = "on_agent_start")]
-    OnAgentStart,
     /// Agent decided to take an action (invoke a tool).
+    ///
+    /// Agent lifecycle (start/end) is represented via the enclosing
+    /// `OnChainStart`/`OnChainEnd` events on the agent executor itself,
+    /// so dedicated `OnAgentStart`/`OnAgentEnd` variants are intentionally
+    /// omitted.
     #[serde(rename = "on_agent_action")]
     OnAgentAction,
     /// Agent finished (produced final answer).
     #[serde(rename = "on_agent_finish")]
     OnAgentFinish,
-    /// Agent execution ended (loop exited).
-    #[serde(rename = "on_agent_end")]
-    OnAgentEnd,
     /// Custom event.
     #[serde(rename = "on_custom_event")]
     OnCustomEvent,
@@ -1364,20 +1363,12 @@ mod tests {
     #[test]
     fn test_agent_event_types_serialize() {
         assert_eq!(
-            serde_json::to_string(&EventType::OnAgentStart).unwrap(),
-            "\"on_agent_start\""
-        );
-        assert_eq!(
             serde_json::to_string(&EventType::OnAgentAction).unwrap(),
             "\"on_agent_action\""
         );
         assert_eq!(
             serde_json::to_string(&EventType::OnAgentFinish).unwrap(),
             "\"on_agent_finish\""
-        );
-        assert_eq!(
-            serde_json::to_string(&EventType::OnAgentEnd).unwrap(),
-            "\"on_agent_end\""
         );
     }
 

--- a/crates/cognis/Cargo.toml
+++ b/crates/cognis/Cargo.toml
@@ -16,6 +16,7 @@ async-trait.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
 futures.workspace = true
+tokio-stream.workspace = true
 regex = "1"
 csv = "1"
 glob = "0.3"

--- a/crates/cognis/src/agents/executor.rs
+++ b/crates/cognis/src/agents/executor.rs
@@ -544,6 +544,80 @@ impl AgentExecutor {
             }
         }
     }
+
+    /// Execute the agent and stream all intermediate events as they occur.
+    ///
+    /// Returns a `Stream` of [`StreamEvent`] values. Each event represents a
+    /// step in the agent loop: LLM invocations, tool calls, agent decisions,
+    /// and the final result. This is the Rust equivalent of Python LangChain's
+    /// `Runnable.astream_events(version="v2")`.
+    ///
+    /// The stream completes when the agent finishes or errors out.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use futures::StreamExt;
+    ///
+    /// let mut stream = executor.astream_events(messages).await?;
+    /// while let Some(event) = stream.next().await {
+    ///     let ev = event?;
+    ///     // Match on ev.event (EventType enum) to handle each phase.
+    /// }
+    /// ```
+    pub async fn astream_events(
+        &self,
+        initial_messages: Vec<cognis_core::messages::Message>,
+    ) -> cognis_core::error::Result<
+        std::pin::Pin<
+            Box<
+                dyn futures::Stream<
+                        Item = cognis_core::error::Result<
+                            cognis_core::tracers::event_stream::StreamEvent,
+                        >,
+                    > + Send,
+            >,
+        >,
+    > {
+        use cognis_core::callbacks::CallbackHandler;
+        use cognis_core::tracers::event_stream::EventStreamCallbackHandler;
+        use futures::StreamExt;
+        use std::sync::Arc;
+        use tokio_stream::wrappers::ReceiverStream;
+
+        // Create the event stream handler and take its receiver.
+        let handler = Arc::new(EventStreamCallbackHandler::with_defaults());
+        let rx = handler
+            .take_receiver()
+            .expect("fresh EventStreamCallbackHandler must have a receiver");
+
+        // Build a new executor that includes the event handler in its callbacks.
+        // Clone the inner fields; AgentExecutor itself isn't Clone.
+        let mut callbacks = self.callbacks.clone();
+        callbacks.push(handler as Arc<dyn CallbackHandler>);
+
+        #[allow(deprecated)]
+        let spawned_executor = AgentExecutor {
+            model: self.model.clone(),
+            tools: self.tools.clone(),
+            middleware: self.middleware.clone(),
+            max_iterations: self.max_iterations,
+            max_execution_time_secs: self.max_execution_time_secs,
+            return_intermediate_steps: self.return_intermediate_steps,
+            early_stopping_method: self.early_stopping_method,
+            handle_parsing_errors: self.handle_parsing_errors,
+            callbacks,
+        };
+
+        // Spawn the run in the background. Errors surface as OnChainError events.
+        tokio::spawn(async move {
+            let _ = spawned_executor.run(&initial_messages).await;
+        });
+
+        // Wrap the mpsc receiver in a Stream; each item is Ok(StreamEvent).
+        let stream = ReceiverStream::new(rx).map(Ok);
+        Ok(Box::pin(stream))
+    }
 }
 
 /// Implements the `Runnable` trait so `AgentExecutor` can be composed in LCEL chains.

--- a/crates/cognis/tests/astream_events_tests.rs
+++ b/crates/cognis/tests/astream_events_tests.rs
@@ -1,0 +1,62 @@
+//! Integration tests for AgentExecutor::astream_events.
+
+use std::sync::Arc;
+
+use futures::StreamExt;
+
+use cognis::agents::AgentExecutor;
+use cognis_core::language_models::fake::FakeMessagesListChatModel;
+use cognis_core::messages::{AIMessage, HumanMessage, Message};
+use cognis_core::tracers::event_stream::EventType;
+
+#[tokio::test]
+async fn test_astream_events_emits_chain_start_and_end() {
+    // Fake model that returns a simple AI response (no tool calls).
+    let model = Arc::new(FakeMessagesListChatModel::new(vec![Message::Ai(
+        AIMessage::new("Hello, world!"),
+    )]));
+
+    let executor = AgentExecutor::builder()
+        .model(model)
+        .max_iterations(1)
+        .build();
+
+    let messages = vec![Message::Human(HumanMessage::new("Hi"))];
+    let mut stream = executor.astream_events(messages).await.unwrap();
+
+    let mut events = Vec::new();
+    while let Some(event) = stream.next().await {
+        events.push(event.unwrap());
+    }
+
+    let event_types: Vec<&EventType> = events.iter().map(|e| &e.event).collect();
+    assert!(
+        event_types.contains(&&EventType::OnChainStart),
+        "expected OnChainStart, got {:?}",
+        event_types
+    );
+    assert!(
+        event_types.contains(&&EventType::OnChainEnd),
+        "expected OnChainEnd, got {:?}",
+        event_types
+    );
+}
+
+#[tokio::test]
+async fn test_astream_events_stream_completes() {
+    let model = Arc::new(FakeMessagesListChatModel::new(vec![Message::Ai(
+        AIMessage::new("Done"),
+    )]));
+
+    let executor = AgentExecutor::builder()
+        .model(model)
+        .max_iterations(1)
+        .build();
+
+    let messages = vec![Message::Human(HumanMessage::new("Test"))];
+    let stream = executor.astream_events(messages).await.unwrap();
+
+    // Collect all events — should terminate, not hang.
+    let events: Vec<_> = stream.collect().await;
+    assert!(!events.is_empty(), "expected at least one event");
+}

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -345,3 +345,7 @@ path = "../../examples/tools/ollama_tool_calling.rs"
 [[example]]
 name = "typed_runnable_demo"
 path = "../../examples/chains/typed_runnable_demo.rs"
+
+[[example]]
+name = "streaming_agent_events"
+path = "../../examples/agents/streaming_agent_events.rs"

--- a/examples/agents/streaming_agent_events.rs
+++ b/examples/agents/streaming_agent_events.rs
@@ -1,0 +1,144 @@
+//! Streaming Agent Events Example
+//!
+//! Demonstrates `AgentExecutor::astream_events()` — the high-level streaming
+//! API that eliminates hand-rolled callback handlers + channels.
+//!
+//! Shows how to match on event types to build a UI-ready stream of agent
+//! progress (LLM calls, tool invocations, final answer).
+//!
+//! Run with: `cargo run -p cognis-examples --example streaming_agent_events`
+
+#[path = "../shared.rs"]
+mod shared;
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde_json::{json, Value};
+
+use cognis::agents::AgentExecutor;
+use cognis_core::error::Result;
+use cognis_core::messages::{HumanMessage, Message};
+use cognis_core::tools::types::{ToolInput, ToolOutput};
+use cognis_core::tools::BaseTool;
+use cognis_core::tracers::event_stream::EventType;
+
+/// A simple calculator tool that adds two numbers.
+struct CalculatorTool;
+
+#[async_trait]
+impl BaseTool for CalculatorTool {
+    fn name(&self) -> &str {
+        "calculator"
+    }
+
+    fn description(&self) -> &str {
+        "Add two numbers. Input: JSON object with keys 'a' and 'b' (numbers)."
+    }
+
+    fn args_schema(&self) -> Option<Value> {
+        Some(json!({
+            "type": "object",
+            "properties": {
+                "a": {"type": "number", "description": "First number"},
+                "b": {"type": "number", "description": "Second number"}
+            },
+            "required": ["a", "b"]
+        }))
+    }
+
+    async fn _run(&self, input: ToolInput) -> Result<ToolOutput> {
+        let (a, b) = match &input {
+            ToolInput::Structured(m) => (
+                m.get("a").and_then(|v| v.as_f64()).unwrap_or(0.0),
+                m.get("b").and_then(|v| v.as_f64()).unwrap_or(0.0),
+            ),
+            ToolInput::ToolCall(tc) => (
+                tc.args.get("a").and_then(|v| v.as_f64()).unwrap_or(0.0),
+                tc.args.get("b").and_then(|v| v.as_f64()).unwrap_or(0.0),
+            ),
+            ToolInput::Text(s) => {
+                if let Ok(v) = serde_json::from_str::<Value>(s) {
+                    (
+                        v.get("a").and_then(|v| v.as_f64()).unwrap_or(0.0),
+                        v.get("b").and_then(|v| v.as_f64()).unwrap_or(0.0),
+                    )
+                } else {
+                    (0.0, 0.0)
+                }
+            }
+        };
+        println!("  [Calculator] {} + {} = {}", a, b, a + b);
+        Ok(ToolOutput::Content(json!({ "result": a + b })))
+    }
+}
+
+#[tokio::main]
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    println!("=== Streaming Agent Events Demo ===\n");
+
+    let model =
+        shared::get_chat_model(vec!["I'll compute 7 + 5 for you. The answer is 12.".into()]);
+
+    let executor = AgentExecutor::builder()
+        .model(model)
+        .tools(vec![Arc::new(CalculatorTool) as Arc<dyn BaseTool>])
+        .max_iterations(3)
+        .build();
+
+    let messages = vec![Message::Human(HumanMessage::new("What is 7 + 5?"))];
+
+    let mut stream = executor.astream_events(messages).await?;
+
+    println!("Streaming events as they occur:\n");
+    let mut event_count = 0usize;
+    while let Some(event) = stream.next().await {
+        let ev = event?;
+        event_count += 1;
+        match ev.event {
+            EventType::OnChainStart => {
+                println!("→ [{}] Agent started", ev.run_id);
+            }
+            EventType::OnChatModelStart | EventType::OnLlmStart => {
+                println!("→ LLM call started ({})", ev.name);
+            }
+            EventType::OnChatModelEnd | EventType::OnLlmEnd => {
+                println!("← LLM call finished");
+            }
+            EventType::OnAgentAction => {
+                println!(
+                    "→ Tool call: {} with input {:?}",
+                    ev.name,
+                    ev.data.input.as_ref().unwrap_or(&json!(null))
+                );
+            }
+            EventType::OnToolStart => {
+                println!("→ Tool '{}' starting", ev.name);
+            }
+            EventType::OnToolEnd => {
+                println!(
+                    "← Tool '{}' returned: {:?}",
+                    ev.name,
+                    ev.data.output.as_ref().unwrap_or(&json!(null))
+                );
+            }
+            EventType::OnAgentFinish => {
+                println!(
+                    "✓ Final answer: {:?}",
+                    ev.data.output.as_ref().unwrap_or(&json!(null))
+                );
+            }
+            EventType::OnChainEnd => {
+                println!("← Agent finished");
+            }
+            other => {
+                println!("  (event: {:?})", other);
+            }
+        }
+    }
+
+    println!("\nTotal events received: {}", event_count);
+    println!("\n=== Done ===");
+    Ok(())
+}

--- a/examples/agents/streaming_agent_events.rs
+++ b/examples/agents/streaming_agent_events.rs
@@ -78,8 +78,21 @@ impl BaseTool for CalculatorTool {
 async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     println!("=== Streaming Agent Events Demo ===\n");
 
-    let model =
-        shared::get_chat_model(vec!["I'll compute 7 + 5 for you. The answer is 12.".into()]);
+    // Use the tool-calling fallback helper: real Ollama if available, otherwise
+    // a scripted fake model that issues a tool call then a final answer. This
+    // ensures the example demonstrates OnAgentAction/OnToolStart/OnToolEnd
+    // events even without a live LLM.
+    let model = shared::get_tool_calling_model(vec![
+        Message::ai_with_tool_calls(
+            "",
+            vec![json!({
+                "name": "calculator",
+                "args": {"a": 7, "b": 5},
+                "id": "call_1"
+            })],
+        ),
+        Message::ai("7 + 5 = 12"),
+    ]);
 
     let executor = AgentExecutor::builder()
         .model(model)


### PR DESCRIPTION
## Summary

Closes #5 — adds a high-level streaming API that eliminates the need for users to hand-roll callback handlers + channels + select loops.

**Before** (what users hand-roll today):
```rust
// 1. Implement CallbackHandler
// 2. Push on_llm_*/on_tool_* events into mpsc::Sender
// 3. Wrap executor.run() + receiver in select!
// ~150 lines of boilerplate
```

**After** (what this PR enables):
```rust
let mut stream = executor.astream_events(messages).await?;
while let Some(event) = stream.next().await {
    match event?.event {
        EventType::OnAgentAction => ...,
        EventType::OnToolEnd => ...,
        EventType::OnAgentFinish => ...,
        _ => {}
    }
}
```

## Changes

### cognis-core
- Extend `EventType` enum with 4 agent variants: `OnAgentStart`, `OnAgentAction`, `OnAgentFinish`, `OnAgentEnd` (serde renames to `on_agent_*`)
- Implement `on_agent_action` and `on_agent_finish` on `EventStreamCallbackHandler` to emit corresponding `StreamEvent` values

### cognis
- New `AgentExecutor::astream_events(messages) -> Result<Stream<StreamEvent>>` method
- Spawns `run()` in background with injected `EventStreamCallbackHandler`
- Returns `ReceiverStream` that auto-closes when the executor finishes

### Tests (5 new)
- `test_agent_event_types_serialize` + `test_agent_event_types_display` — snake_case serialization
- `test_handler_receives_agent_events` — handler end-to-end
- `test_astream_events_emits_chain_start_and_end` — integration
- `test_astream_events_stream_completes` — stream termination

### Example
- \`streaming_agent_events\` — demonstrates the API with \`CalculatorTool\` + Ollama fallback

## Test plan

- [x] All workspace tests pass (0 failures)
- [x] \`cargo clippy --workspace --features all-providers -- -D warnings\` clean
- [x] \`cubic review --base origin/main\` — no issues found
- [x] Example runs successfully with Ollama

## Related follow-ups (separate PRs)

- #8 — cancellation token support (same event plumbing)
- #6 — typed tool outputs alongside stringified form
- #7 — approval-gate middleware (emits \`OnToolPendingApproval\` via same mechanism)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a high‑level streaming API `AgentExecutor::astream_events` to emit agent, LLM, and tool events as a stream without custom callbacks or channels. Closes #5.

- **New Features**
  - `AgentExecutor::astream_events(messages)` returns a `Stream<StreamEvent>` and auto‑closes when the run ends.
  - Injects `EventStreamCallbackHandler` and runs the executor in the background.
  - Extends `cognis-core` `EventType` with `on_agent_action` and `on_agent_finish`; lifecycle uses existing `on_chain_start`/`on_chain_end`. Handler emits action/finish events.
  - Adds example `streaming_agent_events`, updated to use a tool‑calling fallback so it exercises `OnAgentAction`/`OnToolStart`/`OnToolEnd` without Ollama; adds tests for serialization/display, handler flow, chain start/end, and stream termination.

- **Dependencies**
  - Add `tokio-stream` to `cognis` and workspace.

<sup>Written for commit 02a162a54415e0f043c79ac14a45fb2cd67d1d38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

