### PR TITLE
feat: #[cognis::tool] attribute macro for typed tools (#9, PR 2/2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "toml",
+ "toml 0.8.23",
  "uuid",
 ]
 
@@ -206,6 +206,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "trybuild",
  "uuid",
 ]
 
@@ -1890,6 +1891,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,6 +2292,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tempfile"
 version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2292,6 +2308,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2449,9 +2474,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -2464,6 +2504,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,10 +2520,19 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -2482,6 +2540,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -2565,6 +2629,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 1.1.2+spec-1.1.0",
+]
 
 [[package]]
 name = "type1-encoding-parser"
@@ -2837,6 +2916,15 @@ checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
  "wasite",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3139,6 +3227,12 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/cognis-core/Cargo.toml
+++ b/crates/cognis-core/Cargo.toml
@@ -23,3 +23,4 @@ cognis-macros.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }
+trybuild = "1"

--- a/crates/cognis-core/src/lib.rs
+++ b/crates/cognis-core/src/lib.rs
@@ -30,7 +30,7 @@
 //! assert_eq!(msg.message_type(), cognis_core::messages::MessageType::Human);
 //! ```
 
-pub use cognis_macros::{JsonSchema, ToolSchema};
+pub use cognis_macros::{tool, JsonSchema, ToolSchema};
 
 pub mod agents;
 pub mod caches;

--- a/crates/cognis-core/src/tools/validation.rs
+++ b/crates/cognis-core/src/tools/validation.rs
@@ -19,6 +19,14 @@ use std::sync::OnceLock;
 
 use crate::error::{CognisError, Result};
 
+/// Private re-export of the `regex` crate for use by `#[cognis::tool]`-
+/// generated code. Users of the macro do **not** need `regex` in their
+/// own `Cargo.toml` — the macro emits references through this path.
+#[doc(hidden)]
+pub mod __regex {
+    pub use regex::*;
+}
+
 /// Trait for types that can validate their own field constraints after
 /// deserialization. Typically implemented by code generated from
 /// `#[cognis::tool]` — each struct's `validate()` is a list of calls into the

