### PR TITLE
feat: preserve typed tool-output Value in callbacks (#6)

### DIFF
--- a/crates/cognis-core/src/callbacks/base.rs
+++ b/crates/cognis-core/src/callbacks/base.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 use uuid::Uuid;
 
+use super::events::{ToolEndEvent, ToolErrorEvent, ToolStartEvent};
 use crate::agents::{AgentAction, AgentFinish};
 use crate::documents::Document;
 use crate::error::Result;
@@ -130,31 +131,15 @@ pub trait CallbackHandler: Send + Sync {
         Ok(())
     }
 
-    async fn on_tool_start(
-        &self,
-        _serialized: &Value,
-        _input_str: &str,
-        _run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
+    async fn on_tool_start(&self, _event: ToolStartEvent) -> Result<()> {
         Ok(())
     }
 
-    async fn on_tool_end(
-        &self,
-        _output: &str,
-        _run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
+    async fn on_tool_end(&self, _event: ToolEndEvent) -> Result<()> {
         Ok(())
     }
 
-    async fn on_tool_error(
-        &self,
-        _error: &str,
-        _run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
+    async fn on_tool_error(&self, _event: ToolErrorEvent) -> Result<()> {
         Ok(())
     }
 

--- a/crates/cognis-core/src/callbacks/events.rs
+++ b/crates/cognis-core/src/callbacks/events.rs
@@ -1,0 +1,86 @@
+//! Struct payloads for tool-lifecycle callback events.
+
+use serde_json::Value;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// Emitted when a tool invocation begins.
+#[derive(Debug, Clone)]
+pub struct ToolStartEvent {
+    pub tool: String,
+    pub serialized: Value,
+    pub input_str: String,
+    pub inputs: Value,
+    pub tool_call_id: Option<String>,
+    pub run_id: Uuid,
+    pub parent_run_id: Option<Uuid>,
+    pub tags: Vec<String>,
+    pub metadata: HashMap<String, Value>,
+}
+
+/// Emitted when a tool invocation completes successfully.
+///
+/// `output_str` is the stringified form given to the LLM scratchpad.
+/// `output_value` preserves the original JSON shape so UIs can render
+/// typed payloads without re-parsing. `artifact` is populated only when
+/// the tool returned `ToolOutput::ContentAndArtifact`.
+#[derive(Debug, Clone)]
+pub struct ToolEndEvent {
+    pub tool: String,
+    pub output_str: String,
+    pub output_value: Value,
+    pub artifact: Option<Value>,
+    pub tool_call_id: Option<String>,
+    pub run_id: Uuid,
+    pub parent_run_id: Option<Uuid>,
+}
+
+/// Emitted when a tool invocation fails.
+#[derive(Debug, Clone)]
+pub struct ToolErrorEvent {
+    pub tool: String,
+    pub error: String,
+    pub error_kind: ToolErrorKind,
+    pub tool_call_id: Option<String>,
+    pub run_id: Uuid,
+    pub parent_run_id: Option<Uuid>,
+}
+
+/// Structured discriminator for tool-invocation errors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolErrorKind {
+    /// Tool name did not resolve in the executor's registry.
+    NotFound,
+    /// Tool `_run` returned `Err(ToolException | ToolValidationError)`.
+    Execution,
+    /// Any other failure (serde, panics surfaced as errors, etc.).
+    Other,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_end_event_is_clone_debug() {
+        let event = ToolEndEvent {
+            tool: "search".into(),
+            output_str: "\"hit\"".into(),
+            output_value: Value::String("hit".into()),
+            artifact: None,
+            tool_call_id: Some("call_1".into()),
+            run_id: Uuid::new_v4(),
+            parent_run_id: None,
+        };
+        let cloned = event.clone();
+        assert_eq!(cloned.tool, "search");
+        // Debug impl should not panic.
+        let _ = format!("{event:?}");
+    }
+
+    #[test]
+    fn tool_error_kind_equality() {
+        assert_eq!(ToolErrorKind::NotFound, ToolErrorKind::NotFound);
+        assert_ne!(ToolErrorKind::NotFound, ToolErrorKind::Execution);
+    }
+}

--- a/crates/cognis-core/src/callbacks/events.rs
+++ b/crates/cognis-core/src/callbacks/events.rs
@@ -7,14 +7,23 @@ use uuid::Uuid;
 /// Emitted when a tool invocation begins.
 #[derive(Debug, Clone)]
 pub struct ToolStartEvent {
+    /// Name of the tool being invoked.
     pub tool: String,
+    /// Serialized tool metadata (name + arguments schema).
     pub serialized: Value,
+    /// JSON-stringified tool arguments, suitable for logs.
     pub input_str: String,
+    /// Structured tool arguments as a `Value`.
     pub inputs: Value,
+    /// Identifier from the AI message's `tool_call`, if present.
     pub tool_call_id: Option<String>,
+    /// Unique identifier for this tool invocation.
     pub run_id: Uuid,
+    /// Identifier of the enclosing run (e.g., chain or agent).
     pub parent_run_id: Option<Uuid>,
+    /// Tags propagated from the run configuration.
     pub tags: Vec<String>,
+    /// Run-scoped metadata.
     pub metadata: HashMap<String, Value>,
 }
 
@@ -26,23 +35,37 @@ pub struct ToolStartEvent {
 /// the tool returned `ToolOutput::ContentAndArtifact`.
 #[derive(Debug, Clone)]
 pub struct ToolEndEvent {
+    /// Name of the tool that completed.
     pub tool: String,
+    /// Stringified form of the output; this is what the LLM scratchpad sees.
     pub output_str: String,
+    /// Original JSON shape of the output, preserved for UI consumers that render typed payloads.
     pub output_value: Value,
+    /// Structured side-channel payload from tools that return `ToolOutput::ContentAndArtifact`;
+    /// `None` for plain `ToolOutput::Content`.
     pub artifact: Option<Value>,
+    /// Identifier from the AI message's `tool_call`, if present.
     pub tool_call_id: Option<String>,
+    /// Unique identifier for this tool invocation.
     pub run_id: Uuid,
+    /// Identifier of the enclosing run.
     pub parent_run_id: Option<Uuid>,
 }
 
 /// Emitted when a tool invocation fails.
 #[derive(Debug, Clone)]
 pub struct ToolErrorEvent {
+    /// Name of the tool that failed.
     pub tool: String,
+    /// Display-formatted error message.
     pub error: String,
+    /// Structured discriminator for programmatic handling.
     pub error_kind: ToolErrorKind,
+    /// Identifier from the AI message's `tool_call`, if present.
     pub tool_call_id: Option<String>,
+    /// Unique identifier for this tool invocation.
     pub run_id: Uuid,
+    /// Identifier of the enclosing run.
     pub parent_run_id: Option<Uuid>,
 }
 
@@ -51,9 +74,10 @@ pub struct ToolErrorEvent {
 pub enum ToolErrorKind {
     /// Tool name did not resolve in the executor's registry.
     NotFound,
-    /// Tool `_run` returned `Err(ToolException | ToolValidationError)`.
+    /// Tool `_run` returned an error (e.g., `CognisError::ToolException` or
+    /// `CognisError::ToolValidationError`).
     Execution,
-    /// Any other failure (serde, panics surfaced as errors, etc.).
+    /// Any other failure (serde errors, panics surfaced as errors, etc.).
     Other,
 }
 

--- a/crates/cognis-core/src/callbacks/handlers.rs
+++ b/crates/cognis-core/src/callbacks/handlers.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use super::base::CallbackHandler;
+use super::events::{ToolEndEvent, ToolErrorEvent, ToolStartEvent};
 use crate::agents::{AgentAction, AgentFinish};
 use crate::documents::Document;
 use crate::error::Result;
@@ -255,29 +256,18 @@ impl CallbackHandler for FileCallbackHandler {
         Ok(())
     }
 
-    async fn on_tool_start(
-        &self,
-        _serialized: &Value,
-        input_str: &str,
-        run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
+    async fn on_tool_start(&self, event: ToolStartEvent) -> Result<()> {
         self.write_line(&format!(
             "[tool/start] [{}] Entering tool run with input: {}",
-            run_id, input_str
+            event.run_id, event.input_str
         ));
         Ok(())
     }
 
-    async fn on_tool_end(
-        &self,
-        output: &str,
-        run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
+    async fn on_tool_end(&self, event: ToolEndEvent) -> Result<()> {
         self.write_line(&format!(
             "[tool/end] [{}] Finished tool run with output: {}",
-            run_id, output
+            event.run_id, event.output_str
         ));
         Ok(())
     }
@@ -621,34 +611,26 @@ impl CallbackHandler for LoggingCallbackHandler {
         Ok(())
     }
 
-    async fn on_tool_start(
-        &self,
-        _serialized: &Value,
-        input_str: &str,
-        run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
-        self.log("tool/start", &format!("input: {}", input_str), run_id);
+    async fn on_tool_start(&self, event: ToolStartEvent) -> Result<()> {
+        self.log(
+            "tool/start",
+            &format!("input: {}", event.input_str),
+            event.run_id,
+        );
         Ok(())
     }
 
-    async fn on_tool_end(
-        &self,
-        output: &str,
-        run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
-        self.log("tool/end", &format!("output: {}", output), run_id);
+    async fn on_tool_end(&self, event: ToolEndEvent) -> Result<()> {
+        self.log(
+            "tool/end",
+            &format!("output: {}", event.output_str),
+            event.run_id,
+        );
         Ok(())
     }
 
-    async fn on_tool_error(
-        &self,
-        error: &str,
-        run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
-        self.log("tool/error", error, run_id);
+    async fn on_tool_error(&self, event: ToolErrorEvent) -> Result<()> {
+        self.log("tool/error", &event.error, event.run_id);
         Ok(())
     }
 
@@ -850,23 +832,12 @@ impl CallbackHandler for MetricsCallbackHandler {
         Ok(())
     }
 
-    async fn on_tool_start(
-        &self,
-        _serialized: &Value,
-        _input_str: &str,
-        _run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
+    async fn on_tool_start(&self, _event: ToolStartEvent) -> Result<()> {
         self.total_tool_calls.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
 
-    async fn on_tool_error(
-        &self,
-        _error: &str,
-        _run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
+    async fn on_tool_error(&self, _event: ToolErrorEvent) -> Result<()> {
         self.total_errors.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }

--- a/crates/cognis-core/src/callbacks/manager.rs
+++ b/crates/cognis-core/src/callbacks/manager.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use super::base::CallbackHandler;
+use super::events::{ToolEndEvent, ToolErrorEvent, ToolStartEvent};
 use crate::agents::{AgentAction, AgentFinish};
 use crate::error::Result;
 use crate::outputs::LLMResult;
@@ -249,34 +250,23 @@ impl CallbackManager {
         Ok(())
     }
 
-    pub async fn on_tool_start(
-        &self,
-        serialized: &Value,
-        input_str: &str,
-        run_id: Uuid,
-    ) -> Result<()> {
+    pub async fn on_tool_start(&self, event: ToolStartEvent) -> Result<()> {
         for handler in &self.handlers {
-            handler
-                .on_tool_start(serialized, input_str, run_id, self.parent_run_id)
-                .await?;
+            handler.on_tool_start(event.clone()).await?;
         }
         Ok(())
     }
 
-    pub async fn on_tool_end(&self, output: &str, run_id: Uuid) -> Result<()> {
+    pub async fn on_tool_end(&self, event: ToolEndEvent) -> Result<()> {
         for handler in &self.handlers {
-            handler
-                .on_tool_end(output, run_id, self.parent_run_id)
-                .await?;
+            handler.on_tool_end(event.clone()).await?;
         }
         Ok(())
     }
 
-    pub async fn on_tool_error(&self, error: &str, run_id: Uuid) -> Result<()> {
+    pub async fn on_tool_error(&self, event: ToolErrorEvent) -> Result<()> {
         for handler in &self.handlers {
-            handler
-                .on_tool_error(error, run_id, self.parent_run_id)
-                .await?;
+            handler.on_tool_error(event.clone()).await?;
         }
         Ok(())
     }
@@ -354,6 +344,43 @@ mod tests {
         }
     }
 
+    fn start_event(run_id: Uuid, input: &str) -> ToolStartEvent {
+        ToolStartEvent {
+            tool: "test".into(),
+            serialized: json!({}),
+            input_str: input.into(),
+            inputs: json!({}),
+            tool_call_id: None,
+            run_id,
+            parent_run_id: None,
+            tags: vec![],
+            metadata: HashMap::new(),
+        }
+    }
+
+    fn end_event(run_id: Uuid, out: &str) -> ToolEndEvent {
+        ToolEndEvent {
+            tool: "test".into(),
+            output_str: out.into(),
+            output_value: Value::String(out.into()),
+            artifact: None,
+            tool_call_id: None,
+            run_id,
+            parent_run_id: None,
+        }
+    }
+
+    fn error_event(run_id: Uuid, err: &str) -> ToolErrorEvent {
+        ToolErrorEvent {
+            tool: "test".into(),
+            error: err.into(),
+            error_kind: crate::callbacks::ToolErrorKind::Execution,
+            tool_call_id: None,
+            run_id,
+            parent_run_id: None,
+        }
+    }
+
     #[tokio::test]
     async fn test_dispatch_to_multiple_handlers() {
         let logging = Arc::new(LoggingCallbackHandler::new(LogLevel::Info));
@@ -406,7 +433,7 @@ mod tests {
             .await
             .unwrap();
         manager
-            .on_tool_start(&json!({}), "search query", run_id)
+            .on_tool_start(start_event(run_id, "search query"))
             .await
             .unwrap();
 
@@ -443,7 +470,7 @@ mod tests {
 
         // One tool call
         manager
-            .on_tool_start(&json!({}), "input", run_id)
+            .on_tool_start(start_event(run_id, "input"))
             .await
             .unwrap();
 
@@ -520,11 +547,14 @@ mod tests {
         manager.on_chain_end(&json!({}), run_id).await.unwrap();
         manager.on_chain_error("err", run_id).await.unwrap();
         manager
-            .on_tool_start(&json!({}), "in", run_id)
+            .on_tool_start(start_event(run_id, "in"))
             .await
             .unwrap();
-        manager.on_tool_end("out", run_id).await.unwrap();
-        manager.on_tool_error("err", run_id).await.unwrap();
+        manager.on_tool_end(end_event(run_id, "out")).await.unwrap();
+        manager
+            .on_tool_error(error_event(run_id, "err"))
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -567,11 +597,14 @@ mod tests {
         manager.on_chain_end(&json!({}), run_id).await.unwrap();
         manager.on_chain_error("err", run_id).await.unwrap();
         manager
-            .on_tool_start(&json!({}), "in", run_id)
+            .on_tool_start(start_event(run_id, "in"))
             .await
             .unwrap();
-        manager.on_tool_end("out", run_id).await.unwrap();
-        manager.on_tool_error("err", run_id).await.unwrap();
+        manager.on_tool_end(end_event(run_id, "out")).await.unwrap();
+        manager
+            .on_tool_error(error_event(run_id, "err"))
+            .await
+            .unwrap();
 
         let logs = logging.get_logs();
         assert_eq!(logs.len(), 9);

--- a/crates/cognis-core/src/callbacks/mod.rs
+++ b/crates/cognis-core/src/callbacks/mod.rs
@@ -1,9 +1,11 @@
 pub mod base;
+mod events;
 pub mod handlers;
 pub mod manager;
 pub mod run_manager;
 
 pub use base::CallbackHandler;
+pub use events::{ToolEndEvent, ToolErrorEvent, ToolErrorKind, ToolStartEvent};
 pub use handlers::{
     FileCallbackHandler, LogLevel, LoggingCallbackHandler, MetricsCallbackHandler, MetricsSnapshot,
     StdOutCallbackHandler, StreamingStdOutCallbackHandler, UsageMetadataCallbackHandler,

--- a/crates/cognis-core/src/callbacks/run_manager.rs
+++ b/crates/cognis-core/src/callbacks/run_manager.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use super::base::CallbackHandler;
+use super::events::{ToolEndEvent, ToolErrorEvent, ToolErrorKind};
 use super::manager::CallbackManager;
 use crate::agents::{AgentAction, AgentFinish};
 use crate::documents::Document;
@@ -227,6 +228,8 @@ pub struct RunManagerForTool {
     handlers: Vec<Arc<dyn CallbackHandler>>,
     inheritable_handlers: Vec<Arc<dyn CallbackHandler>>,
     parent_run_id: Option<Uuid>,
+    tool_name: Option<String>,
+    tool_call_id: Option<String>,
 }
 
 impl RunManagerForTool {
@@ -241,7 +244,22 @@ impl RunManagerForTool {
             handlers,
             inheritable_handlers,
             parent_run_id,
+            tool_name: None,
+            tool_call_id: None,
         }
+    }
+
+    /// Set the tool name associated with this run (used when forwarding
+    /// `ToolEndEvent` / `ToolErrorEvent` to handlers).
+    pub fn with_tool_name(mut self, name: impl Into<String>) -> Self {
+        self.tool_name = Some(name.into());
+        self
+    }
+
+    /// Set the tool-call id associated with this run.
+    pub fn with_tool_call_id(mut self, id: impl Into<String>) -> Self {
+        self.tool_call_id = Some(id.into());
+        self
     }
 
     pub fn run_id(&self) -> Uuid {
@@ -253,19 +271,39 @@ impl RunManagerForTool {
         CallbackManager::new(self.inheritable_handlers.clone(), Some(self.run_id))
     }
 
-    pub async fn on_tool_end(&self, output: &str) -> Result<()> {
+    pub async fn on_tool_end(
+        &self,
+        output_str: String,
+        output_value: Value,
+        artifact: Option<Value>,
+    ) -> Result<()> {
         for handler in &self.handlers {
             handler
-                .on_tool_end(output, self.run_id, self.parent_run_id)
+                .on_tool_end(ToolEndEvent {
+                    tool: self.tool_name.clone().unwrap_or_default(),
+                    output_str: output_str.clone(),
+                    output_value: output_value.clone(),
+                    artifact: artifact.clone(),
+                    tool_call_id: self.tool_call_id.clone(),
+                    run_id: self.run_id,
+                    parent_run_id: self.parent_run_id,
+                })
                 .await?;
         }
         Ok(())
     }
 
-    pub async fn on_tool_error(&self, error: &str) -> Result<()> {
+    pub async fn on_tool_error(&self, error: String, kind: ToolErrorKind) -> Result<()> {
         for handler in &self.handlers {
             handler
-                .on_tool_error(error, self.run_id, self.parent_run_id)
+                .on_tool_error(ToolErrorEvent {
+                    tool: self.tool_name.clone().unwrap_or_default(),
+                    error: error.clone(),
+                    error_kind: kind.clone(),
+                    tool_call_id: self.tool_call_id.clone(),
+                    run_id: self.run_id,
+                    parent_run_id: self.parent_run_id,
+                })
                 .await?;
         }
         Ok(())

--- a/crates/cognis-core/src/cross_encoders.rs
+++ b/crates/cognis-core/src/cross_encoders.rs
@@ -353,7 +353,7 @@ impl<E: CrossEncoder> CrossEncoder for CachedCrossEncoder<E> {
             let scores = self.inner.score_pairs(&miss_pairs).await?;
 
             let mut cache = self.cache.lock().unwrap();
-            for ((idx, pair), score) in misses.into_iter().zip(scores.into_iter()) {
+            for ((idx, pair), score) in misses.into_iter().zip(scores) {
                 cache.insert(pair, score);
                 results[idx] = score;
             }

--- a/crates/cognis-core/src/indexing/in_memory.rs
+++ b/crates/cognis-core/src/indexing/in_memory.rs
@@ -60,7 +60,7 @@ impl InMemoryDocumentIndex {
             })
             .collect();
 
-        counts.sort_by(|a, b| b.1.cmp(&a.1));
+        counts.sort_by_key(|b| std::cmp::Reverse(b.1));
         counts
             .into_iter()
             .take(self.top_k)

--- a/crates/cognis-core/src/messages/tool.rs
+++ b/crates/cognis-core/src/messages/tool.rs
@@ -39,8 +39,39 @@ impl ToolMessage {
         self
     }
 
-    pub fn with_artifact(mut self, artifact: Value) -> Self {
-        self.artifact = Some(artifact);
-        self
+    /// Constructor that also sets the structured artifact payload.
+    ///
+    /// Use when the tool returned `ToolOutput::ContentAndArtifact`: `content`
+    /// goes to the LLM scratchpad, `artifact` is the structured payload for
+    /// UIs and callback consumers.
+    pub fn with_artifact(
+        content: impl Into<String>,
+        tool_call_id: impl Into<String>,
+        artifact: Value,
+    ) -> Self {
+        let mut msg = Self::new(content, tool_call_id);
+        msg.artifact = Some(artifact);
+        msg
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn with_artifact_sets_the_field() {
+        let artifact = json!({"chart": [1, 2, 3]});
+        let msg = ToolMessage::with_artifact("summary text", "call_abc", artifact.clone());
+        assert_eq!(msg.base.content.text(), "summary text");
+        assert_eq!(msg.tool_call_id, "call_abc");
+        assert_eq!(msg.artifact, Some(artifact));
+    }
+
+    #[test]
+    fn new_leaves_artifact_none() {
+        let msg = ToolMessage::new("just text", "call_abc");
+        assert_eq!(msg.artifact, None);
     }
 }

--- a/crates/cognis-core/src/tools/base.rs
+++ b/crates/cognis-core/src/tools/base.rs
@@ -104,6 +104,11 @@ pub trait BaseTool: Send + Sync {
     async fn _run(&self, input: ToolInput) -> Result<ToolOutput>;
 
     /// Run the tool with error handling.
+    ///
+    /// Returns only the content `Value`. If the tool produces
+    /// `ToolOutput::ContentAndArtifact`, the artifact is discarded.
+    /// Callers that need the artifact (such as UI callback consumers)
+    /// should call [`_run`](Self::_run) directly and match on `ToolOutput`.
     async fn run(&self, input: ToolInput, _tool_call_id: Option<&str>) -> Result<Value> {
         match self._run(input).await {
             Ok(output) => Ok(match output {
@@ -121,11 +126,17 @@ pub trait BaseTool: Send + Sync {
     }
 
     /// Convenience method to run the tool with a string input.
+    ///
+    /// Returns only the content `Value`; see [`run`](Self::run) for the
+    /// artifact-discard caveat.
     async fn run_str(&self, input: &str) -> Result<Value> {
         self.run(ToolInput::Text(input.to_string()), None).await
     }
 
     /// Run the tool with structured (JSON) input.
+    ///
+    /// Returns only the content `Value`; see [`run`](Self::run) for the
+    /// artifact-discard caveat.
     async fn run_json(&self, input: &Value) -> Result<Value> {
         let map: HashMap<String, Value> = match input {
             Value::Object(m) => m.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),

--- a/crates/cognis-core/src/tools/base.rs
+++ b/crates/cognis-core/src/tools/base.rs
@@ -21,6 +21,30 @@ pub trait BaseToolkit: Send + Sync {
     fn get_tools(&self) -> Vec<Box<dyn BaseTool>>;
 }
 
+/// Apply an error-handler policy to a tool error, converting it (where
+/// configured) into a `Value::String` observation the agent can feed back
+/// to the model, or re-raising the error for caller-side handling.
+///
+/// Used by `BaseTool::run` and the agent executor (which calls `_run`
+/// directly and must replicate policy outside the trait).
+pub fn apply_error_handler(handler: &ErrorHandler, error: CognisError) -> Result<Value> {
+    match error {
+        CognisError::ToolException(msg) => match handler {
+            ErrorHandler::Propagate => Err(CognisError::ToolException(msg)),
+            ErrorHandler::DefaultMessage => Ok(Value::String(msg)),
+            ErrorHandler::StaticMessage(s) => Ok(Value::String(s.clone())),
+            ErrorHandler::Dynamic(f) => Ok(Value::String(f(&msg))),
+        },
+        CognisError::ToolValidationError(msg) => match handler {
+            ErrorHandler::Propagate => Err(CognisError::ToolValidationError(msg)),
+            ErrorHandler::DefaultMessage => Ok(Value::String(msg)),
+            ErrorHandler::StaticMessage(s) => Ok(Value::String(s.clone())),
+            ErrorHandler::Dynamic(f) => Ok(Value::String(f(&msg))),
+        },
+        other => Err(other),
+    }
+}
+
 /// Interface for tools that can be called by agents.
 #[async_trait]
 pub trait BaseTool: Send + Sync {
@@ -82,25 +106,16 @@ pub trait BaseTool: Send + Sync {
     /// Run the tool with error handling.
     async fn run(&self, input: ToolInput, _tool_call_id: Option<&str>) -> Result<Value> {
         match self._run(input).await {
-            Ok(output) => {
-                let content = match output {
-                    ToolOutput::Content(v) => v,
-                    ToolOutput::ContentAndArtifact { content, .. } => content,
-                };
-                Ok(content)
+            Ok(output) => Ok(match output {
+                ToolOutput::Content(v) => v,
+                ToolOutput::ContentAndArtifact { content, .. } => content,
+            }),
+            Err(e @ CognisError::ToolException(_)) => {
+                apply_error_handler(self.handle_tool_error(), e)
             }
-            Err(CognisError::ToolException(msg)) => match self.handle_tool_error() {
-                ErrorHandler::Propagate => Err(CognisError::ToolException(msg)),
-                ErrorHandler::DefaultMessage => Ok(Value::String(msg)),
-                ErrorHandler::StaticMessage(s) => Ok(Value::String(s.clone())),
-                ErrorHandler::Dynamic(f) => Ok(Value::String(f(&msg))),
-            },
-            Err(CognisError::ToolValidationError(msg)) => match self.handle_validation_error() {
-                ErrorHandler::Propagate => Err(CognisError::ToolValidationError(msg)),
-                ErrorHandler::DefaultMessage => Ok(Value::String(msg)),
-                ErrorHandler::StaticMessage(s) => Ok(Value::String(s.clone())),
-                ErrorHandler::Dynamic(f) => Ok(Value::String(f(&msg))),
-            },
+            Err(e @ CognisError::ToolValidationError(_)) => {
+                apply_error_handler(self.handle_validation_error(), e)
+            }
             Err(e) => Err(e),
         }
     }
@@ -118,5 +133,39 @@ pub trait BaseTool: Send + Sync {
             _ => return self.run(ToolInput::Text(input.to_string()), None).await,
         };
         self.run(ToolInput::Structured(map), None).await
+    }
+}
+
+#[cfg(test)]
+mod error_handler_tests {
+    use super::*;
+
+    #[test]
+    fn propagate_returns_err() {
+        let handler = ErrorHandler::Propagate;
+        let result = apply_error_handler(&handler, CognisError::ToolException("boom".into()));
+        assert!(matches!(result, Err(CognisError::ToolException(_))));
+    }
+
+    #[test]
+    fn default_message_returns_error_text() {
+        let handler = ErrorHandler::DefaultMessage;
+        let result = apply_error_handler(&handler, CognisError::ToolException("boom".into()));
+        assert_eq!(result.unwrap(), Value::String("boom".to_string()));
+    }
+
+    #[test]
+    fn static_message_returns_configured_text() {
+        let handler = ErrorHandler::StaticMessage("safe fallback".into());
+        let result = apply_error_handler(&handler, CognisError::ToolException("boom".into()));
+        assert_eq!(result.unwrap(), Value::String("safe fallback".to_string()));
+    }
+
+    #[test]
+    fn dynamic_uses_callback() {
+        let handler =
+            ErrorHandler::Dynamic(std::sync::Arc::new(|msg: &str| format!("wrapped: {msg}")));
+        let result = apply_error_handler(&handler, CognisError::ToolException("boom".into()));
+        assert_eq!(result.unwrap(), Value::String("wrapped: boom".to_string()));
     }
 }

--- a/crates/cognis-core/src/tools/base.rs
+++ b/crates/cognis-core/src/tools/base.rs
@@ -144,7 +144,10 @@ mod error_handler_tests {
     fn propagate_returns_err() {
         let handler = ErrorHandler::Propagate;
         let result = apply_error_handler(&handler, CognisError::ToolException("boom".into()));
-        assert!(matches!(result, Err(CognisError::ToolException(_))));
+        match result {
+            Err(CognisError::ToolException(msg)) => assert_eq!(msg, "boom"),
+            other => panic!("expected ToolException, got {other:?}"),
+        }
     }
 
     #[test]
@@ -167,5 +170,42 @@ mod error_handler_tests {
             ErrorHandler::Dynamic(std::sync::Arc::new(|msg: &str| format!("wrapped: {msg}")));
         let result = apply_error_handler(&handler, CognisError::ToolException("boom".into()));
         assert_eq!(result.unwrap(), Value::String("wrapped: boom".to_string()));
+    }
+
+    #[test]
+    fn validation_error_respects_static_message() {
+        let handler = ErrorHandler::StaticMessage("bad input".into());
+        let result = apply_error_handler(
+            &handler,
+            CognisError::ToolValidationError("schema mismatch".into()),
+        );
+        assert_eq!(result.unwrap(), Value::String("bad input".to_string()));
+    }
+
+    #[test]
+    fn validation_error_propagate_preserves_variant_and_message() {
+        let handler = ErrorHandler::Propagate;
+        let result = apply_error_handler(
+            &handler,
+            CognisError::ToolValidationError("schema mismatch".into()),
+        );
+        match result {
+            Err(CognisError::ToolValidationError(msg)) => assert_eq!(msg, "schema mismatch"),
+            other => panic!("expected ToolValidationError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_tool_error_passes_through_unchanged() {
+        // `CognisError::Other` is not a tool-level error; the `other => Err(other)`
+        // fallthrough in `apply_error_handler` must propagate it unchanged
+        // regardless of the handler policy.
+        let handler = ErrorHandler::DefaultMessage;
+        let error = CognisError::Other("unexpected failure".into());
+        let result = apply_error_handler(&handler, error);
+        match result {
+            Err(CognisError::Other(msg)) => assert_eq!(msg, "unexpected failure"),
+            other => panic!("expected Other, got {other:?}"),
+        }
     }
 }

--- a/crates/cognis-core/src/tracers/event_stream.rs
+++ b/crates/cognis-core/src/tracers/event_stream.rs
@@ -677,7 +677,8 @@ impl CallbackHandler for EventStreamCallbackHandler {
             event: EventType::OnToolEnd,
             name: run_info.name,
             data: EventData {
-                output: Some(Value::String(event.output_str.clone())),
+                output: Some(event.output_value),
+                artifact: event.artifact,
                 input: run_info.inputs,
                 ..Default::default()
             },
@@ -1044,6 +1045,49 @@ mod tests {
             evt.data.output,
             Some(Value::String("tool output".to_string()))
         );
+    }
+
+    #[tokio::test]
+    async fn on_tool_end_preserves_structured_value() {
+        let handler = EventStreamCallbackHandler::with_defaults();
+        let mut rx = handler.take_receiver().unwrap();
+        let run_id = Uuid::new_v4();
+
+        handler
+            .on_tool_start(ToolStartEvent {
+                tool: "search".into(),
+                serialized: json!({"name": "search"}),
+                input_str: "\"q\"".into(),
+                inputs: json!("q"),
+                tool_call_id: None,
+                run_id,
+                parent_run_id: None,
+                tags: vec![],
+                metadata: HashMap::new(),
+            })
+            .await
+            .unwrap();
+
+        let typed = json!({"hits": [1, 2, 3]});
+        handler
+            .on_tool_end(ToolEndEvent {
+                tool: "search".into(),
+                output_str: typed.to_string(),
+                output_value: typed.clone(),
+                artifact: Some(json!({"source": "cache"})),
+                tool_call_id: None,
+                run_id,
+                parent_run_id: None,
+            })
+            .await
+            .unwrap();
+
+        // Drain the start event; the end event is what matters.
+        let _ = rx.recv().await.unwrap();
+        let end_event = rx.recv().await.unwrap();
+        assert_eq!(end_event.event, EventType::OnToolEnd);
+        assert_eq!(end_event.data.output, Some(typed));
+        assert_eq!(end_event.data.artifact, Some(json!({"source": "cache"})));
     }
 
     #[tokio::test]

--- a/crates/cognis-core/src/tracers/event_stream.rs
+++ b/crates/cognis-core/src/tracers/event_stream.rs
@@ -16,7 +16,7 @@ use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use crate::agents::{AgentAction, AgentFinish};
-use crate::callbacks::CallbackHandler;
+use crate::callbacks::{CallbackHandler, ToolEndEvent, ToolErrorEvent, ToolStartEvent};
 use crate::documents::Document;
 use crate::error::Result;
 use crate::messages::Message;
@@ -636,96 +636,80 @@ impl CallbackHandler for EventStreamCallbackHandler {
         Ok(())
     }
 
-    async fn on_tool_start(
-        &self,
-        serialized: &Value,
-        input_str: &str,
-        run_id: Uuid,
-        parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
-        let name = assign_name(None, serialized);
+    async fn on_tool_start(&self, event: ToolStartEvent) -> Result<()> {
+        let name = assign_name(None, &event.serialized);
         let run_type = "tool".to_string();
-        let inputs = Some(Value::String(input_str.to_string()));
+        let inputs = Some(Value::String(event.input_str.clone()));
 
         self.write_run_start_info(
-            run_id,
+            event.run_id,
             name.clone(),
             run_type.clone(),
             Vec::new(),
             HashMap::new(),
-            parent_run_id,
+            event.parent_run_id,
             inputs.clone(),
         );
 
-        let event = StreamEvent {
+        let stream_event = StreamEvent {
             event: EventType::OnToolStart,
             name,
             data: EventData {
                 input: inputs,
                 ..Default::default()
             },
-            run_id: run_id.to_string(),
-            parent_ids: self.get_parent_ids(run_id),
+            run_id: event.run_id.to_string(),
+            parent_ids: self.get_parent_ids(event.run_id),
             tags: Vec::new(),
             metadata: HashMap::new(),
         };
-        self.send_event(event, &run_type);
+        self.send_event(stream_event, &run_type);
         Ok(())
     }
 
-    async fn on_tool_end(
-        &self,
-        output: &str,
-        run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
-        let run_info = match self.pop_run_info(run_id) {
+    async fn on_tool_end(&self, event: ToolEndEvent) -> Result<()> {
+        let run_info = match self.pop_run_info(event.run_id) {
             Some(info) => info,
             None => return Ok(()),
         };
 
-        let event = StreamEvent {
+        let stream_event = StreamEvent {
             event: EventType::OnToolEnd,
             name: run_info.name,
             data: EventData {
-                output: Some(Value::String(output.to_string())),
+                output: Some(Value::String(event.output_str.clone())),
                 input: run_info.inputs,
                 ..Default::default()
             },
-            run_id: run_id.to_string(),
-            parent_ids: self.get_parent_ids(run_id),
+            run_id: event.run_id.to_string(),
+            parent_ids: self.get_parent_ids(event.run_id),
             tags: run_info.tags,
             metadata: run_info.metadata,
         };
-        self.send_event(event, &run_info.run_type);
+        self.send_event(stream_event, &run_info.run_type);
         Ok(())
     }
 
-    async fn on_tool_error(
-        &self,
-        error: &str,
-        run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
-        let run_info = match self.pop_run_info(run_id) {
+    async fn on_tool_error(&self, event: ToolErrorEvent) -> Result<()> {
+        let run_info = match self.pop_run_info(event.run_id) {
             Some(info) => info,
             None => return Ok(()),
         };
 
-        let event = StreamEvent {
+        let stream_event = StreamEvent {
             event: EventType::OnToolError,
             name: run_info.name,
             data: EventData {
-                error: Some(error.to_string()),
+                error: Some(event.error.clone()),
                 input: run_info.inputs,
                 ..Default::default()
             },
-            run_id: run_id.to_string(),
-            parent_ids: self.get_parent_ids(run_id),
+            run_id: event.run_id.to_string(),
+            parent_ids: self.get_parent_ids(event.run_id),
             tags: run_info.tags,
             metadata: run_info.metadata,
         };
-        self.send_event(event, &run_info.run_type);
+        self.send_event(stream_event, &run_info.run_type);
         Ok(())
     }
 
@@ -916,6 +900,52 @@ mod tests {
         json!({"name": name})
     }
 
+    fn start_event(
+        serialized: &Value,
+        input: &str,
+        run_id: Uuid,
+        parent: Option<Uuid>,
+    ) -> ToolStartEvent {
+        ToolStartEvent {
+            tool: serialized
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            serialized: serialized.clone(),
+            input_str: input.to_string(),
+            inputs: Value::Null,
+            tool_call_id: None,
+            run_id,
+            parent_run_id: parent,
+            tags: vec![],
+            metadata: HashMap::new(),
+        }
+    }
+
+    fn end_event(out: &str, run_id: Uuid) -> ToolEndEvent {
+        ToolEndEvent {
+            tool: "".into(),
+            output_str: out.into(),
+            output_value: Value::String(out.into()),
+            artifact: None,
+            tool_call_id: None,
+            run_id,
+            parent_run_id: None,
+        }
+    }
+
+    fn error_event(err: &str, run_id: Uuid) -> ToolErrorEvent {
+        ToolErrorEvent {
+            tool: "".into(),
+            error: err.into(),
+            error_kind: crate::callbacks::ToolErrorKind::Execution,
+            tool_call_id: None,
+            run_id,
+            parent_run_id: None,
+        }
+    }
+
     #[tokio::test]
     async fn test_llm_start_end_events() {
         let handler = EventStreamCallbackHandler::with_defaults();
@@ -990,7 +1020,12 @@ mod tests {
         let run_id = Uuid::new_v4();
 
         handler
-            .on_tool_start(&make_serialized("my-tool"), "tool input", run_id, None)
+            .on_tool_start(start_event(
+                &make_serialized("my-tool"),
+                "tool input",
+                run_id,
+                None,
+            ))
             .await
             .unwrap();
 
@@ -999,7 +1034,7 @@ mod tests {
         assert_eq!(evt.name, "my-tool");
 
         handler
-            .on_tool_end("tool output", run_id, None)
+            .on_tool_end(end_event("tool output", run_id))
             .await
             .unwrap();
 
@@ -1130,12 +1165,12 @@ mod tests {
         // Tool error
         let run_id = Uuid::new_v4();
         handler
-            .on_tool_start(&make_serialized("err-tool"), "", run_id, None)
+            .on_tool_start(start_event(&make_serialized("err-tool"), "", run_id, None))
             .await
             .unwrap();
         let _ = rx.try_recv();
         handler
-            .on_tool_error("tool failed", run_id, None)
+            .on_tool_error(error_event("tool failed", run_id))
             .await
             .unwrap();
         let evt = rx.try_recv().unwrap();
@@ -1187,12 +1222,12 @@ mod tests {
 
         // Grandchild tool
         handler
-            .on_tool_start(
+            .on_tool_start(start_event(
                 &make_serialized("grandchild"),
                 "",
                 grandchild_id,
                 Some(child_id),
-            )
+            ))
             .await
             .unwrap();
         let evt = rx.try_recv().unwrap();

--- a/crates/cognis-core/src/tracers/event_stream.rs
+++ b/crates/cognis-core/src/tracers/event_stream.rs
@@ -118,6 +118,9 @@ pub struct EventData {
     /// Streaming chunk (present on stream events).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chunk: Option<Value>,
+    /// Structured artifact payload from tools (present on tool end events).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact: Option<Value>,
     /// Error description (present on error events).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,

--- a/crates/cognis-core/src/tracers/langsmith.rs
+++ b/crates/cognis-core/src/tracers/langsmith.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::callbacks::CallbackHandler;
+use crate::callbacks::{CallbackHandler, ToolEndEvent, ToolErrorEvent, ToolStartEvent};
 use crate::documents::Document;
 use crate::error::Result;
 use crate::messages::Message;
@@ -433,42 +433,30 @@ impl CallbackHandler for LangSmithTracer {
         Ok(())
     }
 
-    async fn on_tool_start(
-        &self,
-        serialized: &Value,
-        input_str: &str,
-        run_id: Uuid,
-        parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
+    async fn on_tool_start(&self, event: ToolStartEvent) -> Result<()> {
         let mut run = LangSmithRun::new(
-            run_id,
+            event.run_id,
             "tool",
             LangSmithRunType::Tool,
-            serde_json::json!({ "input": input_str }),
+            serde_json::json!({ "input": event.input_str }),
         );
-        run.parent_run_id = parent_run_id;
-        run.serialized = Some(serialized.clone());
+        run.parent_run_id = event.parent_run_id;
+        run.serialized = Some(event.serialized.clone());
         self.add_run(run);
         Ok(())
     }
 
-    async fn on_tool_end(
-        &self,
-        output: &str,
-        run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
-        self.finish_run(run_id, Some(serde_json::json!({ "output": output })), None);
+    async fn on_tool_end(&self, event: ToolEndEvent) -> Result<()> {
+        self.finish_run(
+            event.run_id,
+            Some(serde_json::json!({ "output": event.output_str })),
+            None,
+        );
         Ok(())
     }
 
-    async fn on_tool_error(
-        &self,
-        error: &str,
-        run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
-        self.finish_run(run_id, None, Some(error.to_string()));
+    async fn on_tool_error(&self, event: ToolErrorEvent) -> Result<()> {
+        self.finish_run(event.run_id, None, Some(event.error.clone()));
         Ok(())
     }
 
@@ -538,6 +526,41 @@ impl CallbackHandler for LangSmithTracer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn start_event(
+        serialized: Value,
+        input: &str,
+        run_id: Uuid,
+        parent: Option<Uuid>,
+    ) -> ToolStartEvent {
+        ToolStartEvent {
+            tool: serialized
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            serialized,
+            input_str: input.to_string(),
+            inputs: Value::Null,
+            tool_call_id: None,
+            run_id,
+            parent_run_id: parent,
+            tags: vec![],
+            metadata: HashMap::new(),
+        }
+    }
+
+    fn end_event(out: &str, run_id: Uuid) -> ToolEndEvent {
+        ToolEndEvent {
+            tool: "".into(),
+            output_str: out.into(),
+            output_value: Value::String(out.into()),
+            artifact: None,
+            tool_call_id: None,
+            run_id,
+            parent_run_id: None,
+        }
+    }
 
     fn test_config() -> LangSmithConfig {
         LangSmithConfig::new("test-api-key").with_project_name("test-project")
@@ -634,12 +657,12 @@ mod tests {
         let run_id = Uuid::new_v4();
 
         tracer
-            .on_tool_start(&Value::Null, "search query", run_id, None)
+            .on_tool_start(start_event(Value::Null, "search query", run_id, None))
             .await
             .unwrap();
 
         tracer
-            .on_tool_end("search result", run_id, None)
+            .on_tool_end(end_event("search result", run_id))
             .await
             .unwrap();
 
@@ -661,7 +684,12 @@ mod tests {
             .unwrap();
 
         tracer
-            .on_tool_start(&Value::Null, "child input", child_id, Some(parent_id))
+            .on_tool_start(start_event(
+                Value::Null,
+                "child input",
+                child_id,
+                Some(parent_id),
+            ))
             .await
             .unwrap();
 
@@ -765,7 +793,7 @@ mod tests {
 
         // Pending run (no end)
         tracer
-            .on_tool_start(&Value::Null, "input", pending_id, None)
+            .on_tool_start(start_event(Value::Null, "input", pending_id, None))
             .await
             .unwrap();
 
@@ -792,7 +820,7 @@ mod tests {
             .await
             .unwrap();
         tracer
-            .on_tool_start(&Value::Null, "t", Uuid::new_v4(), None)
+            .on_tool_start(start_event(Value::Null, "t", Uuid::new_v4(), None))
             .await
             .unwrap();
         tracer

--- a/crates/cognis-core/src/tracers/otel.rs
+++ b/crates/cognis-core/src/tracers/otel.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::callbacks::CallbackHandler;
+use crate::callbacks::{CallbackHandler, ToolEndEvent, ToolErrorEvent, ToolStartEvent};
 use crate::documents::Document;
 use crate::error::Result;
 use crate::outputs::LLMResult;
@@ -251,43 +251,35 @@ impl CallbackHandler for OtelTraceCallbackHandler {
         Ok(())
     }
 
-    async fn on_tool_start(
-        &self,
-        serialized: &Value,
-        input_str: &str,
-        run_id: Uuid,
-        parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
-        let tool_name = serialized
+    async fn on_tool_start(&self, event: ToolStartEvent) -> Result<()> {
+        let tool_name = event
+            .serialized
             .get("name")
             .and_then(|v| v.as_str())
             .unwrap_or("unknown");
         let mut attrs = HashMap::new();
         attrs.insert("tool_name".into(), Value::String(tool_name.to_string()));
-        attrs.insert("input".into(), Value::String(input_str.to_string()));
-        self.start_span(run_id, "tool", parent_run_id, attrs);
+        attrs.insert("input".into(), Value::String(event.input_str.clone()));
+        self.start_span(event.run_id, "tool", event.parent_run_id, attrs);
         Ok(())
     }
 
-    async fn on_tool_end(
-        &self,
-        output: &str,
-        run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
+    async fn on_tool_end(&self, event: ToolEndEvent) -> Result<()> {
         let mut attrs = HashMap::new();
-        attrs.insert("output_length".into(), serde_json::json!(output.len()));
-        self.end_span(run_id, SpanStatus::Ok, attrs);
+        attrs.insert(
+            "output_length".into(),
+            serde_json::json!(event.output_str.len()),
+        );
+        self.end_span(event.run_id, SpanStatus::Ok, attrs);
         Ok(())
     }
 
-    async fn on_tool_error(
-        &self,
-        error: &str,
-        run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
-        self.end_span(run_id, SpanStatus::Error(error.to_string()), HashMap::new());
+    async fn on_tool_error(&self, event: ToolErrorEvent) -> Result<()> {
+        self.end_span(
+            event.run_id,
+            SpanStatus::Error(event.error.clone()),
+            HashMap::new(),
+        );
         Ok(())
     }
 
@@ -341,6 +333,36 @@ impl CallbackHandler for OtelTraceCallbackHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn start_event(serialized: Value, input: &str, run_id: Uuid) -> ToolStartEvent {
+        ToolStartEvent {
+            tool: serialized
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            serialized,
+            input_str: input.to_string(),
+            inputs: Value::Null,
+            tool_call_id: None,
+            run_id,
+            parent_run_id: None,
+            tags: vec![],
+            metadata: std::collections::HashMap::new(),
+        }
+    }
+
+    fn end_event(out: &str, run_id: Uuid) -> ToolEndEvent {
+        ToolEndEvent {
+            tool: "".into(),
+            output_str: out.into(),
+            output_value: Value::String(out.into()),
+            artifact: None,
+            tool_call_id: None,
+            run_id,
+            parent_run_id: None,
+        }
+    }
 
     fn make_llm_result(generations_count: usize) -> LLMResult {
         use crate::outputs::Generation;
@@ -419,10 +441,10 @@ mod tests {
         let serialized = serde_json::json!({"name": "calculator"});
 
         handler
-            .on_tool_start(&serialized, "2+2", run_id, None)
+            .on_tool_start(start_event(serialized.clone(), "2+2", run_id))
             .await
             .unwrap();
-        handler.on_tool_end("4", run_id, None).await.unwrap();
+        handler.on_tool_end(end_event("4", run_id)).await.unwrap();
 
         let spans = handler.get_spans();
         assert_eq!(spans.len(), 1);
@@ -492,15 +514,17 @@ mod tests {
         // Tool span
         let tool_id = Uuid::new_v4();
         handler
-            .on_tool_start(
-                &serde_json::json!({"name": "search"}),
+            .on_tool_start(start_event(
+                serde_json::json!({"name": "search"}),
                 "query",
                 tool_id,
-                None,
-            )
+            ))
             .await
             .unwrap();
-        handler.on_tool_end("result", tool_id, None).await.unwrap();
+        handler
+            .on_tool_end(end_event("result", tool_id))
+            .await
+            .unwrap();
 
         // Chain span
         let chain_id = Uuid::new_v4();

--- a/crates/cognis-core/src/tracers/run_collector.rs
+++ b/crates/cognis-core/src/tracers/run_collector.rs
@@ -151,7 +151,7 @@ impl CallbackHandler for RunCollectorCallbackHandler {
     async fn on_tool_end(&self, event: ToolEndEvent) -> Result<()> {
         let mut runs = self.runs.lock().unwrap();
         if let Some(run) = runs.iter_mut().find(|r| r.id == event.run_id) {
-            run.outputs = Some(Value::String(event.output_str.clone()));
+            run.outputs = Some(event.output_value.clone());
         }
         Ok(())
     }

--- a/crates/cognis-core/src/tracers/run_collector.rs
+++ b/crates/cognis-core/src/tracers/run_collector.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::callbacks::CallbackHandler;
+use crate::callbacks::{CallbackHandler, ToolEndEvent, ToolErrorEvent, ToolStartEvent};
 use crate::documents::Document;
 use crate::error::Result;
 use crate::outputs::LLMResult;
@@ -136,46 +136,30 @@ impl CallbackHandler for RunCollectorCallbackHandler {
         Ok(())
     }
 
-    async fn on_tool_start(
-        &self,
-        _serialized: &Value,
-        input_str: &str,
-        run_id: Uuid,
-        parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
+    async fn on_tool_start(&self, event: ToolStartEvent) -> Result<()> {
         let mut run = Run::new(
-            run_id,
+            event.run_id,
             "tool",
             RunType::Tool,
-            Value::String(input_str.to_string()),
+            Value::String(event.input_str.clone()),
         );
-        run.parent_run_id = parent_run_id;
+        run.parent_run_id = event.parent_run_id;
         self.add_run(run);
         Ok(())
     }
 
-    async fn on_tool_end(
-        &self,
-        output: &str,
-        run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
+    async fn on_tool_end(&self, event: ToolEndEvent) -> Result<()> {
         let mut runs = self.runs.lock().unwrap();
-        if let Some(run) = runs.iter_mut().find(|r| r.id == run_id) {
-            run.outputs = Some(Value::String(output.to_string()));
+        if let Some(run) = runs.iter_mut().find(|r| r.id == event.run_id) {
+            run.outputs = Some(Value::String(event.output_str.clone()));
         }
         Ok(())
     }
 
-    async fn on_tool_error(
-        &self,
-        error: &str,
-        run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
+    async fn on_tool_error(&self, event: ToolErrorEvent) -> Result<()> {
         let mut runs = self.runs.lock().unwrap();
-        if let Some(run) = runs.iter_mut().find(|r| r.id == run_id) {
-            run.error = Some(error.to_string());
+        if let Some(run) = runs.iter_mut().find(|r| r.id == event.run_id) {
+            run.error = Some(event.error.clone());
         }
         Ok(())
     }

--- a/crates/cognis-core/src/tracers/stdout.rs
+++ b/crates/cognis-core/src/tracers/stdout.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::callbacks::CallbackHandler;
+use crate::callbacks::{CallbackHandler, ToolEndEvent, ToolErrorEvent, ToolStartEvent};
 use crate::documents::Document;
 use crate::error::Result;
 use crate::messages::Message;
@@ -159,43 +159,27 @@ impl CallbackHandler for ConsoleCallbackHandler {
         Ok(())
     }
 
-    async fn on_tool_start(
-        &self,
-        _serialized: &Value,
-        input_str: &str,
-        run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
-        self.print_header(COLOR_YELLOW, "tool/start", run_id);
+    async fn on_tool_start(&self, event: ToolStartEvent) -> Result<()> {
+        self.print_header(COLOR_YELLOW, "tool/start", event.run_id);
         let indent = self.indent();
-        println!("{}  input: {}", indent, input_str);
+        println!("{}  input: {}", indent, event.input_str);
         self.depth.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
 
-    async fn on_tool_end(
-        &self,
-        output: &str,
-        run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
+    async fn on_tool_end(&self, event: ToolEndEvent) -> Result<()> {
         self.depth.fetch_sub(1, Ordering::Relaxed);
-        self.print_header(COLOR_YELLOW, "tool/end", run_id);
+        self.print_header(COLOR_YELLOW, "tool/end", event.run_id);
         let indent = self.indent();
-        println!("{}  output: {}", indent, output);
+        println!("{}  output: {}", indent, event.output_str);
         Ok(())
     }
 
-    async fn on_tool_error(
-        &self,
-        error: &str,
-        run_id: Uuid,
-        _parent_run_id: Option<Uuid>,
-    ) -> Result<()> {
+    async fn on_tool_error(&self, event: ToolErrorEvent) -> Result<()> {
         self.depth.fetch_sub(1, Ordering::Relaxed);
-        self.print_header(COLOR_RED, "tool/error", run_id);
+        self.print_header(COLOR_RED, "tool/error", event.run_id);
         let indent = self.indent();
-        println!("{}  error: {}", indent, error);
+        println!("{}  error: {}", indent, event.error);
         Ok(())
     }
 

--- a/crates/cognis-core/tests/callbacks_expanded_tests.rs
+++ b/crates/cognis-core/tests/callbacks_expanded_tests.rs
@@ -202,8 +202,18 @@ async fn test_run_manager_for_tool() {
     let run_mgr = RunManagerForTool::new(run_id, vec![h.clone()], vec![h], None);
     assert_eq!(run_mgr.run_id(), run_id);
 
-    run_mgr.on_tool_end("output").await.unwrap();
-    run_mgr.on_tool_error("error").await.unwrap();
+    run_mgr
+        .on_tool_end(
+            "output".into(),
+            serde_json::Value::String("output".into()),
+            None,
+        )
+        .await
+        .unwrap();
+    run_mgr
+        .on_tool_error("error".into(), ToolErrorKind::Execution)
+        .await
+        .unwrap();
     run_mgr.on_text("text").await.unwrap();
 
     let child = run_mgr.get_child();

--- a/crates/cognis-core/tests/messages_tests.rs
+++ b/crates/cognis-core/tests/messages_tests.rs
@@ -118,7 +118,7 @@ fn tool_message_error() {
 
 #[test]
 fn tool_message_artifact() {
-    let msg = ToolMessage::new("ok", "call_3").with_artifact(json!({"data": [1, 2, 3]}));
+    let msg = ToolMessage::with_artifact("ok", "call_3", json!({"data": [1, 2, 3]}));
     assert!(msg.artifact.is_some());
 }
 

--- a/crates/cognis/src/agents/executor.rs
+++ b/crates/cognis/src/agents/executor.rs
@@ -25,6 +25,7 @@ use serde_json::Value;
 
 use cognis_core::callbacks::base::CallbackHandler;
 use cognis_core::callbacks::manager::CallbackManager;
+use cognis_core::callbacks::{ToolEndEvent, ToolErrorEvent, ToolErrorKind, ToolStartEvent};
 use cognis_core::error::{CognisError, Result};
 use cognis_core::language_models::chat_model::BaseChatModel;
 use cognis_core::messages::{Message, ToolMessage};
@@ -402,33 +403,74 @@ impl AgentExecutor {
 
                 let tool_run_id = Uuid::new_v4();
                 let serialized_tool = serde_json::json!({"name": &tool_call.name});
-                let tool_input_str = serde_json::to_string(&tool_call.args).unwrap_or_default();
+                let args_value = serde_json::to_value(&tool_call.args).unwrap_or_default();
+                let tool_input_str = serde_json::to_string(&args_value).unwrap_or_default();
+                let tool_call_id_opt = tool_call.id.clone();
+
                 let _ = cb
-                    .on_tool_start(&serialized_tool, &tool_input_str, tool_run_id)
+                    .on_tool_start(ToolStartEvent {
+                        tool: tool_call.name.clone(),
+                        serialized: serialized_tool.clone(),
+                        input_str: tool_input_str.clone(),
+                        inputs: args_value.clone(),
+                        tool_call_id: tool_call_id_opt.clone(),
+                        run_id: tool_run_id,
+                        parent_run_id: Some(chain_run_id),
+                        tags: vec![],
+                        metadata: Default::default(),
+                    })
                     .await;
 
                 let result_text = match self.tools.get(&tool_call.name) {
                     Some(tool) => {
-                        let args_value = serde_json::to_value(&tool_call.args).unwrap_or_default();
                         match tool.run_json(&args_value).await {
                             Ok(value) => {
                                 let text = match value {
                                     serde_json::Value::String(s) => s,
                                     other => other.to_string(),
                                 };
-                                let _ = cb.on_tool_end(&text, tool_run_id).await;
+                                let _ = cb
+                                    .on_tool_end(ToolEndEvent {
+                                        tool: tool_call.name.clone(),
+                                        output_str: text.clone(),
+                                        // TEMPORARY: Task 6 will replace this with the real Value.
+                                        output_value: serde_json::Value::String(text.clone()),
+                                        artifact: None,
+                                        tool_call_id: tool_call_id_opt.clone(),
+                                        run_id: tool_run_id,
+                                        parent_run_id: Some(chain_run_id),
+                                    })
+                                    .await;
                                 text
                             }
                             Err(e) => {
                                 let err_text = format!("Error: {e}");
-                                let _ = cb.on_tool_error(&err_text, tool_run_id).await;
+                                let _ = cb
+                                    .on_tool_error(ToolErrorEvent {
+                                        tool: tool_call.name.clone(),
+                                        error: err_text.clone(),
+                                        error_kind: ToolErrorKind::Execution,
+                                        tool_call_id: tool_call_id_opt.clone(),
+                                        run_id: tool_run_id,
+                                        parent_run_id: Some(chain_run_id),
+                                    })
+                                    .await;
                                 err_text
                             }
                         }
                     }
                     None => {
                         let err_text = format!("Error: tool '{}' not found", tool_call.name);
-                        let _ = cb.on_tool_error(&err_text, tool_run_id).await;
+                        let _ = cb
+                            .on_tool_error(ToolErrorEvent {
+                                tool: tool_call.name.clone(),
+                                error: err_text.clone(),
+                                error_kind: ToolErrorKind::NotFound,
+                                tool_call_id: tool_call_id_opt.clone(),
+                                run_id: tool_run_id,
+                                parent_run_id: Some(chain_run_id),
+                            })
+                            .await;
                         err_text
                     }
                 };
@@ -1307,33 +1349,17 @@ mod tests {
             Ok(())
         }
 
-        async fn on_tool_start(
-            &self,
-            _serialized: &Value,
-            _input_str: &str,
-            _run_id: Uuid,
-            _parent_run_id: Option<Uuid>,
-        ) -> cognis_core::error::Result<()> {
+        async fn on_tool_start(&self, _event: ToolStartEvent) -> cognis_core::error::Result<()> {
             self.events.lock().unwrap().push("tool_start".to_string());
             Ok(())
         }
 
-        async fn on_tool_end(
-            &self,
-            _output: &str,
-            _run_id: Uuid,
-            _parent_run_id: Option<Uuid>,
-        ) -> cognis_core::error::Result<()> {
+        async fn on_tool_end(&self, _event: ToolEndEvent) -> cognis_core::error::Result<()> {
             self.events.lock().unwrap().push("tool_end".to_string());
             Ok(())
         }
 
-        async fn on_tool_error(
-            &self,
-            _error: &str,
-            _run_id: Uuid,
-            _parent_run_id: Option<Uuid>,
-        ) -> cognis_core::error::Result<()> {
+        async fn on_tool_error(&self, _event: ToolErrorEvent) -> cognis_core::error::Result<()> {
             self.events.lock().unwrap().push("tool_error".to_string());
             Ok(())
         }

--- a/crates/cognis/src/agents/executor.rs
+++ b/crates/cognis/src/agents/executor.rs
@@ -31,7 +31,8 @@ use cognis_core::language_models::chat_model::BaseChatModel;
 use cognis_core::messages::{Message, ToolMessage};
 use cognis_core::runnables::base::Runnable;
 use cognis_core::runnables::config::RunnableConfig;
-use cognis_core::tools::base::BaseTool;
+use cognis_core::tools::base::{apply_error_handler, BaseTool};
+use cognis_core::tools::types::{ToolInput, ToolOutput};
 use uuid::Uuid;
 
 #[allow(deprecated)]
@@ -399,18 +400,15 @@ impl AgentExecutor {
 
             // Execute each tool call
             for tool_call in &ai_msg.tool_calls {
-                let tool_call_id = tool_call.id.clone().unwrap_or_default();
-
+                let tool_call_id_opt = tool_call.id.clone();
                 let tool_run_id = Uuid::new_v4();
-                let serialized_tool = serde_json::json!({"name": &tool_call.name});
                 let args_value = serde_json::to_value(&tool_call.args).unwrap_or_default();
                 let tool_input_str = serde_json::to_string(&args_value).unwrap_or_default();
-                let tool_call_id_opt = tool_call.id.clone();
 
                 let _ = cb
                     .on_tool_start(ToolStartEvent {
                         tool: tool_call.name.clone(),
-                        serialized: serialized_tool.clone(),
+                        serialized: serde_json::json!({ "name": &tool_call.name }),
                         input_str: tool_input_str.clone(),
                         inputs: args_value.clone(),
                         tool_call_id: tool_call_id_opt.clone(),
@@ -421,41 +419,64 @@ impl AgentExecutor {
                     })
                     .await;
 
-                let result_text = match self.tools.get(&tool_call.name) {
+                let (result_text, result_artifact) = match self.tools.get(&tool_call.name) {
                     Some(tool) => {
-                        match tool.run_json(&args_value).await {
-                            Ok(value) => {
-                                let text = match value {
-                                    serde_json::Value::String(s) => s,
-                                    other => other.to_string(),
+                        let input = value_to_tool_input(&args_value);
+                        match tool._run(input).await {
+                            Ok(output) => {
+                                let (content, artifact) = match output {
+                                    ToolOutput::Content(v) => (v, None),
+                                    ToolOutput::ContentAndArtifact { content, artifact } => {
+                                        (content, Some(artifact))
+                                    }
                                 };
+                                let text = value_to_observation_str(&content);
                                 let _ = cb
                                     .on_tool_end(ToolEndEvent {
                                         tool: tool_call.name.clone(),
                                         output_str: text.clone(),
-                                        // TEMPORARY: Task 6 will replace this with the real Value.
-                                        output_value: serde_json::Value::String(text.clone()),
-                                        artifact: None,
+                                        output_value: content,
+                                        artifact: artifact.clone(),
                                         tool_call_id: tool_call_id_opt.clone(),
                                         run_id: tool_run_id,
                                         parent_run_id: Some(chain_run_id),
                                     })
                                     .await;
-                                text
+                                (text, artifact)
                             }
                             Err(e) => {
-                                let err_text = format!("Error: {e}");
+                                let kind = match &e {
+                                    CognisError::ToolException(_)
+                                    | CognisError::ToolValidationError(_) => {
+                                        ToolErrorKind::Execution
+                                    }
+                                    _ => ToolErrorKind::Other,
+                                };
+                                // Apply the tool's configured error-handler policy.
+                                let handler_policy = match &e {
+                                    CognisError::ToolValidationError(_) => {
+                                        tool.handle_validation_error().clone()
+                                    }
+                                    _ => tool.handle_tool_error().clone(),
+                                };
+                                let err_fallback = format!("Error: {e}");
+                                let observation = apply_error_handler(&handler_policy, e)
+                                    .unwrap_or_else(|_| Value::String(err_fallback.clone()));
+                                let err_text = match &observation {
+                                    Value::String(s) => s.clone(),
+                                    other => other.to_string(),
+                                };
                                 let _ = cb
                                     .on_tool_error(ToolErrorEvent {
                                         tool: tool_call.name.clone(),
                                         error: err_text.clone(),
-                                        error_kind: ToolErrorKind::Execution,
+                                        error_kind: kind,
                                         tool_call_id: tool_call_id_opt.clone(),
                                         run_id: tool_run_id,
                                         parent_run_id: Some(chain_run_id),
                                     })
                                     .await;
-                                err_text
+                                (err_text, None)
                             }
                         }
                     }
@@ -471,7 +492,7 @@ impl AgentExecutor {
                                 parent_run_id: Some(chain_run_id),
                             })
                             .await;
-                        err_text
+                        (err_text, None)
                     }
                 };
 
@@ -479,7 +500,7 @@ impl AgentExecutor {
                 intermediate_steps.push(AgentStep {
                     action: AgentAction::new(
                         tool_call.name.clone(),
-                        serde_json::to_value(&tool_call.args).unwrap_or_default(),
+                        args_value.clone(),
                         format!(
                             "Calling tool `{}` with args: {}",
                             tool_call.name, tool_input_str
@@ -488,7 +509,14 @@ impl AgentExecutor {
                     observation: result_text.clone(),
                 });
 
-                messages.push(Message::Tool(ToolMessage::new(&result_text, &tool_call_id)));
+                let tool_call_id = tool_call_id_opt.unwrap_or_default();
+                let tm = match result_artifact {
+                    Some(artifact) => {
+                        ToolMessage::with_artifact(&result_text, &tool_call_id, artifact)
+                    }
+                    None => ToolMessage::new(&result_text, &tool_call_id),
+                };
+                messages.push(Message::Tool(tm));
             }
         }
 
@@ -1062,6 +1090,30 @@ impl PlannerAgentExecutor {
                 }
             }
         }
+    }
+}
+
+/// Render a tool-output `Value` as the observation string that will be fed
+/// back to the LLM. Strings are passed through verbatim; structured values are
+/// serialized to their JSON representation.
+fn value_to_observation_str(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+/// Convert a tool-call `args` JSON blob into the [`ToolInput`] variant the
+/// tool expects. Object -> `Structured`, String -> `Text`, other -> stringified
+/// `Text`.
+fn value_to_tool_input(v: &Value) -> ToolInput {
+    match v {
+        Value::Object(m) => {
+            let map = m.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+            ToolInput::Structured(map)
+        }
+        Value::String(s) => ToolInput::Text(s.clone()),
+        other => ToolInput::Text(other.to_string()),
     }
 }
 
@@ -2673,5 +2725,188 @@ mod tests {
         let json = finish.to_json();
         assert_eq!(json["return_values"]["confidence"], 0.95);
         assert_eq!(json["return_values"]["sources"][0], "doc1");
+    }
+}
+
+#[cfg(test)]
+mod tool_value_tests {
+    use super::*;
+    use async_trait::async_trait;
+    use cognis_core::callbacks::base::CallbackHandler;
+    use cognis_core::callbacks::ToolEndEvent;
+    use cognis_core::messages::tool_types::ToolCall;
+    use cognis_core::messages::{AIMessage, Message};
+    use cognis_core::outputs::{ChatGeneration, ChatResult};
+    use cognis_core::tools::types::{ToolInput, ToolOutput};
+    use serde_json::{json, Value};
+    use std::sync::Mutex;
+
+    /// Fake tool that returns a structured JSON object as the content value.
+    struct StructuredTool;
+
+    #[async_trait]
+    impl BaseTool for StructuredTool {
+        fn name(&self) -> &str {
+            "structured"
+        }
+
+        fn description(&self) -> &str {
+            "returns a structured value"
+        }
+
+        async fn _run(&self, _input: ToolInput) -> Result<ToolOutput> {
+            Ok(ToolOutput::Content(json!({"k": 1, "v": [2, 3]})))
+        }
+    }
+
+    /// Fake tool that returns both content and a structured artifact.
+    struct ArtifactTool;
+
+    #[async_trait]
+    impl BaseTool for ArtifactTool {
+        fn name(&self) -> &str {
+            "artifact_tool"
+        }
+
+        fn description(&self) -> &str {
+            "returns content + artifact"
+        }
+
+        async fn _run(&self, _input: ToolInput) -> Result<ToolOutput> {
+            Ok(ToolOutput::ContentAndArtifact {
+                content: Value::String("display text".into()),
+                artifact: json!({"chart": [1.0, 2.0]}),
+            })
+        }
+    }
+
+    /// A mock model that calls a given tool once, then answers with "done".
+    struct CallThenAnswerModel {
+        tool_name: String,
+        call_count: Mutex<u32>,
+    }
+
+    impl CallThenAnswerModel {
+        fn new(tool_name: impl Into<String>) -> Self {
+            Self {
+                tool_name: tool_name.into(),
+                call_count: Mutex::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl BaseChatModel for CallThenAnswerModel {
+        async fn _generate(
+            &self,
+            _messages: &[Message],
+            _stop: Option<&[String]>,
+        ) -> Result<ChatResult> {
+            let mut count = self.call_count.lock().unwrap();
+            *count += 1;
+            if *count == 1 {
+                let mut ai = AIMessage::new("calling tool");
+                ai.tool_calls.push(ToolCall {
+                    name: self.tool_name.clone(),
+                    args: HashMap::new(),
+                    id: Some("call_1".to_string()),
+                });
+                Ok(ChatResult {
+                    generations: vec![ChatGeneration::new(ai)],
+                    llm_output: None,
+                })
+            } else {
+                let ai = AIMessage::new("done");
+                Ok(ChatResult {
+                    generations: vec![ChatGeneration::new(ai)],
+                    llm_output: None,
+                })
+            }
+        }
+
+        fn llm_type(&self) -> &str {
+            "mock-call-then-answer"
+        }
+    }
+
+    /// Callback handler that records every `on_tool_end` event.
+    struct RecordingEnd(Arc<Mutex<Vec<ToolEndEvent>>>);
+
+    #[async_trait]
+    impl CallbackHandler for RecordingEnd {
+        async fn on_tool_end(&self, event: ToolEndEvent) -> cognis_core::error::Result<()> {
+            self.0.lock().unwrap().push(event);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_end_event_carries_typed_value() {
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let handler: Arc<dyn CallbackHandler> = Arc::new(RecordingEnd(recorded.clone()));
+
+        let model: Arc<dyn BaseChatModel> = Arc::new(CallThenAnswerModel::new("structured"));
+        let tool: Arc<dyn BaseTool> = Arc::new(StructuredTool);
+        let executor = AgentExecutor::builder()
+            .model(model)
+            .tool(tool)
+            .callback(handler)
+            .build();
+
+        let result = executor
+            .run(&[Message::human("go")])
+            .await
+            .expect("should succeed");
+        assert_eq!(result.output, "done");
+
+        let events = recorded.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].output_value, json!({"k": 1, "v": [2, 3]}));
+        assert_eq!(
+            events[0].output_str,
+            json!({"k": 1, "v": [2, 3]}).to_string()
+        );
+        assert_eq!(events[0].artifact, None);
+    }
+
+    #[tokio::test]
+    async fn tool_end_event_carries_artifact_and_tool_message_stores_it() {
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let handler: Arc<dyn CallbackHandler> = Arc::new(RecordingEnd(recorded.clone()));
+
+        let model: Arc<dyn BaseChatModel> = Arc::new(CallThenAnswerModel::new("artifact_tool"));
+        let tool: Arc<dyn BaseTool> = Arc::new(ArtifactTool);
+        let executor = AgentExecutor::builder()
+            .model(model)
+            .tool(tool)
+            .callback(handler)
+            .build();
+
+        let result = executor
+            .run(&[Message::human("go")])
+            .await
+            .expect("should succeed");
+        assert_eq!(result.output, "done");
+
+        // ToolEndEvent carries artifact + raw typed Value.
+        let events = recorded.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].artifact, Some(json!({"chart": [1.0, 2.0]})));
+        assert_eq!(events[0].output_str, "display text");
+        assert_eq!(events[0].output_value, Value::String("display text".into()));
+
+        // The appended ToolMessage has the artifact populated and the right
+        // tool_call_id.
+        let tool_msg = result
+            .messages
+            .iter()
+            .find_map(|m| match m {
+                Message::Tool(tm) => Some(tm.clone()),
+                _ => None,
+            })
+            .expect("a ToolMessage should have been appended");
+        assert_eq!(tool_msg.tool_call_id, "call_1");
+        assert_eq!(tool_msg.base.content.text(), "display text");
+        assert_eq!(tool_msg.artifact, Some(json!({"chart": [1.0, 2.0]})));
     }
 }

--- a/crates/cognis/src/agents/middleware/context_editing.rs
+++ b/crates/cognis/src/agents/middleware/context_editing.rs
@@ -106,14 +106,13 @@ impl ClearToolUsesEdit {
                 MessageType::Tool => {
                     indices.push(i);
                 }
-                MessageType::Ai => {
+                MessageType::Ai
                     // Check if the AI message appears to have tool calls
                     // by looking at subsequent Tool messages
                     if i + 1 < messages.len() && messages[i + 1].message_type() == MessageType::Tool
-                    {
+                    => {
                         indices.push(i);
                     }
-                }
                 _ => {}
             }
         }

--- a/crates/cognis/src/agents/middleware/redaction.rs
+++ b/crates/cognis/src/agents/middleware/redaction.rs
@@ -534,7 +534,7 @@ pub fn apply_matches(
         return Ok(text.to_string());
     }
     // Sort by start position descending so replacements don't invalidate offsets.
-    matches.sort_by(|a, b| b.start.cmp(&a.start));
+    matches.sort_by_key(|b| std::cmp::Reverse(b.start));
     let mut result = text.to_string();
     for m in &matches {
         result = apply_strategy(&result, m, strategy)?;
@@ -550,7 +550,7 @@ pub fn apply_rules(
     mut rules: Vec<ResolvedRedactionRule>,
 ) -> std::result::Result<String, PIIDetectionError> {
     // Sort by start position descending so replacements don't invalidate offsets.
-    rules.sort_by(|a, b| b.pii_match.start.cmp(&a.pii_match.start));
+    rules.sort_by_key(|b| std::cmp::Reverse(b.pii_match.start));
     let mut result = text.to_string();
     for rule in &rules {
         result = apply_strategy(&result, &rule.pii_match, &rule.strategy)?;

--- a/crates/cognis/src/memory/conversation.rs
+++ b/crates/cognis/src/memory/conversation.rs
@@ -524,11 +524,9 @@ impl MemoryStats {
 
     /// Average content length (in characters) per message, or 0 if empty.
     pub fn average_message_length(&self) -> usize {
-        if self.total_messages == 0 {
-            0
-        } else {
-            self.total_content_length / self.total_messages
-        }
+        self.total_content_length
+            .checked_div(self.total_messages)
+            .unwrap_or(0)
     }
 
     /// Serialize statistics to JSON.

--- a/crates/cognis/src/prompts/management.rs
+++ b/crates/cognis/src/prompts/management.rs
@@ -393,7 +393,7 @@ impl FewShotSelector {
             .collect();
 
         // Sort descending by score, then take top-k.
-        scored.sort_by(|a, b| b.0.cmp(&a.0));
+        scored.sort_by_key(|b| std::cmp::Reverse(b.0));
         scored.into_iter().take(k).map(|(_, ex)| ex).collect()
     }
 

--- a/crates/cognis/src/retrievers/multi_vector.rs
+++ b/crates/cognis/src/retrievers/multi_vector.rs
@@ -93,7 +93,7 @@ impl MultiVectorRetriever {
             "docs and summaries must have the same length"
         );
 
-        for (doc, mut summary) in docs.into_iter().zip(summaries.into_iter()) {
+        for (doc, mut summary) in docs.into_iter().zip(summaries) {
             let doc_id = Uuid::new_v4().to_string();
 
             // Store the full original document.

--- a/crates/cognis/src/text_splitter/token_aware.rs
+++ b/crates/cognis/src/text_splitter/token_aware.rs
@@ -65,11 +65,9 @@ impl TokenAwareTextSplitter {
     /// recognized.
     pub fn from_model_context(model_name: &str, chunks_per_context: usize) -> Self {
         let context_window = get_model_context_window(model_name).unwrap_or(2000);
-        let max_tokens = if chunks_per_context > 0 {
-            context_window / chunks_per_context
-        } else {
-            context_window
-        };
+        let max_tokens = context_window
+            .checked_div(chunks_per_context)
+            .unwrap_or(context_window);
         Self {
             max_tokens,
             overlap_tokens: 50,

--- a/crates/cognis/tests/tool_output_value_stream.rs
+++ b/crates/cognis/tests/tool_output_value_stream.rs
@@ -1,0 +1,89 @@
+//! Integration: AgentExecutor::astream_events emits typed tool output.
+//!
+//! End-to-end verification that a tool returning `ToolOutput::Content(json!(...))`
+//! has its structured value preserved all the way through the stream:
+//!
+//! 1. Executor runs the tool and fires `on_tool_end` with `output_value`
+//!    set to the raw `serde_json::Value`.
+//! 2. `EventStreamCallbackHandler::on_tool_end` forwards that value into
+//!    `EventData.output` verbatim (no stringification, no re-wrapping).
+//! 3. `AgentExecutor::astream_events` yields the corresponding
+//!    `StreamEvent` with `EventType::OnToolEnd` and the structured payload
+//!    intact in `ev.data.output`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde_json::json;
+
+use cognis::agents::AgentExecutor;
+use cognis_core::language_models::fake::FakeMessagesListChatModel;
+use cognis_core::messages::tool_types::ToolCall;
+use cognis_core::messages::{AIMessage, HumanMessage, Message};
+use cognis_core::tools::{BaseTool, ToolInput, ToolOutput};
+use cognis_core::tracers::EventType;
+
+/// Tool that returns a structured JSON object as its content.
+struct JsonTool;
+
+#[async_trait]
+impl BaseTool for JsonTool {
+    fn name(&self) -> &str {
+        "json_tool"
+    }
+
+    fn description(&self) -> &str {
+        "returns structured JSON"
+    }
+
+    async fn _run(&self, _input: ToolInput) -> cognis_core::error::Result<ToolOutput> {
+        Ok(ToolOutput::Content(
+            json!({"answer": 42, "confidence": 0.9}),
+        ))
+    }
+}
+
+#[tokio::test]
+async fn astream_events_preserves_tool_output_shape() {
+    // Model script: first turn requests a call to `json_tool`; second turn
+    // finalizes with a plain AI response.
+    let tool_call = ToolCall {
+        name: "json_tool".to_string(),
+        args: HashMap::new(),
+        id: Some("call_1".to_string()),
+    };
+    let first = Message::Ai(AIMessage::new("calling tool").with_tool_calls(vec![tool_call]));
+    let second = Message::Ai(AIMessage::new("done"));
+
+    let model = Arc::new(FakeMessagesListChatModel::new(vec![first, second]));
+    let tool: Arc<dyn BaseTool> = Arc::new(JsonTool);
+
+    let executor = AgentExecutor::builder()
+        .model(model)
+        .tool(tool)
+        .max_iterations(3)
+        .build();
+
+    let messages = vec![Message::Human(HumanMessage::new("go"))];
+    let mut stream = executor.astream_events(messages).await.unwrap();
+
+    let mut saw_typed_output = false;
+    while let Some(ev) = stream.next().await {
+        let ev = ev.unwrap();
+        if ev.event == EventType::OnToolEnd {
+            let out = ev.data.output.expect("output should be set on OnToolEnd");
+            assert_eq!(
+                out,
+                json!({"answer": 42, "confidence": 0.9}),
+                "OnToolEnd.data.output must be the raw structured value (no stringification)"
+            );
+            saw_typed_output = true;
+        }
+    }
+    assert!(
+        saw_typed_output,
+        "expected at least one OnToolEnd event carrying the typed tool output"
+    );
+}

--- a/crates/cognisagent/src/memory.rs
+++ b/crates/cognisagent/src/memory.rs
@@ -448,7 +448,7 @@ impl MemoryIndex {
         }
 
         let mut ranked: Vec<(String, usize)> = scores.into_iter().collect();
-        ranked.sort_by(|a, b| b.1.cmp(&a.1));
+        ranked.sort_by_key(|b| std::cmp::Reverse(b.1));
         ranked.into_iter().map(|(k, _)| k).collect()
     }
 

--- a/crates/cognisagent/src/middleware/context.rs
+++ b/crates/cognisagent/src/middleware/context.rs
@@ -409,7 +409,7 @@ impl ContextManager {
             }
         }
         // Sort by priority descending.
-        entries.sort_by(|a, b| b.priority.cmp(&a.priority));
+        entries.sort_by_key(|b| std::cmp::Reverse(b.priority));
         entries
     }
 
@@ -461,7 +461,7 @@ impl ContextManager {
             }
             PriorityMode::DropOldest => {
                 // Sort by creation time descending (newest first).
-                entries.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+                entries.sort_by_key(|b| std::cmp::Reverse(b.created_at));
                 let mut total = 0usize;
                 let mut kept = Vec::new();
                 for entry in entries {

--- a/crates/cognisgraph/src/checkpoint/memory.rs
+++ b/crates/cognisgraph/src/checkpoint/memory.rs
@@ -239,7 +239,7 @@ impl MemoryCheckpointSaver {
             .filter(|((tid, _), _)| tid == thread_id)
             .collect();
 
-        entries.sort_by(|a, b| b.1.seq.cmp(&a.1.seq));
+        entries.sort_by_key(|b| std::cmp::Reverse(b.1.seq));
 
         Ok(entries
             .into_iter()
@@ -452,7 +452,7 @@ impl CheckpointSaver for MemoryCheckpointSaver {
             .collect();
 
         // Sort newest first by sequence number.
-        entries.sort_by(|a, b| b.1.seq.cmp(&a.1.seq));
+        entries.sort_by_key(|b| std::cmp::Reverse(b.1.seq));
 
         let mut results: Vec<CheckpointTuple> = entries
             .into_iter()

--- a/crates/cognisgraph/src/graph/audit.rs
+++ b/crates/cognisgraph/src/graph/audit.rs
@@ -382,7 +382,7 @@ impl AuditReport {
         if !self.event_counts.is_empty() {
             out.push_str("Event counts:\n");
             let mut counts: Vec<_> = self.event_counts.iter().collect();
-            counts.sort_by(|(a, _), (b, _)| a.cmp(b));
+            counts.sort_by_key(|(a, _)| *a);
             for (label, count) in counts {
                 out.push_str(&format!("  {label}: {count}\n"));
             }
@@ -391,7 +391,7 @@ impl AuditReport {
         if !self.node_activity.is_empty() {
             out.push_str("Node activity:\n");
             let mut activity: Vec<_> = self.node_activity.iter().collect();
-            activity.sort_by(|(a, _), (b, _)| a.cmp(b));
+            activity.sort_by_key(|(a, _)| *a);
             for (node, count) in activity {
                 out.push_str(&format!("  {node}: {count}\n"));
             }

--- a/crates/cognisgraph/src/graph/compiled.rs
+++ b/crates/cognisgraph/src/graph/compiled.rs
@@ -419,10 +419,12 @@ impl CompiledGraph {
 
         for edge in &self.edges {
             match edge {
-                CompiledEdge::Direct { from, to } if from == node => {
-                    if self.nodes.contains_key(to) && self.dfs_cycle(to, visited, stack) {
-                        return true;
-                    }
+                CompiledEdge::Direct { from, to }
+                    if from == node
+                        && self.nodes.contains_key(to)
+                        && self.dfs_cycle(to, visited, stack) =>
+                {
+                    return true;
                 }
                 CompiledEdge::Conditional { from, targets, .. } if from == node => {
                     for target in targets {
@@ -452,10 +454,10 @@ impl CompiledGraph {
             }
             for edge in &self.edges {
                 match edge {
-                    CompiledEdge::Direct { from, to } if from == &current => {
-                        if !reachable.contains(to) {
-                            queue.push_back(to.clone());
-                        }
+                    CompiledEdge::Direct { from, to }
+                        if from == &current && !reachable.contains(to) =>
+                    {
+                        queue.push_back(to.clone());
                     }
                     CompiledEdge::Conditional { from, targets, .. } if from == &current => {
                         for target in targets {

--- a/crates/cognisgraph/src/graph/metrics.rs
+++ b/crates/cognisgraph/src/graph/metrics.rs
@@ -304,14 +304,14 @@ impl GraphMetrics {
     /// Nodes sorted by total duration descending.
     pub fn nodes_by_duration(&self) -> Vec<&NodeMetrics> {
         let mut v: Vec<_> = self.node_metrics.values().collect();
-        v.sort_by(|a, b| b.total_duration.cmp(&a.total_duration));
+        v.sort_by_key(|b| std::cmp::Reverse(b.total_duration));
         v
     }
 
     /// Edges sorted by traversal count descending.
     pub fn edges_by_traversal(&self) -> Vec<&EdgeMetrics> {
         let mut v: Vec<_> = self.edge_metrics.values().collect();
-        v.sort_by(|a, b| b.traversal_count.cmp(&a.traversal_count));
+        v.sort_by_key(|b| std::cmp::Reverse(b.traversal_count));
         v
     }
 }
@@ -487,7 +487,7 @@ impl MetricsAggregator {
     /// Top N nodes by total duration.
     pub fn top_nodes_by_duration(&self, n: usize) -> Vec<&NodeMetrics> {
         let mut v: Vec<_> = self.node_metrics.values().collect();
-        v.sort_by(|a, b| b.total_duration.cmp(&a.total_duration));
+        v.sort_by_key(|b| std::cmp::Reverse(b.total_duration));
         v.truncate(n);
         v
     }
@@ -495,7 +495,7 @@ impl MetricsAggregator {
     /// Top N edges by traversal count.
     pub fn top_edges_by_traversal(&self, n: usize) -> Vec<&EdgeMetrics> {
         let mut v: Vec<_> = self.edge_metrics.values().collect();
-        v.sort_by(|a, b| b.traversal_count.cmp(&a.traversal_count));
+        v.sort_by_key(|b| std::cmp::Reverse(b.traversal_count));
         v.truncate(n);
         v
     }
@@ -559,7 +559,7 @@ impl MetricsReport {
 
         let node_summaries: Vec<NodeSummary> = {
             let mut nodes: Vec<_> = agg.node_metrics.values().collect();
-            nodes.sort_by(|a, b| b.total_duration.cmp(&a.total_duration));
+            nodes.sort_by_key(|b| std::cmp::Reverse(b.total_duration));
             nodes
                 .iter()
                 .map(|nm| NodeSummary {

--- a/crates/cognisgraph/src/graph/streaming.rs
+++ b/crates/cognisgraph/src/graph/streaming.rs
@@ -467,10 +467,8 @@ impl StreamAggregator {
             ChunkType::StateUpdate => {
                 self.state = Some(chunk.data.clone());
             }
-            ChunkType::NodeStart => {
-                if !self.order.contains(&chunk.node_id) {
-                    self.order.push(chunk.node_id.clone());
-                }
+            ChunkType::NodeStart if !self.order.contains(&chunk.node_id) => {
+                self.order.push(chunk.node_id.clone());
             }
             _ => {}
         }

--- a/crates/cognisgraph/src/utils/profiler.rs
+++ b/crates/cognisgraph/src/utils/profiler.rs
@@ -530,7 +530,7 @@ pub fn format_report(report: &ProfileReport) -> String {
 
     // Collect and sort nodes by total duration descending.
     let mut nodes: Vec<&NodeProfile> = report.node_profiles.values().collect();
-    nodes.sort_by(|a, b| b.total_duration.cmp(&a.total_duration));
+    nodes.sort_by_key(|b| std::cmp::Reverse(b.total_duration));
 
     // Determine column widths.
     let node_width = nodes.iter().map(|n| n.name.len()).max().unwrap_or(4).max(4);


### PR DESCRIPTION
## Summary

Closes #6.

`AgentExecutor` previously stringified tool outputs before emitting `on_tool_end`, forcing UI consumers that need typed cards (charts, structured summaries, diffs) to re-parse JSON on the client. This PR threads the original `Value` end-to-end and populates `ToolMessage.artifact` when a tool returns `ToolOutput::ContentAndArtifact`.

**Key changes:**
- `CallbackHandler::on_tool_{start,end,error}` now take dedicated struct events (`ToolStartEvent`, `ToolEndEvent`, `ToolErrorEvent`) instead of positional arguments.
- `ToolEndEvent` carries both `output_str` (what the LLM scratchpad sees) and `output_value: Value` (original shape for UI consumers), plus `artifact: Option<Value>`.
- `AgentExecutor` now calls `BaseTool::_run` directly, preserving `ToolOutput::ContentAndArtifact`. Error-handler policies (`DefaultMessage`/`StaticMessage`/`Dynamic`) apply via a new `apply_error_handler` helper.
- `EventStreamCallbackHandler` forwards the typed `output_value` into `EventData.output` instead of re-wrapping it as `Value::String`; `EventData` gained an `artifact: Option<Value>` field.
- `ToolMessage::with_artifact(content, tool_call_id, artifact)` populates the existing `artifact` field in one call.

## Breaking changes

Pre-1.0, accepted cost:
- `CallbackHandler::on_tool_{start,end,error}` take event structs. Downstream implementors must update three method signatures.
- `CallbackManager::on_tool_*` and `RunManagerForTool::on_tool_{end,error}` callers pass events (or the decomposed `(output_str, output_value, artifact)` triple for the latter).
- `ToolMessage::with_artifact` went from a builder `(self, Value) -> Self` to an associated fn `(content, id, artifact) -> Self`. Replaces `ToolMessage::new(a, b).with_artifact(c)` with `ToolMessage::with_artifact(a, b, c)`.
- `EventData` gained `artifact: Option<Value>` — additive; in-tree literals already use `..Default::default()`.

## Migration for external \`CallbackHandler\` implementors

```rust
// Before
async fn on_tool_end(&self, output: &str, run_id: Uuid, parent_run_id: Option<Uuid>) -> Result<()> {
    self.log(output, run_id);
    Ok(())
}

// After
async fn on_tool_end(&self, event: ToolEndEvent) -> Result<()> {
    self.log(&event.output_str, event.run_id);
    Ok(())
}
```

Handlers that want the original typed value read `event.output_value` instead of parsing `event.output_str`.

## Test plan

- [x] \`cargo test --workspace\` — 10,448 passed, 0 failed
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --features all-providers -- -D warnings\` — clean
- [x] \`cubic review --base main\` — "No issues found."
- [x] New unit tests for event structs, \`ToolMessage::with_artifact\`, \`apply_error_handler\` (including \`ToolValidationError\` + pass-through coverage)
- [x] New executor tests cover \`ToolOutput::Content\` and \`ContentAndArtifact\` paths — \`output_value\` shape and \`artifact\` propagation verified
- [x] New tracer test confirms \`EventStreamCallbackHandler\` preserves typed JSON shape and artifact
- [x] New integration test \`tests/tool_output_value_stream.rs\` drives \`AgentExecutor::astream_events\` end-to-end and asserts \`ev.data.output\` is the original JSON object (not a string)

## Commits

1. \`fa6afa8\` feat(callbacks): event structs
2. \`9b149b9\` feat(messages): \`ToolMessage::with_artifact\`
3. \`08833d6\` feat(tracers): \`EventData.artifact\`
4. \`aff0dbe\` refactor(tools): extract \`apply_error_handler\`
5. \`ad39b36\` test(tools): \`ToolValidationError\` coverage
6. \`cc98d63\` feat(callbacks)!: struct-based tool event signatures
7. \`e124660\` docs(callbacks): field-level doc comments
8. \`6f14d10\` feat(agents): executor uses \`_run\`, preserves typed Value & artifact (Closes #6)
9. \`4831472\` feat(tracers): event_stream preserves typed Value and artifact
10. \`0cc30f9\` docs(tools): artifact-discard caveat on \`run\`/\`run_str\`/\`run_json\`
11. \`a74684a\` test(agents): astream_events integration test


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves typed tool outputs and artifacts across callbacks and streams so UIs can render structured data without re-parsing. Also fixes clippy lints across the workspace. Closes #6.

- **New Features**
  - Added `ToolStartEvent`/`ToolEndEvent`/`ToolErrorEvent`; `ToolEndEvent` includes `output_value` and optional `artifact`.
  - `AgentExecutor` now uses `BaseTool::_run`, forwarding `ToolOutput::ContentAndArtifact`; added `ToolMessage::with_artifact`.
  - `EventStreamCallbackHandler`, `RunCollectorCallbackHandler`, and tracers emit typed `output` and `artifact`; `EventData.artifact` added.
  - Unified tool error handling via `apply_error_handler` to match prior behavior.

- **Migration**
  - Update `CallbackHandler::on_tool_{start,end,error}` to accept event structs.
  - If calling `RunManagerForTool::on_tool_end/on_tool_error`, pass the new payloads (`output_str`, `output_value`, `artifact` or `error` + `ToolErrorKind`).
  - Replace `ToolMessage::new(...).with_artifact(artifact)` with `ToolMessage::with_artifact(content, tool_call_id, artifact)`.
  - Note: `BaseTool::run` discards artifacts; use `_run` to access `ToolOutput::ContentAndArtifact`.

<sup>Written for commit 9fe70ad78d834b304c6b15100c56455e480e1848. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