--- a/crates/cognis-core/tests/tool_attr_impl_tests.rs
+++ b/crates/cognis-core/tests/tool_attr_impl_tests.rs
@@ -1,0 +1,129 @@
+//! Integration tests for `#[cognis::tool]` on an `impl` block — the
+//! stateful form where the tool struct holds configuration such as
+//! API keys or HTTP clients.
+
+use cognis_core::error::Result;
+use cognis_core::tool;
+use cognis_core::tools::{BaseTool, ToolInput, ToolOutput};
+use serde_json::json;
+use std::collections::HashMap;
+
+pub struct Calculator {
+    offset: i64,
+}
+
+#[tool(name = "add_with_offset")]
+impl Calculator {
+    /// Add two numbers, biased by the offset configured on the Calculator.
+    async fn add(&self, a: i64, b: i64) -> Result<ToolOutput> {
+        Ok(ToolOutput::Content(json!(a + b + self.offset)))
+    }
+}
+
+#[tokio::test]
+async fn impl_form_uses_receiver_state() {
+    let calc = Calculator { offset: 100 };
+    assert_eq!(calc.name(), "add_with_offset");
+    assert_eq!(
+        calc.description(),
+        "Add two numbers, biased by the offset configured on the Calculator."
+    );
+
+    let mut m = HashMap::new();
+    m.insert("a".to_string(), json!(2));
+    m.insert("b".to_string(), json!(3));
+    let out = calc._run(ToolInput::Structured(m)).await.unwrap();
+    match out {
+        ToolOutput::Content(v) => assert_eq!(v, json!(105)),
+        _ => panic!("expected Content"),
+    }
+}
+
+#[tokio::test]
+async fn impl_form_preserves_inherent_method() {
+    // The original async fn must still be callable as an inherent method,
+    // independent of the generated BaseTool impl.
+    let calc = Calculator { offset: 10 };
+    let out = calc.add(1, 2).await.unwrap();
+    match out {
+        ToolOutput::Content(v) => assert_eq!(v, json!(13)),
+        _ => panic!("expected Content"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Impl form with schema validators on args
+// ---------------------------------------------------------------------------
+
+pub struct Translator {
+    default_lang: String,
+}
+
+#[tool(name = "translate")]
+impl Translator {
+    /// Translate a piece of text into a target language.
+    async fn translate(
+        &self,
+        #[schema(length(min = 1, max = 500))] text: String,
+        #[schema(enum_values("en", "fr", "es", "de", "ja"))] target: Option<String>,
+    ) -> Result<ToolOutput> {
+        let target = target.unwrap_or_else(|| self.default_lang.clone());
+        Ok(ToolOutput::Content(
+            json!({ "text": text, "target": target }),
+        ))
+    }
+}
+
+#[tokio::test]
+async fn impl_form_validates_enum_and_falls_back_to_state_default() {
+    let t = Translator {
+        default_lang: "fr".into(),
+    };
+    let mut m = HashMap::new();
+    m.insert("text".to_string(), json!("hello"));
+    let out = t._run(ToolInput::Structured(m)).await.unwrap();
+    match out {
+        ToolOutput::Content(v) => {
+            assert_eq!(v["text"], json!("hello"));
+            assert_eq!(v["target"], json!("fr"));
+        }
+        _ => panic!("expected Content"),
+    }
+}
+
+#[tokio::test]
+async fn impl_form_rejects_invalid_enum() {
+    let t = Translator {
+        default_lang: "fr".into(),
+    };
+    let mut m = HashMap::new();
+    m.insert("text".to_string(), json!("hello"));
+    m.insert("target".to_string(), json!("xx"));
+    let err = t._run(ToolInput::Structured(m)).await.unwrap_err();
+    assert!(err.to_string().contains("xx"), "got {err}");
+}
+
+#[tokio::test]
+async fn impl_form_rejects_short_text() {
+    let t = Translator {
+        default_lang: "fr".into(),
+    };
+    let mut m = HashMap::new();
+    m.insert("text".to_string(), json!(""));
+    let err = t._run(ToolInput::Structured(m)).await.unwrap_err();
+    assert!(err.to_string().contains("minimum"), "got {err}");
+}
+
+#[tokio::test]
+async fn impl_form_exposes_schema() {
+    let t = Translator {
+        default_lang: "fr".into(),
+    };
+    let schema = t.args_schema().unwrap();
+    assert_eq!(schema["properties"]["text"]["minLength"], json!(1));
+    assert_eq!(schema["properties"]["text"]["maxLength"], json!(500));
+    assert_eq!(
+        schema["properties"]["target"]["enum"],
+        json!(["en", "fr", "es", "de", "ja"])
+    );
+}

--- a/crates/cognis-core/tests/tool_attr_impl_tests.rs
+++ b/crates/cognis-core/tests/tool_attr_impl_tests.rs
@@ -127,3 +127,53 @@ async fn impl_form_exposes_schema() {
         json!(["en", "fr", "es", "de", "ja"])
     );
 }
+
+// ---------------------------------------------------------------------------
+// Regression — doc comments on impl-form args must be stripped from the
+// preserved inherent method (stable Rust rejects `///` on function
+// parameters with "only allow/cfg/.../warn are allowed").
+// ---------------------------------------------------------------------------
+
+pub struct DocParams;
+
+#[tool(name = "with_doc_params")]
+impl DocParams {
+    /// Tool whose args carry rustdoc comments — they should appear in
+    /// the generated JSON Schema but be stripped from the inherent fn.
+    async fn call(
+        &self,
+        /// First arg: the subject.
+        subject: String,
+        /// Second arg: optional adjective.
+        adjective: Option<String>,
+    ) -> Result<ToolOutput> {
+        Ok(ToolOutput::Content(json!({
+            "subject": subject,
+            "adjective": adjective,
+        })))
+    }
+}
+
+#[tokio::test]
+async fn impl_form_strips_doc_attrs_from_method_params() {
+    let t = DocParams;
+    let schema = t.args_schema().unwrap();
+    assert_eq!(
+        schema["properties"]["subject"]["description"],
+        json!("First arg: the subject.")
+    );
+    assert_eq!(
+        schema["properties"]["adjective"]["description"],
+        json!("Second arg: optional adjective.")
+    );
+
+    // Inherent method still callable (would have failed compilation if
+    // doc attrs hadn't been stripped from the preserved impl).
+    let out = t.call("cat".into(), Some("happy".into())).await.unwrap();
+    match out {
+        ToolOutput::Content(v) => {
+            assert_eq!(v, json!({ "subject": "cat", "adjective": "happy" }))
+        }
+        _ => panic!("expected Content"),
+    }
+}

--- a/crates/cognis-core/tests/tool_attr_tests.rs
+++ b/crates/cognis-core/tests/tool_attr_tests.rs
@@ -1,0 +1,160 @@
+//! Integration tests for `#[cognis::tool]` on standalone `async fn`s.
+//!
+//! Lives in `cognis-core` (not `cognis-macros`) because the macro crate
+//! can't dev-dep its own consumer — `cognis-core` → `cognis-macros` is
+//! the runtime direction.
+
+use cognis_core::error::Result;
+use cognis_core::tool;
+use cognis_core::tools::{BaseTool, ToolInput, ToolOutput};
+use serde_json::json;
+use std::collections::HashMap;
+
+/// Search documents in the index.
+#[tool(name = "search")]
+async fn search(
+    /// Query string
+    query: String,
+    /// Max results
+    #[schema(range(min = 1, max = 50))]
+    limit: Option<u32>,
+) -> Result<ToolOutput> {
+    Ok(ToolOutput::Content(json!({ "q": query, "l": limit })))
+}
+
+#[tokio::test]
+async fn basic_invocation() {
+    let tool = Search;
+    assert_eq!(tool.name(), "search");
+    assert_eq!(tool.description(), "Search documents in the index.");
+    let schema = tool.args_schema().unwrap();
+    assert_eq!(schema["properties"]["limit"]["minimum"], json!(1));
+    assert_eq!(schema["properties"]["limit"]["maximum"], json!(50));
+    assert_eq!(
+        schema["properties"]["query"]["type"],
+        json!("string"),
+        "schema: {schema}"
+    );
+
+    let mut m = HashMap::new();
+    m.insert("query".to_string(), json!("rust"));
+    let out = tool._run(ToolInput::Structured(m)).await.unwrap();
+    match out {
+        ToolOutput::Content(v) => assert_eq!(v, json!({ "q": "rust", "l": null })),
+        _ => panic!("expected Content"),
+    }
+}
+
+#[tokio::test]
+async fn validation_rejects_out_of_range() {
+    let tool = Search;
+    let mut m = HashMap::new();
+    m.insert("query".to_string(), json!("x"));
+    m.insert("limit".to_string(), json!(100));
+    let err = tool._run(ToolInput::Structured(m)).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("limit"), "got {msg}");
+    assert!(msg.contains("maximum"), "got {msg}");
+}
+
+#[tokio::test]
+async fn validation_rejects_missing_required() {
+    let tool = Search;
+    let err = tool
+        ._run(ToolInput::Structured(HashMap::new()))
+        .await
+        .unwrap_err();
+    let msg = err.to_string().to_lowercase();
+    assert!(msg.contains("query"), "got {msg}");
+}
+
+// ---------------------------------------------------------------------------
+// length + pattern + enum_values validators
+// ---------------------------------------------------------------------------
+
+/// Route requests to a service by region.
+#[tool]
+async fn route(
+    /// Two-letter region code
+    #[schema(enum_values("us", "eu", "asia"))]
+    region: String,
+    /// Human-readable label
+    #[schema(length(min = 1, max = 32))]
+    label: String,
+    /// Optional slug (lowercase letters only)
+    #[schema(pattern("^[a-z]+$"))]
+    slug: Option<String>,
+) -> Result<ToolOutput> {
+    Ok(ToolOutput::Content(json!({
+        "region": region,
+        "label": label,
+        "slug": slug,
+    })))
+}
+
+#[tokio::test]
+async fn enum_values_accepts_listed() {
+    let tool = Route;
+    let mut m = HashMap::new();
+    m.insert("region".to_string(), json!("eu"));
+    m.insert("label".to_string(), json!("prod"));
+    assert!(tool._run(ToolInput::Structured(m)).await.is_ok());
+}
+
+#[tokio::test]
+async fn enum_values_rejects_unlisted() {
+    let tool = Route;
+    let mut m = HashMap::new();
+    m.insert("region".to_string(), json!("mars"));
+    m.insert("label".to_string(), json!("prod"));
+    let err = tool._run(ToolInput::Structured(m)).await.unwrap_err();
+    assert!(err.to_string().contains("mars"), "got {err}");
+}
+
+#[tokio::test]
+async fn length_validator_enforced() {
+    let tool = Route;
+    let mut m = HashMap::new();
+    m.insert("region".to_string(), json!("us"));
+    m.insert("label".to_string(), json!("")); // empty → below min
+    let err = tool._run(ToolInput::Structured(m)).await.unwrap_err();
+    assert!(err.to_string().contains("minimum"), "got {err}");
+}
+
+#[tokio::test]
+async fn pattern_validator_enforced() {
+    let tool = Route;
+    let mut m = HashMap::new();
+    m.insert("region".to_string(), json!("us"));
+    m.insert("label".to_string(), json!("ok"));
+    m.insert("slug".to_string(), json!("HAS-CAPS"));
+    let err = tool._run(ToolInput::Structured(m)).await.unwrap_err();
+    assert!(err.to_string().contains("pattern"), "got {err}");
+}
+
+#[tokio::test]
+async fn default_name_is_fn_name() {
+    let tool = Route;
+    assert_eq!(tool.name(), "route");
+}
+
+#[tokio::test]
+async fn empty_description_when_no_doc_comment() {
+    #[tool]
+    async fn no_docs(_x: String) -> Result<ToolOutput> {
+        Ok(ToolOutput::Content(json!(null)))
+    }
+    let tool = NoDocs;
+    assert_eq!(tool.description(), "");
+}
+
+#[tokio::test]
+async fn description_override_wins_over_doc() {
+    /// This doc comment should be ignored.
+    #[tool(description = "overridden desc")]
+    async fn with_override(_q: String) -> Result<ToolOutput> {
+        Ok(ToolOutput::Content(json!(null)))
+    }
+    let tool = WithOverride;
+    assert_eq!(tool.description(), "overridden desc");
+}

--- a/crates/cognis-core/tests/tool_attr_ui.rs
+++ b/crates/cognis-core/tests/tool_attr_ui.rs
@@ -1,0 +1,12 @@
+//! trybuild-driven compile-failure tests for `#[cognis::tool]`.
+//!
+//! Each fixture in `tests/ui/` must fail to compile with a specific
+//! error message. The `.stderr` files are captured on first run
+//! (`TRYBUILD=overwrite cargo test -p cognis-core --test tool_attr_ui`)
+//! and then committed alongside the `.rs` fixtures.
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/tool_attr/*.rs");
+}

--- a/crates/cognis-core/tests/ui/tool_attr/multiple_async_fns_in_impl.rs
+++ b/crates/cognis-core/tests/ui/tool_attr/multiple_async_fns_in_impl.rs
@@ -1,0 +1,18 @@
+//! `#[tool]` impl-form with multiple async fns — must fail; exactly
+//! one async fn is required per impl block.
+
+use cognis_core::tool;
+
+pub struct Searcher;
+
+#[tool]
+impl Searcher {
+    async fn search(&self, _q: String) -> cognis_core::error::Result<cognis_core::tools::ToolOutput> {
+        Ok(cognis_core::tools::ToolOutput::Content(serde_json::json!(null)))
+    }
+    async fn also_search(&self, _q: String) -> cognis_core::error::Result<cognis_core::tools::ToolOutput> {
+        Ok(cognis_core::tools::ToolOutput::Content(serde_json::json!(null)))
+    }
+}
+
+fn main() {}

--- a/crates/cognis-core/tests/ui/tool_attr/multiple_async_fns_in_impl.stderr
+++ b/crates/cognis-core/tests/ui/tool_attr/multiple_async_fns_in_impl.stderr
@@ -1,0 +1,7 @@
+error: #[tool] impl block must contain exactly one `async fn`; found multiple — split the extra async methods into a separate `impl` block
+  --> tests/ui/tool_attr/multiple_async_fns_in_impl.rs:13:5
+   |
+13 | /     async fn also_search(&self, _q: String) -> cognis_core::error::Result<cognis_core::tools::ToolOutput> {
+14 | |         Ok(cognis_core::tools::ToolOutput::Content(serde_json::json!(null)))
+15 | |     }
+   | |_____^

--- a/crates/cognis-core/tests/ui/tool_attr/mut_self.rs
+++ b/crates/cognis-core/tests/ui/tool_attr/mut_self.rs
@@ -1,0 +1,17 @@
+//! `#[tool]` impl-form with `&mut self` — must fail because the
+//! generated `BaseTool::_run` takes `&self`.
+
+use cognis_core::tool;
+
+pub struct Counter;
+
+#[tool]
+impl Counter {
+    async fn bump(&mut self) -> cognis_core::error::Result<cognis_core::tools::ToolOutput> {
+        Ok(cognis_core::tools::ToolOutput::Content(
+            serde_json::json!(null),
+        ))
+    }
+}
+
+fn main() {}

--- a/crates/cognis-core/tests/ui/tool_attr/mut_self.stderr
+++ b/crates/cognis-core/tests/ui/tool_attr/mut_self.stderr
@@ -1,0 +1,5 @@
+error: #[tool] method receiver must be `&self` (not `&mut self`)
+  --> tests/ui/tool_attr/mut_self.rs:10:19
+   |
+10 |     async fn bump(&mut self) -> cognis_core::error::Result<cognis_core::tools::ToolOutput> {
+   |                   ^^^^^^^^^

--- a/crates/cognis-core/tests/ui/tool_attr/non_async_fn.rs
+++ b/crates/cognis-core/tests/ui/tool_attr/non_async_fn.rs
@@ -1,0 +1,12 @@
+//! `#[tool]` applied to a sync fn — must fail with a clear error.
+
+use cognis_core::tool;
+
+#[tool]
+fn not_async(_q: String) -> cognis_core::error::Result<cognis_core::tools::ToolOutput> {
+    Ok(cognis_core::tools::ToolOutput::Content(
+        serde_json::json!(null),
+    ))
+}
+
+fn main() {}

--- a/crates/cognis-core/tests/ui/tool_attr/non_async_fn.stderr
+++ b/crates/cognis-core/tests/ui/tool_attr/non_async_fn.stderr
@@ -1,0 +1,5 @@
+error: #[tool] requires an `async fn` — tools are invoked asynchronously
+ --> tests/ui/tool_attr/non_async_fn.rs:6:1
+  |
+6 | fn not_async(_q: String) -> cognis_core::error::Result<cognis_core::tools::ToolOutput> {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/cognis-core/tests/ui/tool_attr/ref_arg.rs
+++ b/crates/cognis-core/tests/ui/tool_attr/ref_arg.rs
@@ -1,0 +1,13 @@
+//! `#[tool]` with a reference-typed arg — must fail because the macro
+//! deserializes owned types via `serde_json::from_value`.
+
+use cognis_core::tool;
+
+#[tool]
+async fn borrow_arg(_q: &str) -> cognis_core::error::Result<cognis_core::tools::ToolOutput> {
+    Ok(cognis_core::tools::ToolOutput::Content(
+        serde_json::json!(null),
+    ))
+}
+
+fn main() {}

--- a/crates/cognis-core/tests/ui/tool_attr/ref_arg.stderr
+++ b/crates/cognis-core/tests/ui/tool_attr/ref_arg.stderr
@@ -1,0 +1,5 @@
+error: #[tool] args must be owned types (e.g. `String`, not `&str`) — the macro deserializes via `serde_json::from_value`
+ --> tests/ui/tool_attr/ref_arg.rs:7:25
+  |
+7 | async fn borrow_arg(_q: &str) -> cognis_core::error::Result<cognis_core::tools::ToolOutput> {
+  |                         ^^^^

--- a/crates/cognis-macros/src/lib.rs
+++ b/crates/cognis-macros/src/lib.rs
@@ -43,6 +43,7 @@
 
 mod graph_state;
 mod schema_attr;
+mod tool_attr;
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
@@ -103,6 +104,41 @@ pub fn derive_tool_schema(input: TokenStream) -> TokenStream {
 pub fn derive_graph_state(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     graph_state::derive_graph_state(input).into()
+}
+
+// ---------------------------------------------------------------------------
+// #[cognis::tool] attribute macro
+// ---------------------------------------------------------------------------
+
+/// `#[cognis::tool]` — attribute macro that generates a
+/// [`cognis_core::tools::BaseTool`] implementation from an `async fn`.
+///
+/// Applies to either a standalone `async fn` or an `impl` block that
+/// contains exactly one `async fn` (the stateful form, where the tool
+/// struct holds configuration such as HTTP clients or API keys).
+///
+/// # Arguments
+///
+/// - `name = "..."` — overrides the tool name (defaults to the fn name).
+/// - `description = "..."` — overrides the fn's doc-comment description.
+/// - `return_direct = true|false` — passes through to `BaseTool::return_direct`.
+///
+/// # Field validators
+///
+/// `#[schema(range(...))]`, `#[schema(length(...))]`, `#[schema(pattern(...))]`,
+/// `#[schema(enum_values(...))]`, and `#[schema(format(...))]` on fn arguments
+/// emit matching runtime checks plus JSON Schema keywords.
+///
+/// See `cognis_core::tools::validation` for the helpers the generated
+/// code invokes.
+#[proc_macro_attribute]
+pub fn tool(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr as tool_attr::ToolArgs);
+    let item_ts: TokenStream2 = item.into();
+    match tool_attr::expand(args, item_ts) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
 }
 
 // =========================================================================

--- a/crates/cognis-macros/src/lib.rs
+++ b/crates/cognis-macros/src/lib.rs
@@ -1,11 +1,24 @@
-//! Standalone derive macros for generating OpenAPI-compatible JSON schemas.
+//! Proc macros for the Cognis framework.
 //!
-//! This crate is **framework-independent** — it has zero runtime dependencies
-//! and generates no code that references any external framework crate.
+//! This crate exposes two kinds of macros with different coupling guarantees:
 //!
-//! The only requirement for generated code is `serde_json` in scope.
+//! # Framework-independent derives
 //!
-//! # Usage
+//! [`JsonSchema`] / [`ToolSchema`] / [`GraphState`] are derive macros whose
+//! generated code references **only `serde_json`** (and, for `GraphState`, the
+//! reducer fn paths the user supplies). They don't reference `cognis_core` or
+//! any other workspace crate, so consumers can derive schemas in crates that
+//! don't depend on the framework.
+//!
+//! # Framework-coupled attributes
+//!
+//! [`tool`] is a `#[proc_macro_attribute]` that generates a
+//! `cognis_core::tools::BaseTool` implementation. Its output necessarily
+//! references `cognis_core::tools::{ValidateArgs, BaseTool, ToolInput,
+//! ToolOutput}` and `cognis_core::tools::validation::check_*`. Code annotated
+//! with `#[cognis::tool]` must therefore compile against the cognis framework.
+//!
+//! # Derive usage
 //!
 //! ```ignore
 //! use cognis_macros::JsonSchema;
@@ -26,7 +39,7 @@
 //! // {"type":"object","properties":{...},"required":["min_score","categories"]}
 //! ```
 //!
-//! # Supported types
+//! # `#[derive(JsonSchema)]` supported types
 //!
 //! | Rust type | JSON Schema |
 //! |-----------|-------------|

--- a/crates/cognis-macros/src/schema_attr.rs
+++ b/crates/cognis-macros/src/schema_attr.rs
@@ -138,7 +138,7 @@ fn parse_range(input: ParseStream) -> Result<Validator> {
             }
             let lit: syn::Lit = i.parse()?;
             let mut val: f64 = match &lit {
-                syn::Lit::Int(n) => n.base10_parse::<i64>()? as f64,
+                syn::Lit::Int(n) => n.base10_parse::<f64>()?,
                 syn::Lit::Float(f) => f.base10_parse::<f64>()?,
                 _ => {
                     return Err(syn::Error::new_spanned(
@@ -316,5 +316,18 @@ mod tests {
         assert!(
             matches!(r.validators[0], Validator::Range { min: Some(v), max: Some(w) } if v == -0.5 && w == 0.5)
         );
+    }
+
+    #[test]
+    fn range_accepts_integer_beyond_i64_max() {
+        // u64::MAX overflows i64 but fits f64 (with expected precision loss —
+        // the f64 representation is still the right value for JSON Schema
+        // minimum/maximum). Identified by cubic as a P2 restriction.
+        let a: syn::Attribute = parse_quote!(#[schema(range(min = 0, max = 18446744073709551615))]);
+        let r = a.parse_args::<SchemaAttr>().unwrap();
+        assert!(matches!(
+            r.validators[0],
+            Validator::Range { min: Some(v), max: Some(_) } if v == 0.0
+        ));
     }
 }

--- a/crates/cognis-macros/src/tool_attr.rs
+++ b/crates/cognis-macros/src/tool_attr.rs
@@ -255,10 +255,28 @@ fn expand_impl(args: ToolArgs, item_impl: ItemImpl) -> syn::Result<TokenStream2>
         &arg_specs,
     );
 
+    // Strip #[schema(...)] (and helper-macro-only attrs) from the preserved
+    // impl block's method parameters. Those attrs were meaningful to *this*
+    // macro — they've already been consumed into `arg_specs`. Leaving them
+    // on the inherent method emits "cannot find attribute `schema`" because
+    // no derive is in scope there.
+    let mut cleaned_impl = item_impl.clone();
+    for item in cleaned_impl.items.iter_mut() {
+        if let ImplItem::Fn(m) = item {
+            if m.sig.asyncness.is_some() {
+                for input in m.sig.inputs.iter_mut() {
+                    if let FnArg::Typed(pt) = input {
+                        pt.attrs.retain(|a| !a.path().is_ident("schema"));
+                    }
+                }
+            }
+        }
+    }
+
     Ok(quote! {
         #args_struct
         #validate_impl
-        #item_impl
+        #cleaned_impl
         #base_tool_impl
     })
 }

--- a/crates/cognis-macros/src/tool_attr.rs
+++ b/crates/cognis-macros/src/tool_attr.rs
@@ -1,0 +1,70 @@
+//! `#[cognis::tool]` attribute macro.
+//!
+//! Wraps an `async fn` (either standalone or inside an `impl` block) to
+//! generate a `BaseTool` implementation with typed, schema-validated args.
+//!
+//! Two forms are supported:
+//!
+//! - **Standalone** — `#[tool]` on a free `async fn`. The macro emits a
+//!   unit struct with the fn's PascalCase name; that struct is the
+//!   `BaseTool` implementation.
+//! - **Impl-block** — `#[tool]` on an `impl` block containing exactly one
+//!   `async fn`. The macro preserves the original inherent method and
+//!   emits a separate `BaseTool` impl whose `_run` dispatches into that
+//!   method (letting tools hold state like HTTP clients or API keys).
+//!
+//! Generated code references `cognis_core` by absolute path, so callers
+//! only need `cognis_core` and (for pattern validators) `regex` in scope.
+//! The macro re-exports regex via `cognis_core::tools::validation::__regex`
+//! — users do not need to add `regex` to their `Cargo.toml`.
+
+use proc_macro2::TokenStream as TokenStream2;
+use syn::{
+    parse::{Parse, ParseStream},
+    LitStr, Token,
+};
+
+/// Parsed arguments of the `#[tool(...)]` attribute.
+#[derive(Default)]
+pub(crate) struct ToolArgs {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub return_direct: Option<bool>,
+}
+
+impl Parse for ToolArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut args = ToolArgs::default();
+        while !input.is_empty() {
+            let key: syn::Ident = input.parse()?;
+            let _: Token![=] = input.parse()?;
+            match key.to_string().as_str() {
+                "name" => args.name = Some(input.parse::<LitStr>()?.value()),
+                "description" => args.description = Some(input.parse::<LitStr>()?.value()),
+                "return_direct" => {
+                    let b: syn::LitBool = input.parse()?;
+                    args.return_direct = Some(b.value);
+                }
+                other => {
+                    return Err(syn::Error::new(
+                        key.span(),
+                        format!(
+                            "unknown #[tool] argument `{other}`; expected name, description, or return_direct"
+                        ),
+                    ))
+                }
+            }
+            if !input.is_empty() {
+                let _: Token![,] = input.parse()?;
+            }
+        }
+        Ok(args)
+    }
+}
+
+/// Entry point — dispatches to the correct form based on what `input`
+/// parses as. During scaffolding this is a no-op; real expansion lands
+/// in subsequent commits.
+pub(crate) fn expand(_args: ToolArgs, input: TokenStream2) -> syn::Result<TokenStream2> {
+    Ok(input)
+}

--- a/crates/cognis-macros/src/tool_attr.rs
+++ b/crates/cognis-macros/src/tool_attr.rs
@@ -14,21 +14,28 @@
 //!   method (letting tools hold state like HTTP clients or API keys).
 //!
 //! Generated code references `cognis_core` by absolute path, so callers
-//! only need `cognis_core` and (for pattern validators) `regex` in scope.
-//! The macro re-exports regex via `cognis_core::tools::validation::__regex`
-//! — users do not need to add `regex` to their `Cargo.toml`.
+//! only need `cognis_core` and `async_trait` in scope. Regex compilation
+//! for `#[schema(pattern(...))]` goes through
+//! `cognis_core::tools::validation::__regex` — users do not need to add
+//! `regex` to their `Cargo.toml`.
 
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::{format_ident, quote, ToTokens};
 use syn::{
     parse::{Parse, ParseStream},
-    LitStr, Token,
+    spanned::Spanned,
+    Expr, FnArg, ImplItem, ItemFn, ItemImpl, Lit, LitStr, Meta, Pat, Signature, Token, Type,
+    Visibility,
 };
+
+use crate::schema_attr::{self, Validator};
 
 /// Parsed arguments of the `#[tool(...)]` attribute.
 #[derive(Default)]
 pub(crate) struct ToolArgs {
     pub name: Option<String>,
     pub description: Option<String>,
+    #[allow(dead_code)]
     pub return_direct: Option<bool>,
 }
 
@@ -63,8 +70,684 @@ impl Parse for ToolArgs {
 }
 
 /// Entry point — dispatches to the correct form based on what `input`
-/// parses as. During scaffolding this is a no-op; real expansion lands
-/// in subsequent commits.
-pub(crate) fn expand(_args: ToolArgs, input: TokenStream2) -> syn::Result<TokenStream2> {
-    Ok(input)
+/// parses as.
+pub(crate) fn expand(args: ToolArgs, input: TokenStream2) -> syn::Result<TokenStream2> {
+    // Try ItemFn first — if the annotated item is an impl block, we won't
+    // mis-parse it as a fn because ItemImpl has a distinct `impl` keyword.
+    if let Ok(item_fn) = syn::parse2::<ItemFn>(input.clone()) {
+        return expand_fn(args, item_fn);
+    }
+    if let Ok(item_impl) = syn::parse2::<ItemImpl>(input) {
+        return expand_impl(args, item_impl);
+    }
+    Err(syn::Error::new(
+        Span::call_site(),
+        "#[tool] can only be applied to an async fn or to an impl block containing exactly one async fn",
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Standalone `async fn` form
+// ---------------------------------------------------------------------------
+
+fn expand_fn(args: ToolArgs, item_fn: ItemFn) -> syn::Result<TokenStream2> {
+    if item_fn.sig.asyncness.is_none() {
+        return Err(syn::Error::new_spanned(
+            &item_fn.sig,
+            "#[tool] requires an `async fn` — tools are invoked asynchronously",
+        ));
+    }
+    if item_fn.sig.generics.params.iter().next().is_some() {
+        return Err(syn::Error::new_spanned(
+            &item_fn.sig.generics,
+            "#[tool] does not support generic functions in v1",
+        ));
+    }
+
+    let vis = &item_fn.vis;
+    let fn_ident = &item_fn.sig.ident;
+    let fn_doc = collect_doc_comment(&item_fn.attrs);
+
+    // Parse the fn parameters into arg specs. Rejects `&self`/references.
+    let arg_specs = parse_typed_args(&item_fn.sig, /* allow_self = */ false)?;
+
+    // Derive identifiers.
+    let struct_ident = pascal_case_ident(&fn_ident.to_string(), fn_ident.span());
+    let args_struct_ident = format_ident!("__{}Args", pascal_case(&fn_ident.to_string()));
+    let body_fn_ident = format_ident!("__{}_body", fn_ident);
+
+    let tool_name = args.name.clone().unwrap_or_else(|| fn_ident.to_string());
+    let description = args.description.clone().or(fn_doc).unwrap_or_default();
+    let return_direct = args.return_direct.unwrap_or(false);
+
+    // Emit components.
+    let args_struct = emit_args_struct(&args_struct_ident, &arg_specs);
+    let validate_impl = emit_validate_impl(&args_struct_ident, &arg_specs)?;
+    let body_fn = emit_body_fn(&body_fn_ident, &item_fn)?;
+    let base_tool_impl = emit_base_tool_impl_standalone(
+        vis,
+        &struct_ident,
+        &args_struct_ident,
+        &body_fn_ident,
+        &tool_name,
+        &description,
+        return_direct,
+        &arg_specs,
+    );
+
+    Ok(quote! {
+        #args_struct
+        #validate_impl
+        #body_fn
+        #vis struct #struct_ident;
+        #base_tool_impl
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Impl-block form
+// ---------------------------------------------------------------------------
+
+fn expand_impl(args: ToolArgs, item_impl: ItemImpl) -> syn::Result<TokenStream2> {
+    if item_impl.generics.params.iter().next().is_some() {
+        return Err(syn::Error::new_spanned(
+            &item_impl.generics,
+            "#[tool] does not support generic impl blocks in v1",
+        ));
+    }
+    if let Some((_, path, _)) = &item_impl.trait_ {
+        return Err(syn::Error::new_spanned(
+            path,
+            "#[tool] must be applied to an inherent impl block (not a trait impl)",
+        ));
+    }
+
+    // Identify the single async fn in the impl.
+    let mut async_methods = Vec::new();
+    for item in &item_impl.items {
+        if let ImplItem::Fn(m) = item {
+            if m.sig.asyncness.is_some() {
+                async_methods.push(m);
+            }
+        }
+    }
+    if async_methods.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &item_impl,
+            "#[tool] impl block must contain exactly one `async fn` (the tool body); found none",
+        ));
+    }
+    if async_methods.len() > 1 {
+        return Err(syn::Error::new_spanned(
+            async_methods[1],
+            "#[tool] impl block must contain exactly one `async fn`; found multiple — \
+             split the extra async methods into a separate `impl` block",
+        ));
+    }
+    let method = async_methods[0];
+
+    // Extract the self-type (ident) from the impl target.
+    let self_ty = &*item_impl.self_ty;
+    let struct_path = quote! { #self_ty };
+    let struct_ident = match self_ty {
+        Type::Path(tp) => tp
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident.clone())
+            .ok_or_else(|| syn::Error::new_spanned(self_ty, "cannot resolve impl target name"))?,
+        other => {
+            return Err(syn::Error::new_spanned(
+                other,
+                "#[tool] impl target must be a named struct type",
+            ))
+        }
+    };
+
+    // Must take &self.
+    let receiver = method.sig.receiver().ok_or_else(|| {
+        syn::Error::new_spanned(
+            &method.sig,
+            "#[tool] method must take `&self` as its first argument",
+        )
+    })?;
+    if receiver.mutability.is_some() {
+        return Err(syn::Error::new_spanned(
+            receiver,
+            "#[tool] method receiver must be `&self` (not `&mut self`)",
+        ));
+    }
+    if receiver.reference.is_none() {
+        return Err(syn::Error::new_spanned(
+            receiver,
+            "#[tool] method receiver must be `&self` (consuming `self` is not supported)",
+        ));
+    }
+
+    let method_ident = &method.sig.ident;
+    let method_doc = collect_doc_comment(&method.attrs);
+    let arg_specs = parse_typed_args(&method.sig, /* allow_self = */ true)?;
+
+    // Derived idents.
+    let args_struct_ident = format_ident!(
+        "__{}{}Args",
+        pascal_case(&struct_ident.to_string()),
+        pascal_case(&method_ident.to_string())
+    );
+
+    let tool_name = args
+        .name
+        .clone()
+        .unwrap_or_else(|| method_ident.to_string());
+    let description = args.description.clone().or(method_doc).unwrap_or_default();
+    let return_direct = args.return_direct.unwrap_or(false);
+
+    // Emit components.
+    let args_struct = emit_args_struct(&args_struct_ident, &arg_specs);
+    let validate_impl = emit_validate_impl(&args_struct_ident, &arg_specs)?;
+    let base_tool_impl = emit_base_tool_impl_method(
+        &struct_path,
+        &args_struct_ident,
+        method_ident,
+        &tool_name,
+        &description,
+        return_direct,
+        &arg_specs,
+    );
+
+    Ok(quote! {
+        #args_struct
+        #validate_impl
+        #item_impl
+        #base_tool_impl
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+/// A parsed tool argument — one positional fn parameter that becomes a
+/// field in the generated args struct.
+struct ArgSpec {
+    /// Original field identifier (preserved verbatim for serde).
+    ident: syn::Ident,
+    /// Full type path (`Option<T>` preserved).
+    ty: Type,
+    /// Inner type with `Option` stripped (used for type-dispatch in
+    /// validator emission).
+    inner_ty: Type,
+    /// `true` iff the outer type was `Option<T>`.
+    is_option: bool,
+    /// Doc comment (rustdoc) attached to the argument, passed through to
+    /// the generated struct so `#[derive(JsonSchema)]` picks it up.
+    docs: Vec<syn::Attribute>,
+    /// Raw `#[schema(...)]` attributes from the argument, forwarded to
+    /// the generated struct field. These drive both the JSON-Schema
+    /// emission (via `#[derive(JsonSchema)]`) and the runtime validator
+    /// emission (via [`emit_validate_impl`]).
+    schema_attrs: Vec<syn::Attribute>,
+    /// Parsed validators (accumulated across all `#[schema(...)]` attrs).
+    validators: Vec<Validator>,
+}
+
+fn parse_typed_args(sig: &Signature, allow_self: bool) -> syn::Result<Vec<ArgSpec>> {
+    let mut specs = Vec::new();
+    for input in &sig.inputs {
+        match input {
+            FnArg::Receiver(r) => {
+                if !allow_self {
+                    return Err(syn::Error::new_spanned(
+                        r,
+                        "standalone #[tool] functions cannot take `self` — use the impl-block form instead",
+                    ));
+                }
+                // In the impl form, skip the receiver; validated by caller.
+            }
+            FnArg::Typed(pat_type) => {
+                let ident = match &*pat_type.pat {
+                    Pat::Ident(pi) => pi.ident.clone(),
+                    other => {
+                        return Err(syn::Error::new_spanned(
+                            other,
+                            "#[tool] args must be plain identifiers (no destructuring)",
+                        ))
+                    }
+                };
+                if let Type::Reference(tr) = &*pat_type.ty {
+                    return Err(syn::Error::new_spanned(
+                        tr,
+                        "#[tool] args must be owned types (e.g. `String`, not `&str`) — \
+                         the macro deserializes via `serde_json::from_value`",
+                    ));
+                }
+                let (inner_ty, is_option) = unwrap_option(&pat_type.ty);
+                let docs: Vec<syn::Attribute> = pat_type
+                    .attrs
+                    .iter()
+                    .filter(|a| a.path().is_ident("doc"))
+                    .cloned()
+                    .collect();
+                let schema_attrs: Vec<syn::Attribute> = pat_type
+                    .attrs
+                    .iter()
+                    .filter(|a| a.path().is_ident("schema"))
+                    .cloned()
+                    .collect();
+
+                // Parse validators for runtime check emission. Schema emission
+                // happens in the derive(JsonSchema) on the generated struct.
+                let mut validators = Vec::new();
+                for attr in &schema_attrs {
+                    let parsed = attr.parse_args::<schema_attr::SchemaAttr>()?;
+                    validators.extend(parsed.validators);
+                }
+
+                specs.push(ArgSpec {
+                    ident,
+                    ty: (*pat_type.ty).clone(),
+                    inner_ty: inner_ty.clone(),
+                    is_option,
+                    docs,
+                    schema_attrs,
+                    validators,
+                });
+            }
+        }
+    }
+    Ok(specs)
+}
+
+fn unwrap_option(ty: &Type) -> (Type, bool) {
+    if let Type::Path(tp) = ty {
+        if let Some(last) = tp.path.segments.last() {
+            if last.ident == "Option" {
+                if let syn::PathArguments::AngleBracketed(ab) = &last.arguments {
+                    for arg in &ab.args {
+                        if let syn::GenericArgument::Type(t) = arg {
+                            return (t.clone(), true);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    (ty.clone(), false)
+}
+
+// ---------------------------------------------------------------------------
+// Code emission
+// ---------------------------------------------------------------------------
+
+fn emit_args_struct(struct_ident: &syn::Ident, specs: &[ArgSpec]) -> TokenStream2 {
+    let fields = specs.iter().map(|s| {
+        let ident = &s.ident;
+        let ty = &s.ty;
+        let docs = &s.docs;
+        let schema_attrs = &s.schema_attrs;
+        quote! {
+            #(#docs)*
+            #(#schema_attrs)*
+            pub #ident: #ty,
+        }
+    });
+    quote! {
+        #[derive(::serde::Deserialize, ::cognis_macros::JsonSchema)]
+        #[allow(non_camel_case_types, non_snake_case, dead_code)]
+        struct #struct_ident {
+            #(#fields)*
+        }
+    }
+}
+
+fn emit_validate_impl(struct_ident: &syn::Ident, specs: &[ArgSpec]) -> syn::Result<TokenStream2> {
+    // Per-field pattern regex statics — one per `Pattern` validator per
+    // field. Names are derived from struct + field + index so multiple
+    // patterns on the same field still emit unique statics.
+    let mut pattern_statics = Vec::new();
+    let mut validator_stmts = Vec::new();
+
+    for spec in specs {
+        let ident = &spec.ident;
+        let field_name = ident.to_string();
+        let mut checks = Vec::new();
+        let type_kind = classify_type(&spec.inner_ty);
+
+        for (i, v) in spec.validators.iter().enumerate() {
+            match v {
+                Validator::Range { min, max } => {
+                    let min_tok = option_f64(min);
+                    let max_tok = option_f64(max);
+                    checks.push(quote! {
+                        ::cognis_core::tools::validation::check_range(
+                            #field_name,
+                            (*__v) as f64,
+                            #min_tok,
+                            #max_tok,
+                        )?;
+                    });
+                }
+                Validator::Length { min, max } => {
+                    let min_tok = option_usize(min);
+                    let max_tok = option_usize(max);
+                    let len_expr = match type_kind {
+                        TypeKind::String => {
+                            quote! { ::core::primitive::str::chars(__v.as_str()).count() }
+                        }
+                        TypeKind::Vec => quote! { __v.len() },
+                        TypeKind::Other => {
+                            // Fallback: assume it has a `.len()` method.
+                            quote! { __v.len() }
+                        }
+                    };
+                    checks.push(quote! {
+                        ::cognis_core::tools::validation::check_length(
+                            #field_name,
+                            #len_expr,
+                            #min_tok,
+                            #max_tok,
+                        )?;
+                    });
+                }
+                Validator::Pattern(p) => {
+                    let static_ident = format_ident!(
+                        "__{}_{}_PATTERN_{}",
+                        struct_ident.to_string().to_uppercase(),
+                        field_name.to_uppercase(),
+                        i
+                    );
+                    let accessor_ident = format_ident!(
+                        "__{}_{}_pattern_{}",
+                        struct_ident.to_string().to_lowercase(),
+                        field_name.to_lowercase(),
+                        i
+                    );
+                    let pat_lit = p.as_str();
+                    pattern_statics.push(quote! {
+                        static #static_ident:
+                            ::std::sync::OnceLock<
+                                ::cognis_core::tools::validation::__regex::Regex,
+                            > = ::std::sync::OnceLock::new();
+                        #[allow(non_snake_case)]
+                        fn #accessor_ident()
+                            -> &'static ::cognis_core::tools::validation::__regex::Regex
+                        {
+                            #static_ident.get_or_init(|| {
+                                ::cognis_core::tools::validation::__regex::Regex::new(#pat_lit)
+                                    .expect("regex validated at macro time")
+                            })
+                        }
+                    });
+                    checks.push(quote! {
+                        ::cognis_core::tools::validation::check_pattern(
+                            #field_name,
+                            __v.as_str(),
+                            #accessor_ident(),
+                        )?;
+                    });
+                }
+                Validator::EnumValues(values) => {
+                    let values_tok = values.iter().map(|s| quote! { #s });
+                    checks.push(quote! {
+                        ::cognis_core::tools::validation::check_enum(
+                            #field_name,
+                            __v.as_str(),
+                            &[#(#values_tok),*],
+                        )?;
+                    });
+                }
+                Validator::Format(fmt) => {
+                    let fmt_variant = match fmt {
+                        schema_attr::FormatName::Email => quote! { Email },
+                        schema_attr::FormatName::Uri => quote! { Uri },
+                        schema_attr::FormatName::Uuid => quote! { Uuid },
+                        schema_attr::FormatName::DateTime => quote! { DateTime },
+                        schema_attr::FormatName::Ipv4 => quote! { Ipv4 },
+                        schema_attr::FormatName::Ipv6 => quote! { Ipv6 },
+                    };
+                    checks.push(quote! {
+                        ::cognis_core::tools::validation::check_format(
+                            #field_name,
+                            __v.as_str(),
+                            ::cognis_core::tools::validation::Format::#fmt_variant,
+                        )?;
+                    });
+                }
+                Validator::Items(_) => {
+                    // Items-nested validators only contribute to the JSON
+                    // schema for now — runtime iteration over Vec items
+                    // is not implemented in v1.
+                }
+            }
+        }
+
+        if checks.is_empty() {
+            continue;
+        }
+
+        if spec.is_option {
+            validator_stmts.push(quote! {
+                if let Some(ref __v) = self.#ident {
+                    #(#checks)*
+                }
+            });
+        } else {
+            validator_stmts.push(quote! {
+                {
+                    let __v = &self.#ident;
+                    #(#checks)*
+                }
+            });
+        }
+    }
+
+    Ok(quote! {
+        #(#pattern_statics)*
+        impl ::cognis_core::tools::validation::ValidateArgs for #struct_ident {
+            fn validate(&self) -> ::cognis_core::error::Result<()> {
+                #(#validator_stmts)*
+                Ok(())
+            }
+        }
+    })
+}
+
+fn emit_body_fn(body_fn_ident: &syn::Ident, item_fn: &ItemFn) -> syn::Result<TokenStream2> {
+    // Render the function with a renamed ident. Preserve its signature
+    // (including async, return type) and body. Arg attributes (docs,
+    // #[schema]) are stripped — they're meaningless on the body fn and
+    // would trigger unused-attribute warnings.
+    let vis = &item_fn.vis;
+    let mut sig = item_fn.sig.clone();
+    sig.ident = body_fn_ident.clone();
+    for input in sig.inputs.iter_mut() {
+        if let FnArg::Typed(pt) = input {
+            pt.attrs.clear();
+        }
+    }
+    let block = &item_fn.block;
+    Ok(quote! {
+        #[allow(non_snake_case, dead_code)]
+        #vis #sig #block
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_base_tool_impl_standalone(
+    _vis: &Visibility,
+    struct_ident: &syn::Ident,
+    args_struct_ident: &syn::Ident,
+    body_fn_ident: &syn::Ident,
+    tool_name: &str,
+    description: &str,
+    return_direct: bool,
+    specs: &[ArgSpec],
+) -> TokenStream2 {
+    let field_idents: Vec<_> = specs.iter().map(|s| &s.ident).collect();
+    let return_direct_method = if return_direct {
+        Some(quote! {
+            fn return_direct(&self) -> bool { true }
+        })
+    } else {
+        None
+    };
+
+    quote! {
+        #[::async_trait::async_trait]
+        impl ::cognis_core::tools::BaseTool for #struct_ident {
+            fn name(&self) -> &str { #tool_name }
+            fn description(&self) -> &str { #description }
+            fn args_schema(&self) -> ::core::option::Option<::serde_json::Value> {
+                ::core::option::Option::Some(#args_struct_ident::json_schema())
+            }
+            #return_direct_method
+            async fn _run(
+                &self,
+                input: ::cognis_core::tools::ToolInput,
+            ) -> ::cognis_core::error::Result<::cognis_core::tools::ToolOutput> {
+                let __json = input.into_json();
+                let __args: #args_struct_ident = ::serde_json::from_value(__json)
+                    .map_err(|e| ::cognis_core::error::CognisError::ToolValidationError(
+                        e.to_string(),
+                    ))?;
+                <#args_struct_ident as ::cognis_core::tools::validation::ValidateArgs>::validate(&__args)?;
+                #body_fn_ident(#(__args.#field_idents),*).await
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_base_tool_impl_method(
+    struct_path: &TokenStream2,
+    args_struct_ident: &syn::Ident,
+    method_ident: &syn::Ident,
+    tool_name: &str,
+    description: &str,
+    return_direct: bool,
+    specs: &[ArgSpec],
+) -> TokenStream2 {
+    let field_idents: Vec<_> = specs.iter().map(|s| &s.ident).collect();
+    let return_direct_method = if return_direct {
+        Some(quote! {
+            fn return_direct(&self) -> bool { true }
+        })
+    } else {
+        None
+    };
+
+    quote! {
+        #[::async_trait::async_trait]
+        impl ::cognis_core::tools::BaseTool for #struct_path {
+            fn name(&self) -> &str { #tool_name }
+            fn description(&self) -> &str { #description }
+            fn args_schema(&self) -> ::core::option::Option<::serde_json::Value> {
+                ::core::option::Option::Some(#args_struct_ident::json_schema())
+            }
+            #return_direct_method
+            async fn _run(
+                &self,
+                input: ::cognis_core::tools::ToolInput,
+            ) -> ::cognis_core::error::Result<::cognis_core::tools::ToolOutput> {
+                let __json = input.into_json();
+                let __args: #args_struct_ident = ::serde_json::from_value(__json)
+                    .map_err(|e| ::cognis_core::error::CognisError::ToolValidationError(
+                        e.to_string(),
+                    ))?;
+                <#args_struct_ident as ::cognis_core::tools::validation::ValidateArgs>::validate(&__args)?;
+                self.#method_ident(#(__args.#field_idents),*).await
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+enum TypeKind {
+    String,
+    Vec,
+    Other,
+}
+
+fn classify_type(ty: &Type) -> TypeKind {
+    if let Type::Path(tp) = ty {
+        if let Some(last) = tp.path.segments.last() {
+            match last.ident.to_string().as_str() {
+                "String" => return TypeKind::String,
+                "Vec" => return TypeKind::Vec,
+                _ => {}
+            }
+        }
+    }
+    TypeKind::Other
+}
+
+fn option_f64(v: &Option<f64>) -> TokenStream2 {
+    match v {
+        Some(x) => quote! { ::core::option::Option::Some(#x) },
+        None => quote! { ::core::option::Option::None },
+    }
+}
+
+fn option_usize(v: &Option<usize>) -> TokenStream2 {
+    match v {
+        Some(x) => quote! { ::core::option::Option::Some(#x) },
+        None => quote! { ::core::option::Option::None },
+    }
+}
+
+fn pascal_case(s: &str) -> String {
+    let mut out = String::new();
+    let mut upper_next = true;
+    for ch in s.chars() {
+        if ch == '_' {
+            upper_next = true;
+        } else if upper_next {
+            out.extend(ch.to_uppercase());
+            upper_next = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+fn pascal_case_ident(s: &str, span: Span) -> syn::Ident {
+    syn::Ident::new(&pascal_case(s), span)
+}
+
+/// Collect consecutive `#[doc = "..."]` attrs into one description, stripping
+/// a single leading space (rustdoc's convention).
+fn collect_doc_comment(attrs: &[syn::Attribute]) -> Option<String> {
+    let lines: Vec<String> = attrs
+        .iter()
+        .filter_map(|a| {
+            if !a.path().is_ident("doc") {
+                return None;
+            }
+            if let Meta::NameValue(nv) = &a.meta {
+                if let Expr::Lit(el) = &nv.value {
+                    if let Lit::Str(s) = &el.lit {
+                        let raw = s.value();
+                        // Rustdoc prepends a space — strip one if present.
+                        let trimmed = raw.strip_prefix(' ').unwrap_or(&raw).to_string();
+                        return Some(trimmed);
+                    }
+                }
+            }
+            None
+        })
+        .collect();
+    if lines.is_empty() {
+        return None;
+    }
+    Some(lines.join(" ").trim().to_string())
+}
+
+// Silence `unused` warnings on helper imports that only some code paths use.
+#[allow(dead_code)]
+fn _touch_spans(t: &dyn ToTokens) -> Span {
+    t.span()
 }

--- a/crates/cognis-macros/src/tool_attr.rs
+++ b/crates/cognis-macros/src/tool_attr.rs
@@ -255,18 +255,22 @@ fn expand_impl(args: ToolArgs, item_impl: ItemImpl) -> syn::Result<TokenStream2>
         &arg_specs,
     );
 
-    // Strip #[schema(...)] (and helper-macro-only attrs) from the preserved
-    // impl block's method parameters. Those attrs were meaningful to *this*
-    // macro — they've already been consumed into `arg_specs`. Leaving them
-    // on the inherent method emits "cannot find attribute `schema`" because
-    // no derive is in scope there.
+    // Strip helper attributes from the preserved impl block's method
+    // parameters. Both `#[schema(...)]` and `///` doc comments were
+    // already captured into `arg_specs`, and leaving them in place on
+    // the regenerated fn parameters would be a hard error:
+    //
+    // - `#[schema]` → "cannot find attribute `schema`" (no derive in scope)
+    // - `///` (doc) → "allow, cfg, ... are the only allowed built-in
+    //   attributes in function parameters" on stable Rust
     let mut cleaned_impl = item_impl.clone();
     for item in cleaned_impl.items.iter_mut() {
         if let ImplItem::Fn(m) = item {
             if m.sig.asyncness.is_some() {
                 for input in m.sig.inputs.iter_mut() {
                     if let FnArg::Typed(pt) = input {
-                        pt.attrs.retain(|a| !a.path().is_ident("schema"));
+                        pt.attrs
+                            .retain(|a| !a.path().is_ident("schema") && !a.path().is_ident("doc"));
                     }
                 }
             }

--- a/crates/cognis/src/lib.rs
+++ b/crates/cognis/src/lib.rs
@@ -66,3 +66,8 @@ pub mod vectorstores;
 
 // Re-export core for convenience
 pub use cognis_core as core;
+
+/// `#[cognis::tool]` — attribute macro that generates a `BaseTool`
+/// implementation from an `async fn` (or an `impl` block containing one).
+/// See [`cognis_core::tool`] for the full documentation.
+pub use cognis_core::tool;

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -349,3 +349,11 @@ path = "../../examples/chains/typed_runnable_demo.rs"
 [[example]]
 name = "streaming_agent_events"
 path = "../../examples/agents/streaming_agent_events.rs"
+
+[[example]]
+name = "tool_typed_search"
+path = "../../examples/tools/typed_search.rs"
+
+[[example]]
+name = "tool_stateful_http"
+path = "../../examples/tools/stateful_http.rs"

--- a/examples/tools/stateful_http.rs
+++ b/examples/tools/stateful_http.rs
@@ -1,0 +1,84 @@
+//! `#[cognis::tool]` on an `impl` block — a stateful tool that keeps
+//! configuration (a default target language) in its receiver so the
+//! per-call args can be minimal.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example tool_stateful_http -p cognis-examples
+//! ```
+
+use cognis_core::error::Result;
+use cognis_core::tool;
+use cognis_core::tools::{BaseTool, ToolInput, ToolOutput};
+use serde_json::json;
+use std::collections::HashMap;
+
+pub struct Translator {
+    default_target: String,
+}
+
+impl Translator {
+    /// Construct with a fallback target language used when callers omit
+    /// the `target` argument.
+    pub fn new(default_target: impl Into<String>) -> Self {
+        Self {
+            default_target: default_target.into(),
+        }
+    }
+}
+
+#[tool(name = "translate")]
+impl Translator {
+    /// Translate text to a target language. Mock implementation — a real
+    /// one would call an HTTP service using credentials on `self`.
+    async fn translate(
+        &self,
+        /// Source text.
+        #[schema(length(min = 1))]
+        text: String,
+        /// Target language code. Defaults to the translator's configured
+        /// target when omitted.
+        #[schema(enum_values("en", "fr", "es", "de", "ja"))]
+        target: Option<String>,
+    ) -> Result<ToolOutput> {
+        let target = target.unwrap_or_else(|| self.default_target.clone());
+        Ok(ToolOutput::Content(json!({
+            "text": text,
+            "target": target,
+            "translated": format!("[{target}] {text}"),
+        })))
+    }
+}
+
+#[tokio::main]
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let tool = Translator::new("fr");
+
+    println!("tool name: {}", tool.name());
+    println!("tool description: {}", tool.description());
+    println!(
+        "schema:\n{}",
+        serde_json::to_string_pretty(&tool.args_schema().unwrap())?
+    );
+
+    // Call with target explicitly set.
+    let mut args = HashMap::new();
+    args.insert("text".to_string(), json!("hello, world"));
+    args.insert("target".to_string(), json!("es"));
+    if let ToolOutput::Content(v) = tool._run(ToolInput::Structured(args)).await? {
+        println!("\nexplicit target:\n{}", serde_json::to_string_pretty(&v)?);
+    }
+
+    // Call with target omitted — falls back to the configured default.
+    let mut args = HashMap::new();
+    args.insert("text".to_string(), json!("hello, world"));
+    if let ToolOutput::Content(v) = tool._run(ToolInput::Structured(args)).await? {
+        println!(
+            "\ndefault target (from receiver state):\n{}",
+            serde_json::to_string_pretty(&v)?
+        );
+    }
+
+    Ok(())
+}

--- a/examples/tools/typed_search.rs
+++ b/examples/tools/typed_search.rs
@@ -1,0 +1,71 @@
+//! `#[cognis::tool]` on a standalone `async fn`, using schema
+//! validators on the fn parameters.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example tool_typed_search -p cognis-examples
+//! ```
+
+use cognis_core::error::Result;
+use cognis_core::tool;
+use cognis_core::tools::{BaseTool, ToolInput, ToolOutput};
+use serde_json::json;
+use std::collections::HashMap;
+
+/// Search a mock knowledge base. The generated schema surfaces `query`,
+/// `limit`, and their constraints to any LLM that consults it.
+#[tool(name = "search_kb")]
+async fn search_kb(
+    /// The search query — must be 1-200 chars.
+    #[schema(length(min = 1, max = 200))]
+    query: String,
+    /// Max results to return (1-50).
+    #[schema(range(min = 1, max = 50))]
+    limit: Option<u32>,
+) -> Result<ToolOutput> {
+    let limit = limit.unwrap_or(3);
+    let items: Vec<_> = (1..=limit)
+        .map(|i| {
+            json!({
+                "id": i,
+                "snippet": format!("Doc #{i} mentions `{query}`"),
+            })
+        })
+        .collect();
+    Ok(ToolOutput::Content(
+        json!({ "query": query, "results": items }),
+    ))
+}
+
+#[tokio::main]
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let tool = SearchKb;
+
+    println!("tool name: {}", tool.name());
+    println!("tool description: {}", tool.description());
+    println!(
+        "schema:\n{}",
+        serde_json::to_string_pretty(&tool.args_schema().unwrap())?
+    );
+
+    let mut args = HashMap::new();
+    args.insert("query".to_string(), json!("typed tool inputs"));
+    args.insert("limit".to_string(), json!(2));
+
+    let out = tool._run(ToolInput::Structured(args)).await?;
+    if let ToolOutput::Content(v) = out {
+        println!("\nresult:\n{}", serde_json::to_string_pretty(&v)?);
+    }
+
+    // Deliberately trip a validator to show the error path.
+    let mut bad = HashMap::new();
+    bad.insert("query".to_string(), json!("x"));
+    bad.insert("limit".to_string(), json!(100));
+    match tool._run(ToolInput::Structured(bad)).await {
+        Ok(_) => unreachable!("validator should reject limit=100"),
+        Err(e) => println!("\nexpected validation error: {e}"),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Final PR closing #9 — implements the `#[cognis::tool]` attribute proc-macro on top of the PR 1 foundation that already shipped. Bundles the last cubic P2 finding, the full attribute macro (both forms), runnable examples, and `trybuild` UI tests for compile-time rejections.

### 1. P2 cubic carry-over (identified by cubic)

`range(max = 18446744073709551615)` was rejected because the int-parse path went through `i64`. Changed to `base10_parse::<f64>()` — JSON Schema `minimum`/`maximum` are numeric anyway, and f64 is the right target. One-line fix + regression test.

### 2. `#[cognis::tool]` attribute macro (core feature)

Two forms, both supported:

**Standalone async fn:**
\`\`\`rust
use cognis::tool;
use cognis_core::tools::ToolOutput;

/// Search the knowledge base.
#[tool(name = \"search_kb\")]
async fn search_kb(
    #[schema(length(min = 1, max = 200))] query: String,
    #[schema(range(min = 1, max = 50))] limit: Option<u32>,
) -> cognis_core::error::Result<ToolOutput> { /* ... */ }
\`\`\`

Generates a `SearchKb` unit struct implementing `BaseTool`, a hidden args struct deriving `Deserialize + JsonSchema`, a `ValidateArgs` impl that calls into the PR 1 `check_*` helpers, and a body renamed to `__search_kb_body`.

**Impl-block form (stateful tools):**
\`\`\`rust
pub struct Translator { default_target: String }

#[tool(name = \"translate\")]
impl Translator {
    /// Translate text.
    async fn translate(
        &self,
        #[schema(length(min = 1))] text: String,
        #[schema(enum_values(\"en\",\"fr\",\"es\",\"de\",\"ja\"))] target: Option<String>,
    ) -> cognis_core::error::Result<ToolOutput> { /* uses self */ }
}
\`\`\`

The \`#[tool]\` wraps the whole \`impl\` block. Rules: inherent impl only, exactly one \`async fn\`, \`&self\` receiver, no generics. Other methods on the impl (constructors, helpers) pass through unchanged. A \`BaseTool\` impl is emitted at outer module scope so \`Translator\` becomes the tool directly.

**Validators wired through from PR 1:**
- \`range(min, max)\` → \`minimum\`/\`maximum\` + \`check_range\`
- \`length(min, max)\` → \`minLength\`/\`maxLength\` (String) or \`minItems\`/\`maxItems\` (Vec) + \`check_length\` with \`.chars().count()\` for strings
- \`pattern(\"regex\")\` → \`pattern\` + \`check_pattern\` (regex compiled once via \`OnceLock\`, validity checked at macro-expansion time)
- \`enum_values(\"a\",\"b\")\` → \`enum\` + \`check_enum\`
- \`format(\"email\"|\"uuid\"|\"ipv4\"|\"ipv6\"|\"uri\"|\"date-time\")\` → \`format\` + \`check_format\` (stdlib parsers for IP types, regex for email/uuid, passthrough for uri/date-time)

**Validation flow:** \`BaseTool::_run\` deserializes the tool args, runs \`ValidateArgs::validate(&args)\` (emitting \`CognisError::ToolValidationError\` on violation), then invokes the user body. The existing \`BaseTool::run\` → \`handle_validation_error()\` hook surfaces validator messages to the LLM for self-correction.

### 3. Runnable examples

- \`examples/tools/typed_search.rs\` — standalone-fn example with \`length\` + \`range\` validators; prints schema and deliberately trips the range check to show the \`ToolValidationError\` path.
- \`examples/tools/stateful_http.rs\` — impl-form with receiver state demonstrating configured defaults + \`enum_values\`.

Both runnable via \`cargo run --example tool_typed_search -p cognis-examples --features cognis/all-providers\` etc.

### 4. Compile-error tests (\`trybuild\`)

4 UI fixtures in \`crates/cognis-core/tests/ui/tool_attr/\` locking rejections for:
- Non-async fn
- Reference arg (\`&str\`)
- \`&mut self\` receiver on impl form
- Multiple \`async fn\`s in a \`#[tool]\` impl

### 5. Migration scan (PR 3)

\`rg 'input_schema.*json!|args_schema.*json!' crates/\` found 2 hits — both are non-tool uses (\`StateGraph\` input-schema + Anthropic API tool-call serializer). Not migrated. ~30 in-repo \`impl BaseTool for …\` blocks are framework primitives (\`SimpleTool\`, \`StructuredTool\`, \`FunctionTool\`, test fakes) that are intentionally hand-rolled — \`#[cognis::tool]\` is a user-facing convenience, not a replacement for them.

## Scope

- 6 commits, 1 new file in the macro crate (\`tool_attr.rs\` ~620 lines), 2 new examples, 3 new integration test suites (10 standalone + 7 impl + 4 trybuild = 21 new tests)
- New re-exports: \`cognis_core::tool\`, \`cognis::tool\`
- New hidden re-export: \`cognis_core::tools::validation::__regex\` (for the \`pattern(\"…\")\` validator, so users don't need to add \`regex\` to their deps)
- \`trybuild\` added as dev-dep on \`cognis-core\`

## Test Plan

- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --workspace --features all-providers -- -D warnings\`
- [x] \`cargo +1.95 clippy --workspace --features all-providers -- -D warnings\` (matches CI)
- [x] \`cargo test --workspace\` — 0 failures
- [x] \`cargo run --example tool_typed_search -p cognis-examples --features cognis/all-providers\` — prints schema + validation error as expected
- [x] \`cargo run --example tool_stateful_http -p cognis-examples --features cognis/all-providers\` — invokes stateful tool with/without optional target
- [ ] CI green on PR

Closes #9.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements `#[cognis::tool]` to generate typed, schema-validated tools from async functions (standalone and stateful). Adds examples and compile-error tests, accepts large numeric `range(...)` bounds, and clarifies docs that `#[tool]` is framework-coupled while derives are not.

- **New Features**
  - `#[cognis::tool]` on an async fn or an inherent `impl` with one `async fn (&self)`; no generics or trait impls.
  - Emits a unit tool struct (standalone) or a `BaseTool` impl on the receiver (impl form); creates a hidden args struct (`Deserialize` + `JsonSchema`) and a `ValidateArgs` impl from `#[schema(...)]` validators (`range`, `length`, `pattern`, `enum_values`, `format`), with regexes precompiled via `cognis_core::tools::validation::__regex`.
  - `_run` flow: deserialize JSON → `validate()` → call the user body. Re-exports: `cognis_core::tool` and `cognis::tool`.
  - Examples: `tool_typed_search` and `tool_stateful_http`. UI tests (`trybuild`) cover non-async, ref args, `&mut self`, and multiple async methods.
  - Docs: `cognis-macros` clarifies that derives (`JsonSchema`/`ToolSchema`/`GraphState`) are framework-independent, while `#[tool]` references `cognis_core`.

- **Bug Fixes**
  - Parse `range(...)` integers as `f64` to accept very large bounds (e.g., `u64::MAX`).
  - Strip doc comments from impl-form method parameters to avoid stable Rust param-attr errors.

<sup>Written for commit 33a5446bd242489efa56a03720f814b2e9ea17ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

