### PR TITLE
feat: cancellation token support on AgentExecutor (closes #8)

### DIFF
--- a/crates/cognis-core/src/callbacks/base.rs
+++ b/crates/cognis-core/src/callbacks/base.rs
@@ -199,6 +199,19 @@ pub trait CallbackHandler: Send + Sync {
         Ok(())
     }
 
+    /// Called when an agent run is cancelled via `CancellationToken`.
+    ///
+    /// The default implementation is a no-op so existing handlers remain
+    /// source-compatible.
+    async fn on_agent_cancelled(
+        &self,
+        _reason: &str,
+        _run_id: Uuid,
+        _parent_run_id: Option<Uuid>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
     async fn on_text(
         &self,
         _text: &str,

--- a/crates/cognis-core/src/callbacks/manager.rs
+++ b/crates/cognis-core/src/callbacks/manager.rs
@@ -293,6 +293,18 @@ impl CallbackManager {
         Ok(())
     }
 
+    /// Dispatch an agent-cancellation event to every non-ignoring handler.
+    pub async fn on_agent_cancelled(&self, reason: &str, run_id: Uuid) -> Result<()> {
+        for handler in &self.handlers {
+            if !handler.ignore_agent() {
+                handler
+                    .on_agent_cancelled(reason, run_id, self.parent_run_id)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
     pub async fn on_text(&self, text: &str, run_id: Uuid) -> Result<()> {
         for handler in &self.handlers {
             handler.on_text(text, run_id, self.parent_run_id).await?;

--- a/crates/cognis-core/src/cancellation.rs
+++ b/crates/cognis-core/src/cancellation.rs
@@ -1,0 +1,218 @@
+//! Cooperative cancellation primitives.
+//!
+//! Provides a [`CancellationToken`] that can be cloned across tasks and
+//! signalled to request cooperative cancellation of long-running work
+//! (agent loops, LLM calls, tool executions, graph execution, …).
+//!
+//! The token pairs an atomic boolean with a [`tokio::sync::Notify`] so
+//! that consumers can either poll [`CancellationToken::is_cancelled`] at
+//! loop boundaries or `.await` [`CancellationToken::cancelled`] in a
+//! `tokio::select!` arm to interleave cancellation with other I/O.
+//!
+//! # Example
+//!
+//! ```
+//! use cognis_core::CancellationToken;
+//!
+//! # async fn example() {
+//! let token = CancellationToken::new();
+//! let clone = token.clone();
+//!
+//! tokio::spawn(async move {
+//!     clone.cancel();
+//! });
+//!
+//! tokio::select! {
+//!     _ = token.cancelled() => {
+//!         // cooperative shutdown path
+//!     }
+//!     _ = async { /* do work */ } => {}
+//! }
+//! # }
+//! ```
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use tokio::sync::Notify;
+
+/// Cooperative cancellation token.
+///
+/// Cloning a token shares the cancellation state. Signalling cancellation
+/// on any clone wakes every task that is awaiting [`cancelled`](Self::cancelled)
+/// on any clone.
+#[derive(Debug, Clone)]
+pub struct CancellationToken {
+    cancelled: Arc<AtomicBool>,
+    notify: Arc<Notify>,
+}
+
+impl CancellationToken {
+    /// Create a new, uncancelled token.
+    pub fn new() -> Self {
+        Self {
+            cancelled: Arc::new(AtomicBool::new(false)),
+            notify: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Create a token that is already cancelled.
+    ///
+    /// Useful as a sentinel in tests and for pre-cancelled configs where
+    /// the work should abort before it begins.
+    pub fn cancelled_now() -> Self {
+        let t = Self::new();
+        t.cancel();
+        t
+    }
+
+    /// Signal cancellation.
+    ///
+    /// All current and future awaiters of [`cancelled`](Self::cancelled)
+    /// observe this immediately. Calling `cancel` multiple times is a no-op
+    /// after the first call.
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::SeqCst);
+        self.notify.notify_waiters();
+    }
+
+    /// Whether cancellation has been requested.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::SeqCst)
+    }
+
+    /// Returns a future that resolves when cancellation is signalled.
+    ///
+    /// If the token is already cancelled the future resolves immediately.
+    pub async fn cancelled(&self) {
+        if self.is_cancelled() {
+            return;
+        }
+        // Wait for notification. Re-check after wake since we might get
+        // spurious wakes or the token could be cancelled between check
+        // and wait.
+        loop {
+            self.notify.notified().await;
+            if self.is_cancelled() {
+                return;
+            }
+        }
+    }
+
+    /// Reset the token so it can be reused.
+    ///
+    /// Note that there is no synchronisation between `reset` and any
+    /// concurrent waiters; reset is intended for single-threaded reuse
+    /// patterns (e.g. reusing a token across successive agent turns).
+    pub fn reset(&self) {
+        self.cancelled.store(false, Ordering::SeqCst);
+    }
+
+    /// Return `Err(CognisError::Cancelled(reason))` when the token has been
+    /// cancelled, otherwise `Ok(())`.
+    ///
+    /// Convenience helper for loop-boundary checks in synchronous code paths
+    /// where a full `tokio::select!` would be overkill.
+    pub fn check(&self, reason: &str) -> crate::error::Result<()> {
+        if self.is_cancelled() {
+            Err(crate::error::CognisError::Cancelled(reason.to_string()))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Default for CancellationToken {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn initial_state_is_not_cancelled() {
+        let token = CancellationToken::new();
+        assert!(!token.is_cancelled());
+    }
+
+    #[test]
+    fn cancel_sets_cancelled() {
+        let token = CancellationToken::new();
+        token.cancel();
+        assert!(token.is_cancelled());
+    }
+
+    #[test]
+    fn reset_clears_cancellation() {
+        let token = CancellationToken::new();
+        token.cancel();
+        assert!(token.is_cancelled());
+        token.reset();
+        assert!(!token.is_cancelled());
+    }
+
+    #[test]
+    fn clones_share_state() {
+        let token = CancellationToken::new();
+        let token2 = token.clone();
+        token.cancel();
+        assert!(token2.is_cancelled());
+    }
+
+    #[test]
+    fn default_is_not_cancelled() {
+        let token = CancellationToken::default();
+        assert!(!token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn cancelled_future_resolves_when_signalled() {
+        let token = CancellationToken::new();
+        let token2 = token.clone();
+
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            token2.cancel();
+        });
+
+        tokio::time::timeout(Duration::from_secs(2), token.cancelled())
+            .await
+            .expect("cancelled() should resolve when token is cancelled");
+    }
+
+    #[tokio::test]
+    async fn cancelled_future_resolves_immediately_when_already_cancelled() {
+        let token = CancellationToken::new();
+        token.cancel();
+        tokio::time::timeout(Duration::from_millis(50), token.cancelled())
+            .await
+            .expect("cancelled() should resolve immediately when already cancelled");
+    }
+
+    #[test]
+    fn cancelled_now_constructs_pre_cancelled() {
+        let token = CancellationToken::cancelled_now();
+        assert!(token.is_cancelled());
+    }
+
+    #[test]
+    fn check_method_returns_ok_when_not_cancelled() {
+        let token = CancellationToken::new();
+        assert!(token.check("unused").is_ok());
+    }
+
+    #[test]
+    fn check_method_returns_err_when_cancelled() {
+        let token = CancellationToken::new();
+        token.cancel();
+        let err = token.check("stop now").unwrap_err();
+        match err {
+            crate::error::CognisError::Cancelled(reason) => assert_eq!(reason, "stop now"),
+            other => panic!("expected Cancelled, got {other:?}"),
+        }
+    }
+}

--- a/crates/cognis-core/src/error.rs
+++ b/crates/cognis-core/src/error.rs
@@ -72,6 +72,9 @@ pub enum CognisError {
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
 
+    #[error("Cancelled: {0}")]
+    Cancelled(String),
+
     #[error("{0}")]
     Other(String),
 }

--- a/crates/cognis-core/src/lib.rs
+++ b/crates/cognis-core/src/lib.rs
@@ -35,6 +35,7 @@ pub use cognis_macros::{tool, JsonSchema, ToolSchema};
 pub mod agents;
 pub mod caches;
 pub mod callbacks;
+pub mod cancellation;
 pub mod chat_history;
 pub mod chat_loaders;
 pub mod chat_sessions;
@@ -68,3 +69,5 @@ pub mod tracing;
 pub mod types;
 pub mod utils;
 pub mod vectorstores;
+
+pub use cancellation::CancellationToken;

--- a/crates/cognis-core/src/runnables/config.rs
+++ b/crates/cognis-core/src/runnables/config.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::callbacks::CallbackHandler;
+use crate::cancellation::CancellationToken;
 
 /// Configuration for a runnable invocation.
 #[derive(Clone)]
@@ -17,6 +18,13 @@ pub struct RunnableConfig {
     pub configurable: HashMap<String, Value>,
     pub run_id: Option<Uuid>,
     pub callbacks: Vec<Arc<dyn CallbackHandler>>,
+    /// Optional cooperative cancellation token.
+    ///
+    /// When set, runnables (and the callers that compose them) may observe
+    /// the token to abort in-flight work. Specifically, `AgentExecutor::run`
+    /// honours the token at iteration boundaries and wraps the model / tool
+    /// calls in a `tokio::select!` against `token.cancelled()`.
+    pub cancellation_token: Option<CancellationToken>,
 }
 
 impl Default for RunnableConfig {
@@ -30,6 +38,7 @@ impl Default for RunnableConfig {
             configurable: HashMap::new(),
             run_id: None,
             callbacks: Vec::new(),
+            cancellation_token: None,
         }
     }
 }
@@ -45,6 +54,7 @@ impl std::fmt::Debug for RunnableConfig {
             .field("configurable", &self.configurable)
             .field("run_id", &self.run_id)
             .field("callbacks", &format!("[{} handlers]", self.callbacks.len()))
+            .field("cancellation_token", &self.cancellation_token)
             .finish()
     }
 }
@@ -69,6 +79,7 @@ pub struct ConfigPatch {
     recursion_limit: Option<usize>,
     configurable: Option<HashMap<String, Value>>,
     run_id: Option<Uuid>,
+    cancellation_token: Option<CancellationToken>,
 }
 
 impl ConfigPatch {
@@ -82,6 +93,7 @@ impl ConfigPatch {
             recursion_limit: None,
             configurable: None,
             run_id: None,
+            cancellation_token: None,
         }
     }
 
@@ -117,6 +129,10 @@ impl ConfigPatch {
         self.run_id = Some(id);
         self
     }
+    pub fn with_cancellation_token(mut self, token: CancellationToken) -> Self {
+        self.cancellation_token = Some(token);
+        self
+    }
 
     /// Apply this patch to a config, returning a new config.
     pub fn apply(&self, config: &RunnableConfig) -> RunnableConfig {
@@ -138,6 +154,10 @@ impl ConfigPatch {
                 .clone()
                 .unwrap_or_else(|| config.configurable.clone()),
             run_id: self.run_id.or(config.run_id),
+            cancellation_token: self
+                .cancellation_token
+                .clone()
+                .or_else(|| config.cancellation_token.clone()),
         }
     }
 }
@@ -193,6 +213,10 @@ pub fn merge_configs(base: &RunnableConfig, overlay: &RunnableConfig) -> Runnabl
         configurable,
         run_id: overlay.run_id.or(base.run_id),
         callbacks,
+        cancellation_token: overlay
+            .cancellation_token
+            .clone()
+            .or_else(|| base.cancellation_token.clone()),
     }
 }
 

--- a/crates/cognis-core/src/runnables/fallbacks.rs
+++ b/crates/cognis-core/src/runnables/fallbacks.rs
@@ -56,6 +56,7 @@ fn error_variant_name(err: &CognisError) -> &'static str {
         CognisError::TypeMismatch { .. } => "TypeMismatch",
         CognisError::HttpError { .. } => "HttpError",
         CognisError::IoError(_) => "IoError",
+        CognisError::Cancelled(_) => "Cancelled",
         CognisError::Other(_) => "Other",
     }
 }

--- a/crates/cognis/src/agents/executor.rs
+++ b/crates/cognis/src/agents/executor.rs
@@ -33,6 +33,7 @@ use cognis_core::runnables::base::Runnable;
 use cognis_core::runnables::config::RunnableConfig;
 use cognis_core::tools::base::{apply_error_handler, BaseTool};
 use cognis_core::tools::types::{ToolInput, ToolOutput};
+use cognis_core::CancellationToken;
 use uuid::Uuid;
 
 #[allow(deprecated)]
@@ -286,7 +287,37 @@ impl AgentExecutor {
     ///    `early_stopping_method`.
     ///
     /// Callback events are fired throughout the loop for observability.
+    ///
+    /// This is a thin wrapper around [`run_with_cancel`](Self::run_with_cancel)
+    /// using a fresh (never-cancelled) token, preserving the historical
+    /// signature.
     pub async fn run(&self, initial_messages: &[Message]) -> Result<AgentResult> {
+        self.run_with_cancel(initial_messages, CancellationToken::new())
+            .await
+    }
+
+    /// Run the agent loop to completion, honouring a [`CancellationToken`].
+    ///
+    /// Identical to [`run`](Self::run) except that the caller can signal
+    /// cooperative cancellation through `cancel`. The executor honours the
+    /// token at three points:
+    ///
+    /// * at every iteration boundary, via [`CancellationToken::check`];
+    /// * around the model call, via `tokio::select!` — dropping the in-flight
+    ///   `_generate` future (and therefore any `reqwest` request) as soon as
+    ///   the token fires;
+    /// * around each tool execution, in the same fashion. Tools that want
+    ///   tool-specific cleanup can read the token from
+    ///   `RunnableConfig::cancellation_token`.
+    ///
+    /// On cancellation the executor emits `on_agent_cancelled` on every
+    /// configured callback handler and returns
+    /// [`CognisError::Cancelled`](cognis_core::error::CognisError::Cancelled).
+    pub async fn run_with_cancel(
+        &self,
+        initial_messages: &[Message],
+        cancel: CancellationToken,
+    ) -> Result<AgentResult> {
         let cb = CallbackManager::new(self.callbacks.clone(), None);
         let chain_run_id = Uuid::new_v4();
 
@@ -329,13 +360,36 @@ impl AgentExecutor {
                 }
             }
 
+            // Check cancellation at the iteration boundary. Covers both the
+            // pre-cancelled case and the case where a tool just completed and
+            // the client has since fired the token.
+            if cancel.is_cancelled() {
+                let reason = "cancelled between agent iterations";
+                let _ = cb.on_agent_cancelled(reason, chain_run_id).await;
+                let _ = cb.on_chain_error(reason, chain_run_id).await;
+                return Err(CognisError::Cancelled(reason.into()));
+            }
+
             let llm_run_id = Uuid::new_v4();
             let serialized_llm = serde_json::json!({"name": self.model.llm_type()});
             let prompts: Vec<String> = messages.iter().map(|m| m.content().text()).collect();
             let _ = cb.on_llm_start(&serialized_llm, &prompts, llm_run_id).await;
 
-            // Call the model
-            let chat_result = match self.model._generate(&messages, None).await {
+            // Call the model, honouring the cancellation token. Dropping the
+            // `_generate` future cancels any in-flight `reqwest` request.
+            let generate_result = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {
+                    let reason = "cancelled during model call";
+                    let _ = cb.on_llm_error(reason, llm_run_id).await;
+                    let _ = cb.on_agent_cancelled(reason, chain_run_id).await;
+                    let _ = cb.on_chain_error(reason, chain_run_id).await;
+                    return Err(CognisError::Cancelled(reason.into()));
+                }
+                r = self.model._generate(&messages, None) => r,
+            };
+
+            let chat_result = match generate_result {
                 Ok(r) => {
                     let llm_result = cognis_core::outputs::LLMResult {
                         generations: vec![r
@@ -422,7 +476,27 @@ impl AgentExecutor {
                 let (result_text, result_artifact) = match self.tools.get(&tool_call.name) {
                     Some(tool) => {
                         let input = value_to_tool_input(&args_value);
-                        match tool._run(input).await {
+                        let tool_result = tokio::select! {
+                            biased;
+                            _ = cancel.cancelled() => {
+                                let reason = "cancelled during tool call";
+                                let _ = cb
+                                    .on_tool_error(ToolErrorEvent {
+                                        tool: tool_call.name.clone(),
+                                        error: reason.into(),
+                                        error_kind: ToolErrorKind::Other,
+                                        tool_call_id: tool_call_id_opt.clone(),
+                                        run_id: tool_run_id,
+                                        parent_run_id: Some(chain_run_id),
+                                    })
+                                    .await;
+                                let _ = cb.on_agent_cancelled(reason, chain_run_id).await;
+                                let _ = cb.on_chain_error(reason, chain_run_id).await;
+                                return Err(CognisError::Cancelled(reason.into()));
+                            }
+                            r = tool._run(input) => r,
+                        };
+                        match tool_result {
                             Ok(output) => {
                                 let (content, artifact) = match output {
                                     ToolOutput::Content(v) => (v, None),

--- a/crates/cognis/src/agents/plan_and_execute.rs
+++ b/crates/cognis/src/agents/plan_and_execute.rs
@@ -17,6 +17,7 @@ use serde_json::Value;
 
 use cognis_core::error::{CognisError, Result};
 use cognis_core::tools::base::BaseTool;
+use cognis_core::CancellationToken;
 
 /// A thread-safe function that generates plan text from a template string.
 type GeneratorFn = Box<dyn Fn(&str) -> Result<String> + Send + Sync>;
@@ -440,6 +441,31 @@ impl PlanAndExecuteAgent {
         goal: &str,
         on_step: impl Fn(&PlanStep),
     ) -> Result<PlanAndExecuteResult> {
+        self.run_with_cancel_and_callback(goal, CancellationToken::new(), on_step)
+            .await
+    }
+
+    /// Run the plan-and-execute loop honouring a [`CancellationToken`].
+    pub async fn run_with_cancel(
+        &self,
+        goal: &str,
+        cancel: CancellationToken,
+    ) -> Result<PlanAndExecuteResult> {
+        self.run_with_cancel_and_callback(goal, cancel, |_| {})
+            .await
+    }
+
+    /// Run the plan-and-execute loop with both a per-step callback and a
+    /// [`CancellationToken`]. The token is checked between every step and
+    /// the step executor is wrapped in `tokio::select!` so that in-flight
+    /// work is dropped when cancellation fires.
+    pub async fn run_with_cancel_and_callback(
+        &self,
+        goal: &str,
+        cancel: CancellationToken,
+        on_step: impl Fn(&PlanStep),
+    ) -> Result<PlanAndExecuteResult> {
+        cancel.check("cancelled before planning")?;
         let mut plan = self.planner.create_plan(goal)?;
         let mut replans = 0;
         let mut step_results: Vec<(String, String)> = Vec::new();
@@ -449,12 +475,22 @@ impl PlanAndExecuteAgent {
         loop {
             // Process all pending steps in the current plan.
             while let Some(step) = plan.next_step() {
+                cancel.check("cancelled between plan steps")?;
                 on_step(step);
                 step.status = PlanStepStatus::InProgress;
                 let desc = step.description.clone();
                 let idx = step.index;
 
-                match self.executor.execute_step(step, &context).await {
+                let exec_result = tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => {
+                        return Err(CognisError::Cancelled(
+                            "cancelled during plan-and-execute step".into(),
+                        ));
+                    }
+                    r = self.executor.execute_step(step, &context) => r,
+                };
+                match exec_result {
                     Ok(result) => {
                         // Re-borrow after the await.
                         plan.steps[idx].status = PlanStepStatus::Completed;

--- a/crates/cognis/src/agents/react.rs
+++ b/crates/cognis/src/agents/react.rs
@@ -17,6 +17,7 @@ use cognis_core::error::{CognisError, Result};
 use cognis_core::language_models::chat_model::BaseChatModel;
 use cognis_core::messages::Message;
 use cognis_core::tools::base::BaseTool;
+use cognis_core::CancellationToken;
 
 use super::output_parser::{AgentOutput, AgentOutputParser, ReActOutputParser};
 
@@ -214,7 +215,22 @@ impl ReActAgent {
 
     /// Run the ReAct loop on the given input and return the result.
     pub async fn run(&self, input: &str) -> Result<ReActResult> {
-        let (output, trace) = self.run_inner(input).await?;
+        self.run_with_cancel(input, CancellationToken::new()).await
+    }
+
+    /// Run the ReAct loop with cooperative cancellation support.
+    ///
+    /// Honours the token at iteration boundaries, around the model call, and
+    /// around each tool invocation. See [`AgentExecutor::run_with_cancel`] for
+    /// the full contract.
+    ///
+    /// [`AgentExecutor::run_with_cancel`]: super::executor::AgentExecutor::run_with_cancel
+    pub async fn run_with_cancel(
+        &self,
+        input: &str,
+        cancel: CancellationToken,
+    ) -> Result<ReActResult> {
+        let (output, trace) = self.run_inner(input, &cancel).await?;
         let tool_calls: Vec<(String, Value, String)> = trace
             .steps
             .iter()
@@ -237,7 +253,16 @@ impl ReActAgent {
 
     /// Run the ReAct loop and return both the output and a detailed trace.
     pub async fn run_with_trace(&self, input: &str) -> Result<(String, ReActTrace)> {
-        self.run_inner(input).await
+        self.run_inner(input, &CancellationToken::new()).await
+    }
+
+    /// Run the ReAct loop with a trace, honouring a [`CancellationToken`].
+    pub async fn run_with_trace_and_cancel(
+        &self,
+        input: &str,
+        cancel: CancellationToken,
+    ) -> Result<(String, ReActTrace)> {
+        self.run_inner(input, &cancel).await
     }
 
     /// Format a description of all available tools.
@@ -276,17 +301,31 @@ impl ReActAgent {
     // -----------------------------------------------------------------------
 
     /// The core ReAct loop shared by `run` and `run_with_trace`.
-    async fn run_inner(&self, input: &str) -> Result<(String, ReActTrace)> {
+    async fn run_inner(
+        &self,
+        input: &str,
+        cancel: &CancellationToken,
+    ) -> Result<(String, ReActTrace)> {
         let parser = ReActOutputParser::new();
         let mut trace = ReActTrace::new();
         let tool_names: Vec<&str> = self.tools.iter().map(|t| t.name()).collect();
 
         for _iteration in 0..self.max_iterations {
+            cancel.check("cancelled between ReAct iterations")?;
+
             let scratchpad = self.format_scratchpad(&trace.steps);
             let prompt = self.build_prompt(input, &scratchpad, &tool_names);
 
             let messages: Vec<Message> = self.build_messages(&prompt);
-            let ai_msg = self.model.invoke_messages(&messages, None).await?;
+            let ai_msg = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {
+                    return Err(CognisError::Cancelled(
+                        "cancelled during ReAct model call".into(),
+                    ));
+                }
+                r = self.model.invoke_messages(&messages, None) => r?,
+            };
             let ai_text = ai_msg.base.content.text();
 
             // Approximate token tracking.
@@ -321,8 +360,18 @@ impl ReActAgent {
                     // Extract thought from text before Action:
                     let thought = extract_thought(&ai_text);
 
-                    // Find and execute the tool.
-                    let observation = self.execute_tool(&action.tool, &action.tool_input).await?;
+                    // Find and execute the tool. Honour cancellation so a
+                    // long-running tool (HTTP request, child process, …) can
+                    // be dropped as soon as the client signals stop.
+                    let observation = tokio::select! {
+                        biased;
+                        _ = cancel.cancelled() => {
+                            return Err(CognisError::Cancelled(
+                                "cancelled during ReAct tool call".into(),
+                            ));
+                        }
+                        r = self.execute_tool(&action.tool, &action.tool_input) => r?,
+                    };
                     let obs_str = match &observation {
                         Value::String(s) => s.clone(),
                         other => serde_json::to_string(other).unwrap_or_default(),

--- a/crates/cognis/tests/agent_cancellation.rs
+++ b/crates/cognis/tests/agent_cancellation.rs
@@ -10,9 +10,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use serde_json::json;
+use serde_json::{json, Value};
 
-use cognis::agents::AgentExecutor;
+use cognis::agents::{
+    AgentExecutor, Plan, PlanAndExecuteAgent, PlanStep, Planner, ReActAgent, StepExecutor,
+};
 use cognis_core::error::{CognisError, Result};
 use cognis_core::language_models::chat_model::BaseChatModel;
 use cognis_core::language_models::fake::FakeListChatModel;
@@ -178,6 +180,181 @@ async fn run_with_default_token_behaves_as_before() {
     let result = result.expect("run should succeed for final-text models");
     assert_eq!(result.output, "done");
 }
+
+// ---------------------------------------------------------------------------
+// ReActAgent cancellation
+// ---------------------------------------------------------------------------
+
+/// A fake chat model that always parses as an `Action: noop / Action Input: {}`
+/// so the ReAct loop keeps iterating until cancelled or max-iterations runs
+/// out. A per-call delay gives concurrent cancellation a reliable window.
+struct LoopingReActModel {
+    delay_ms: u64,
+}
+
+#[async_trait]
+impl BaseChatModel for LoopingReActModel {
+    async fn _generate(
+        &self,
+        _messages: &[Message],
+        _stop: Option<&[String]>,
+    ) -> Result<ChatResult> {
+        if self.delay_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(self.delay_ms)).await;
+        }
+        // A response that parses as an `Action` step so the ReAct loop
+        // keeps running.
+        let body = "Thought: still thinking\nAction: noop\nAction Input: {}";
+        Ok(ChatResult {
+            generations: vec![ChatGeneration::new(AIMessage::new(body))],
+            llm_output: None,
+        })
+    }
+
+    fn llm_type(&self) -> &str {
+        "looping-react-model"
+    }
+}
+
+struct NoopTool;
+
+#[async_trait]
+impl BaseTool for NoopTool {
+    fn name(&self) -> &str {
+        "noop"
+    }
+    fn description(&self) -> &str {
+        "A tool that does nothing."
+    }
+    async fn _run(&self, _input: ToolInput) -> Result<ToolOutput> {
+        Ok(ToolOutput::Content(json!("ok")))
+    }
+}
+
+#[tokio::test]
+async fn react_run_with_cancel_honors_token() {
+    let model: Arc<dyn BaseChatModel> = Arc::new(LoopingReActModel { delay_ms: 5 });
+    let agent = ReActAgent::builder()
+        .model(model)
+        .tools(vec![Arc::new(NoopTool) as Arc<dyn BaseTool>])
+        .max_iterations(100)
+        .build()
+        .expect("build ReActAgent");
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        cancel_clone.cancel();
+    });
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        agent.run_with_cancel("hello", cancel),
+    )
+    .await
+    .expect("ReAct should respond to cancel quickly");
+    match result {
+        Err(CognisError::Cancelled(_)) => {}
+        other => panic!("expected Cancelled, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn react_pre_cancelled_aborts_immediately() {
+    let model: Arc<dyn BaseChatModel> = Arc::new(LoopingReActModel { delay_ms: 0 });
+    let agent = ReActAgent::builder()
+        .model(model)
+        .tools(vec![Arc::new(NoopTool) as Arc<dyn BaseTool>])
+        .max_iterations(5)
+        .build()
+        .expect("build ReActAgent");
+
+    let cancel = CancellationToken::cancelled_now();
+    let result = agent.run_with_cancel("hi", cancel).await;
+    match result {
+        Err(CognisError::Cancelled(_)) => {}
+        other => panic!("expected Cancelled, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PlanAndExecute cancellation
+// ---------------------------------------------------------------------------
+
+/// A planner producing many pending steps so the loop has material to run.
+struct MultiStepPlanner;
+
+impl Planner for MultiStepPlanner {
+    fn create_plan(&self, goal: &str) -> Result<Plan> {
+        let steps: Vec<PlanStep> = (0..20)
+            .map(|i| PlanStep::new(i, format!("step {i}")))
+            .collect();
+        Ok(Plan::new(goal, steps))
+    }
+}
+
+/// A step executor that sleeps briefly so a concurrent cancel can fire.
+struct SlowStepExecutor {
+    delay_ms: u64,
+}
+
+#[async_trait]
+impl StepExecutor for SlowStepExecutor {
+    async fn execute_step(&self, step: &PlanStep, _context: &Value) -> Result<String> {
+        if self.delay_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(self.delay_ms)).await;
+        }
+        Ok(format!("completed {}", step.description))
+    }
+}
+
+#[tokio::test]
+async fn plan_and_execute_run_with_cancel_honors_token() {
+    let agent = PlanAndExecuteAgent::builder()
+        .planner(MultiStepPlanner)
+        .executor(SlowStepExecutor { delay_ms: 10 })
+        .build()
+        .expect("build PlanAndExecuteAgent");
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        cancel_clone.cancel();
+    });
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        agent.run_with_cancel("do things", cancel),
+    )
+    .await
+    .expect("plan-and-execute should respond to cancel quickly");
+    match result {
+        Err(CognisError::Cancelled(_)) => {}
+        other => panic!("expected Cancelled, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn plan_and_execute_pre_cancelled_aborts_before_planning() {
+    let agent = PlanAndExecuteAgent::builder()
+        .planner(MultiStepPlanner)
+        .executor(SlowStepExecutor { delay_ms: 0 })
+        .build()
+        .expect("build PlanAndExecuteAgent");
+
+    let cancel = CancellationToken::cancelled_now();
+    let result = agent.run_with_cancel("do things", cancel).await;
+    match result {
+        Err(CognisError::Cancelled(_)) => {}
+        other => panic!("expected Cancelled, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AgentExecutor: between-iteration check
+// ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn cancel_between_iterations_emits_cancelled_error() {

--- a/crates/cognis/tests/agent_cancellation.rs
+++ b/crates/cognis/tests/agent_cancellation.rs
@@ -1,0 +1,220 @@
+//! Cooperative-cancellation integration tests for the agent executors.
+//!
+//! Verifies that `AgentExecutor::run_with_cancel` honours a
+//! `CancellationToken` both before the loop starts and during in-flight
+//! model and tool calls.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde_json::json;
+
+use cognis::agents::AgentExecutor;
+use cognis_core::error::{CognisError, Result};
+use cognis_core::language_models::chat_model::BaseChatModel;
+use cognis_core::language_models::fake::FakeListChatModel;
+use cognis_core::messages::{AIMessage, Message, ToolCall};
+use cognis_core::outputs::{ChatGeneration, ChatResult};
+use cognis_core::tools::base::BaseTool;
+use cognis_core::tools::types::{ToolInput, ToolOutput};
+use cognis_core::CancellationToken;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Fake model that always returns a tool call to an `add` tool, so the agent
+/// loop keeps iterating indefinitely until it is cancelled or hits its
+/// iteration cap. Each `_generate` sleeps for `delay_ms` to give concurrent
+/// cancellation a reliable window in which to fire.
+struct LoopingToolModel {
+    call_count: AtomicU32,
+    delay_ms: u64,
+}
+
+impl LoopingToolModel {
+    fn new(delay_ms: u64) -> Self {
+        Self {
+            call_count: AtomicU32::new(0),
+            delay_ms,
+        }
+    }
+}
+
+#[async_trait]
+impl BaseChatModel for LoopingToolModel {
+    async fn _generate(
+        &self,
+        _messages: &[Message],
+        _stop: Option<&[String]>,
+    ) -> Result<ChatResult> {
+        if self.delay_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(self.delay_ms)).await;
+        }
+        let n = self.call_count.fetch_add(1, Ordering::SeqCst);
+        let mut args = HashMap::new();
+        args.insert("a".to_string(), json!(1));
+        args.insert("b".to_string(), json!(n));
+        let ai = AIMessage::new("").with_tool_calls(vec![ToolCall {
+            name: "add".to_string(),
+            args,
+            id: Some(format!("call_{n}")),
+        }]);
+        Ok(ChatResult {
+            generations: vec![ChatGeneration::new(ai)],
+            llm_output: None,
+        })
+    }
+
+    fn llm_type(&self) -> &str {
+        "looping-tool-model"
+    }
+}
+
+/// Trivial add tool used by `LoopingToolModel`.
+struct AddTool;
+
+#[async_trait]
+impl BaseTool for AddTool {
+    fn name(&self) -> &str {
+        "add"
+    }
+
+    fn description(&self) -> &str {
+        "Adds two numbers"
+    }
+
+    async fn _run(&self, input: ToolInput) -> Result<ToolOutput> {
+        let (a, b) = match input {
+            ToolInput::Structured(map) => {
+                let a = map.get("a").and_then(|v| v.as_i64()).unwrap_or(0);
+                let b = map.get("b").and_then(|v| v.as_i64()).unwrap_or(0);
+                (a, b)
+            }
+            _ => (0, 0),
+        };
+        Ok(ToolOutput::Content(json!(a + b)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pre_cancelled_token_aborts_immediately() {
+    // A pre-cancelled token must abort before the first model call completes.
+    let model = Arc::new(LoopingToolModel::new(0));
+    let executor = AgentExecutor::builder()
+        .model(model)
+        .tools(vec![Arc::new(AddTool) as Arc<dyn BaseTool>])
+        .max_iterations(5)
+        .build();
+
+    let cancel = CancellationToken::cancelled_now();
+    let msgs = vec![Message::human("hello")];
+    let result = executor.run_with_cancel(&msgs, cancel).await;
+    match result {
+        Err(CognisError::Cancelled(_)) => {}
+        other => panic!("expected Cancelled, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn cancel_during_run_breaks_loop() {
+    // A slow model + generous iteration budget gives a concurrent cancel
+    // task a reliable window to fire. The run must resolve quickly with
+    // either Ok (if the model happened to complete first) or Cancelled —
+    // the critical assertion is that it does not hang.
+    let slow_model = Arc::new(LoopingToolModel::new(10));
+    let executor = AgentExecutor::builder()
+        .model(slow_model)
+        .tools(vec![Arc::new(AddTool) as Arc<dyn BaseTool>])
+        .max_iterations(100)
+        .build();
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        cancel_clone.cancel();
+    });
+
+    let msgs = vec![Message::human("hello")];
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        executor.run_with_cancel(&msgs, cancel),
+    )
+    .await
+    .expect("run_with_cancel should not hang past the cancellation signal");
+
+    // The model always produces tool calls, so we will definitely hit
+    // enough iterations for cancel to fire before the max-iterations cap.
+    match result {
+        Err(CognisError::Cancelled(_)) => {}
+        other => panic!(
+            "expected Cancelled after concurrent cancel, got {:?}",
+            other
+        ),
+    }
+}
+
+#[tokio::test]
+async fn run_with_default_token_behaves_as_before() {
+    // Backward-compat: the historical `run()` path is preserved. A
+    // `FakeListChatModel` returning a final text terminates the loop on the
+    // first iteration and must not be disturbed by the wrapper delegating
+    // to `run_with_cancel`.
+    let model = Arc::new(FakeListChatModel::new(vec!["done".to_string()]));
+    let executor = AgentExecutor::builder()
+        .model(model)
+        .max_iterations(5)
+        .build();
+    let msgs = vec![Message::human("hi")];
+    let result = executor.run(&msgs).await;
+    let result = result.expect("run should succeed for final-text models");
+    assert_eq!(result.output, "done");
+}
+
+#[tokio::test]
+async fn cancel_between_iterations_emits_cancelled_error() {
+    // Fires cancel after the first model call so the loop-boundary check
+    // sees the token on the next iteration. A small per-call delay on the
+    // model guarantees the spawned cancel task can observe the call count
+    // before the loop exhausts its iteration budget.
+    let model = Arc::new(LoopingToolModel::new(5));
+    let executor = AgentExecutor::builder()
+        .model(model.clone())
+        .tools(vec![Arc::new(AddTool) as Arc<dyn BaseTool>])
+        .max_iterations(100)
+        .build();
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let spy = model.clone();
+    tokio::spawn(async move {
+        // Poll until we see the first call, then cancel.
+        loop {
+            if spy.call_count.load(Ordering::SeqCst) >= 1 {
+                cancel_clone.cancel();
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    });
+
+    let msgs = vec![Message::human("hello")];
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        executor.run_with_cancel(&msgs, cancel),
+    )
+    .await
+    .expect("agent should respond to cancel quickly");
+    match result {
+        Err(CognisError::Cancelled(_)) => {}
+        other => panic!("expected Cancelled, got {other:?}"),
+    }
+}

--- a/crates/cognis/tests/runnable_cancellation.rs
+++ b/crates/cognis/tests/runnable_cancellation.rs
@@ -1,0 +1,164 @@
+//! Tests proving that `RunnableConfig::cancellation_token` is observable from
+//! `Runnable::invoke` and from an LCEL chain composed of two runnables.
+//!
+//! This is the contract that tool authors rely on when they need tool-specific
+//! cleanup beyond the executor-level future drop.
+//!
+//! A tool author who wants to kill a child process on cancel writes a
+//! `Runnable` (or makes their tool implement `Runnable`) that reads
+//! `config.cancellation_token` and pairs its long-running work with
+//! `tokio::select!` against `token.cancelled()`. The executor's
+//! `run_with_cancel` already forwards the token through its own loop, and any
+//! Runnable-composed tool can see it via the config argument.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use cognis_core::error::CognisError;
+use cognis_core::runnables::base::Runnable;
+use cognis_core::runnables::config::RunnableConfig;
+use cognis_core::runnables::lambda::RunnableLambda;
+use cognis_core::CancellationToken;
+use serde_json::{json, Value};
+
+#[tokio::test]
+async fn lambda_can_observe_cancellation_token_from_config() {
+    // A lambda that inspects the config for a cancellation token and bails
+    // early when it is cancelled. This proves the end-to-end wiring:
+    // RunnableConfig carries the token, the lambda observes it, and can
+    // synthesise a `CognisError::Cancelled`.
+    let lambda = RunnableLambda::with_config("observer", |_input, cfg| async move {
+        if let Some(cfg) = cfg {
+            if let Some(ref t) = cfg.cancellation_token {
+                if t.is_cancelled() {
+                    return Err(CognisError::Cancelled("observed by lambda".into()));
+                }
+            }
+        }
+        Ok(Value::Null)
+    });
+
+    let mut cfg = RunnableConfig::default();
+    cfg.cancellation_token = Some(CancellationToken::cancelled_now());
+
+    let err = lambda.invoke(json!({}), Some(&cfg)).await.unwrap_err();
+    match err {
+        CognisError::Cancelled(reason) => assert_eq!(reason, "observed by lambda"),
+        other => panic!("expected Cancelled, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn lambda_without_cancel_token_runs_normally() {
+    let lambda = RunnableLambda::with_config("observer", |_input, cfg| async move {
+        if let Some(cfg) = cfg {
+            if let Some(ref t) = cfg.cancellation_token {
+                if t.is_cancelled() {
+                    return Err(CognisError::Cancelled("observed".into()));
+                }
+            }
+        }
+        Ok(json!("done"))
+    });
+
+    // Default config has no token.
+    let cfg = RunnableConfig::default();
+    let out = lambda.invoke(json!({}), Some(&cfg)).await.unwrap();
+    assert_eq!(out, json!("done"));
+}
+
+#[tokio::test]
+async fn lambda_select_against_cancel_token_drops_inflight_work() {
+    // Mimics the pattern a `Runnable`-based tool would use for cancel-aware
+    // execution: `tokio::select!` between the slow work and the cancel token.
+    let lambda = RunnableLambda::with_config("slow_worker", |_input, cfg| async move {
+        let token = cfg
+            .as_ref()
+            .and_then(|c| c.cancellation_token.clone())
+            .unwrap_or_default();
+
+        tokio::select! {
+            biased;
+            _ = token.cancelled() => Err(CognisError::Cancelled("tool cancelled".into())),
+            _ = tokio::time::sleep(Duration::from_secs(10)) => Ok(json!("normal")),
+        }
+    });
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        cancel_clone.cancel();
+    });
+
+    let mut cfg = RunnableConfig::default();
+    cfg.cancellation_token = Some(cancel);
+
+    let result = tokio::time::timeout(Duration::from_secs(2), lambda.invoke(json!({}), Some(&cfg)))
+        .await
+        .expect("lambda should abort quickly after cancel fires");
+
+    match result {
+        Err(CognisError::Cancelled(reason)) => assert_eq!(reason, "tool cancelled"),
+        other => panic!("expected Cancelled, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn patch_config_carries_cancellation_token() {
+    // The `ConfigPatch::with_cancellation_token` builder puts the token into
+    // a patched config — the usual way callers add a cancel token to an
+    // existing config before forwarding to a nested runnable.
+    use cognis_core::runnables::config::{patch_config, ConfigPatch};
+
+    let base = RunnableConfig::default();
+    let token = CancellationToken::cancelled_now();
+    let patch = ConfigPatch::new().with_cancellation_token(token);
+    let patched = patch_config(&base, &patch);
+    let t = patched
+        .cancellation_token
+        .as_ref()
+        .expect("token should be present");
+    assert!(t.is_cancelled());
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: LCEL chain propagates the token to every step
+// ---------------------------------------------------------------------------
+
+use cognis_core::runnables::sequence::RunnableSequence;
+
+#[tokio::test]
+async fn sequence_propagates_cancellation_token_to_all_steps() {
+    // Build a two-step sequence: the first step passes through, the second
+    // step checks the token. The sequence's `invoke` forwards the caller's
+    // config (which carries the token) to each step.
+    let step1 = Arc::new(RunnableLambda::new("passthrough", |input| async move {
+        Ok(input)
+    }));
+    let step2 = Arc::new(RunnableLambda::with_config(
+        "gate",
+        |input, cfg| async move {
+            if let Some(cfg) = cfg {
+                if let Some(ref t) = cfg.cancellation_token {
+                    if t.is_cancelled() {
+                        return Err(CognisError::Cancelled("gate saw cancel".into()));
+                    }
+                }
+            }
+            Ok(input)
+        },
+    ));
+
+    let seq = RunnableSequence::new(vec![step1 as Arc<dyn Runnable>, step2 as Arc<dyn Runnable>])
+        .expect("sequence should build");
+
+    let mut cfg = RunnableConfig::default();
+    cfg.cancellation_token = Some(CancellationToken::cancelled_now());
+
+    let err = seq.invoke(json!({"x": 1}), Some(&cfg)).await.unwrap_err();
+    match err {
+        CognisError::Cancelled(reason) => assert_eq!(reason, "gate saw cancel"),
+        other => panic!("expected Cancelled, got {other:?}"),
+    }
+}

--- a/crates/cognisagent/src/middleware/approval_gate.rs
+++ b/crates/cognisagent/src/middleware/approval_gate.rs
@@ -44,6 +44,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
+use cognis_core::CancellationToken;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::oneshot;
@@ -140,6 +141,10 @@ pub enum ApprovalError {
     /// Waiting for resolution timed out.
     #[error("timed out waiting for approval decision after {0:?}")]
     Timeout(Duration),
+    /// Waiting for resolution was cooperatively cancelled by a
+    /// [`CancellationToken`].
+    #[error("approval wait cancelled")]
+    Cancelled,
 }
 
 // ---------------------------------------------------------------------------
@@ -267,6 +272,11 @@ pub struct ApprovalGateMiddleware {
     /// Optional upper bound on how long to wait for a decision. `None` means
     /// wait forever (until the registry is cleared).
     timeout: Option<Duration>,
+    /// Optional cooperative cancellation token. When set, a pending approval
+    /// that is still waiting for a decision aborts cleanly as soon as the
+    /// token fires, reporting `Action denied by human: cancelled` rather
+    /// than hanging indefinitely.
+    cancellation_token: Option<CancellationToken>,
 }
 
 impl fmt::Debug for ApprovalGateMiddleware {
@@ -275,6 +285,7 @@ impl fmt::Debug for ApprovalGateMiddleware {
             .field("registry", &self.registry)
             .field("event_bus", &self.event_bus)
             .field("timeout", &self.timeout)
+            .field("cancellation_token", &self.cancellation_token)
             .finish()
     }
 }
@@ -289,6 +300,7 @@ impl ApprovalGateMiddleware {
             event_bus,
             predicate: Arc::new(|_name, _input| true),
             timeout: None,
+            cancellation_token: None,
         }
     }
 
@@ -305,6 +317,7 @@ impl ApprovalGateMiddleware {
             event_bus,
             predicate,
             timeout: None,
+            cancellation_token: None,
         }
     }
 
@@ -319,6 +332,7 @@ impl ApprovalGateMiddleware {
             event_bus,
             predicate,
             timeout: None,
+            cancellation_token: None,
         }
     }
 
@@ -326,6 +340,17 @@ impl ApprovalGateMiddleware {
     /// gate rejects with a timeout observation.
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = Some(timeout);
+        self
+    }
+
+    /// Install a cooperative [`CancellationToken`].
+    ///
+    /// When set, a pending approval that is still waiting for a decision
+    /// aborts cleanly as soon as the token fires, with a rejection
+    /// observation of `Action denied by human: cancelled` so the agent
+    /// loop sees a well-formed tool result instead of hanging.
+    pub fn with_cancellation_token(mut self, token: CancellationToken) -> Self {
+        self.cancellation_token = Some(token);
         self
     }
 
@@ -343,13 +368,28 @@ impl ApprovalGateMiddleware {
         &self,
         rx: oneshot::Receiver<ApprovalDecision>,
     ) -> std::result::Result<ApprovalDecision, ApprovalError> {
-        match self.timeout {
-            Some(duration) => match tokio::time::timeout(duration, rx).await {
-                Ok(Ok(decision)) => Ok(decision),
-                Ok(Err(_)) => Err(ApprovalError::ResolverDropped),
-                Err(_) => Err(ApprovalError::Timeout(duration)),
+        // Always race against the cancellation token (if any) so that a
+        // cancelled run never leaves the gate waiting on a decision that
+        // will never arrive.
+        let cancel = self.cancellation_token.clone();
+        let wait_fut = async move {
+            match self.timeout {
+                Some(duration) => match tokio::time::timeout(duration, rx).await {
+                    Ok(Ok(decision)) => Ok(decision),
+                    Ok(Err(_)) => Err(ApprovalError::ResolverDropped),
+                    Err(_) => Err(ApprovalError::Timeout(duration)),
+                },
+                None => rx.await.map_err(|_| ApprovalError::ResolverDropped),
+            }
+        };
+
+        match cancel {
+            Some(token) => tokio::select! {
+                biased;
+                _ = token.cancelled() => Err(ApprovalError::Cancelled),
+                r = wait_fut => r,
             },
-            None => rx.await.map_err(|_| ApprovalError::ResolverDropped),
+            None => wait_fut.await,
         }
     }
 }
@@ -395,6 +435,14 @@ impl Middleware for ApprovalGateMiddleware {
             }
             Err(ApprovalError::UnknownToken(_)) => {
                 ApprovalDecision::reject("approval registry lost track of this token")
+            }
+            Err(ApprovalError::Cancelled) => {
+                // The run was cooperatively cancelled. Clean up the pending
+                // entry so the registry does not leak tokens, then surface a
+                // well-formed rejection so the agent loop sees a normal
+                // tool result rather than a hang.
+                let _ = self.registry.pending.lock().unwrap().remove(&token);
+                ApprovalDecision::reject("cancelled")
             }
         };
 
@@ -614,6 +662,65 @@ mod tests {
             other => panic!("expected Reject, got {:?}", other),
         }
         // Registry should be cleaned up after timeout.
+        assert_eq!(registry.pending_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn cancellation_token_aborts_pending_approval() {
+        // A pending approval that is still waiting for a decision must
+        // abort cleanly as soon as the cooperative cancellation token
+        // fires. The middleware returns a `Reject` observation rather
+        // than hanging so the agent loop sees a well-formed tool result.
+        let registry = Arc::new(ApprovalRegistry::new());
+        let bus = EventBus::new();
+        let cancel = CancellationToken::new();
+        let gate = ApprovalGateMiddleware::new(registry.clone(), bus)
+            .with_cancellation_token(cancel.clone());
+
+        let cancel_clone = cancel.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            cancel_clone.cancel();
+        });
+
+        let decision = tokio::time::timeout(
+            Duration::from_secs(2),
+            gate.gate_tool(&mut Value::Null, "shell", &json!({})),
+        )
+        .await
+        .expect("gate_tool must not hang past cancellation")
+        .unwrap();
+
+        match decision {
+            ToolGateDecision::Reject { observation } => {
+                assert!(
+                    observation.to_lowercase().contains("cancelled"),
+                    "expected observation to mention cancellation, got {observation:?}"
+                );
+            }
+            other => panic!("expected Reject, got {:?}", other),
+        }
+        // Registry should be cleaned up even though no one called
+        // `resolve` — the middleware must not leak pending entries.
+        assert_eq!(registry.pending_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn pre_cancelled_token_rejects_immediately() {
+        let registry = Arc::new(ApprovalRegistry::new());
+        let bus = EventBus::new();
+        let gate = ApprovalGateMiddleware::new(registry.clone(), bus)
+            .with_cancellation_token(CancellationToken::cancelled_now());
+
+        let decision = tokio::time::timeout(
+            Duration::from_millis(500),
+            gate.gate_tool(&mut Value::Null, "shell", &json!({})),
+        )
+        .await
+        .expect("pre-cancelled gate should resolve immediately")
+        .unwrap();
+
+        assert!(decision.is_rejected());
         assert_eq!(registry.pending_count(), 0);
     }
 

--- a/crates/cognisgraph/src/utils/timeout.rs
+++ b/crates/cognisgraph/src/utils/timeout.rs
@@ -6,14 +6,18 @@
 
 use std::collections::HashMap;
 use std::future::Future;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use serde_json::Value;
-use tokio::sync::Notify;
 
 use crate::errors::{LangGraphError, Result};
+
+/// Cooperative cancellation token, re-exported from `cognis_core`.
+///
+/// Promoted to core so that every crate in the workspace (including
+/// `cognis` and `cognisagent`) can share the same cancellation primitive.
+pub use cognis_core::CancellationToken;
 
 /// Default timeout duration for node execution (30 seconds).
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -222,63 +226,6 @@ impl NodeTimeout {
     }
 }
 
-/// Cooperative cancellation token for graph execution.
-///
-/// Allows signaling cancellation to running nodes. Uses an atomic boolean
-/// and a `Notify` to wake waiting tasks.
-#[derive(Debug, Clone)]
-pub struct CancellationToken {
-    cancelled: Arc<AtomicBool>,
-    notify: Arc<Notify>,
-}
-
-impl CancellationToken {
-    /// Create a new cancellation token.
-    pub fn new() -> Self {
-        Self {
-            cancelled: Arc::new(AtomicBool::new(false)),
-            notify: Arc::new(Notify::new()),
-        }
-    }
-
-    /// Signal cancellation.
-    pub fn cancel(&self) {
-        self.cancelled.store(true, Ordering::SeqCst);
-        self.notify.notify_waiters();
-    }
-
-    /// Check if cancellation has been requested.
-    pub fn is_cancelled(&self) -> bool {
-        self.cancelled.load(Ordering::SeqCst)
-    }
-
-    /// Returns a future that resolves when cancellation is signaled.
-    pub async fn cancelled(&self) {
-        if self.is_cancelled() {
-            return;
-        }
-        // Wait for notification. Re-check after wake since we might get
-        // spurious wakes or the token could be cancelled between check and wait.
-        loop {
-            self.notify.notified().await;
-            if self.is_cancelled() {
-                return;
-            }
-        }
-    }
-
-    /// Reset the token so it can be reused.
-    pub fn reset(&self) {
-        self.cancelled.store(false, Ordering::SeqCst);
-    }
-}
-
-impl Default for CancellationToken {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// Tracks a time budget across multiple node executions.
 ///
 /// Useful for enforcing a total graph execution time limit while dynamically
@@ -419,6 +366,7 @@ impl Default for TimeoutManager {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::sync::atomic::Ordering;
 
     // ── TimeoutConfig tests ──
 

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -357,3 +357,7 @@ path = "../../examples/tools/typed_search.rs"
 [[example]]
 name = "tool_stateful_http"
 path = "../../examples/tools/stateful_http.rs"
+
+[[example]]
+name = "cancellation"
+path = "../../examples/agents/cancellation.rs"

--- a/examples/agents/cancellation.rs
+++ b/examples/agents/cancellation.rs
@@ -1,0 +1,110 @@
+//! Demonstrates client-side Stop with `AgentExecutor::run_with_cancel`.
+//!
+//! Spawns the agent on a `tokio::task`, sleeps briefly, then fires
+//! `CancellationToken::cancel()`. The agent aborts cleanly — both the
+//! in-flight model call and the agent loop return promptly — with
+//! `CognisError::Cancelled(...)` surfaced to the caller.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example cancellation -p cognis-examples --features cognis/all-providers
+//! ```
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use cognis::agents::AgentExecutor;
+use cognis_core::error::{CognisError, Result};
+use cognis_core::language_models::chat_model::BaseChatModel;
+use cognis_core::messages::{AIMessage, Message, ToolCall};
+use cognis_core::outputs::{ChatGeneration, ChatResult};
+use cognis_core::tools::base::BaseTool;
+use cognis_core::tools::types::{ToolInput, ToolOutput};
+use cognis_core::CancellationToken;
+use serde_json::{json, Value};
+
+/// A fake chat model that keeps calling the `noop` tool forever. Each call
+/// sleeps briefly so the cancel task has a window to fire.
+struct LoopingToolModel;
+
+#[async_trait]
+impl BaseChatModel for LoopingToolModel {
+    async fn _generate(
+        &self,
+        _messages: &[Message],
+        _stop: Option<&[String]>,
+    ) -> Result<ChatResult> {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let mut args = HashMap::new();
+        args.insert("n".to_string(), json!(1));
+        let ai = AIMessage::new("").with_tool_calls(vec![ToolCall {
+            name: "noop".into(),
+            args,
+            id: Some("call_1".into()),
+        }]);
+        Ok(ChatResult {
+            generations: vec![ChatGeneration::new(ai)],
+            llm_output: None,
+        })
+    }
+
+    fn llm_type(&self) -> &str {
+        "looping-tool-model"
+    }
+}
+
+struct NoopTool;
+
+#[async_trait]
+impl BaseTool for NoopTool {
+    fn name(&self) -> &str {
+        "noop"
+    }
+    fn description(&self) -> &str {
+        "Does nothing"
+    }
+    async fn _run(&self, _input: ToolInput) -> Result<ToolOutput> {
+        Ok(ToolOutput::Content(Value::String("ok".into())))
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let executor = AgentExecutor::builder()
+        .model(Arc::new(LoopingToolModel))
+        .tools(vec![Arc::new(NoopTool) as Arc<dyn BaseTool>])
+        .max_iterations(1000)
+        .return_intermediate_steps(true)
+        .build();
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+
+    let handle = tokio::spawn(async move {
+        let msgs = vec![Message::human("run many steps")];
+        executor.run_with_cancel(&msgs, cancel).await
+    });
+
+    println!("running for 50ms then cancelling...");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    cancel_clone.cancel();
+    println!("cancel signal sent");
+
+    match handle.await.expect("task join") {
+        Err(CognisError::Cancelled(reason)) => {
+            println!("agent aborted cleanly: {reason}");
+        }
+        Ok(r) => {
+            println!(
+                "agent finished normally (completed before cancel): iterations = {}",
+                r.intermediate_steps.len()
+            );
+        }
+        Err(e) => {
+            println!("unexpected error: {e}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #8 — adds cooperative cancellation to every layer of the agent loop. The public API matches what the issue asks for:

\`\`\`rust
use cognis_core::CancellationToken;

let cancel = CancellationToken::new();
let handle = tokio::spawn(async move {
    executor.run_with_cancel(&initial_messages, cancel.clone()).await
});

// Elsewhere, on client-side abort:
cancel.cancel();
\`\`\`

A cancel during in-flight work (LLM call, tool exec, approval-gate wait) returns \`CognisError::Cancelled(reason)\` within milliseconds and never hangs.

## What changed

### 1. \`cognis-core\` — foundation

- **Promoted** \`CancellationToken\` from \`cognisgraph::utils::timeout\` into \`cognis_core::cancellation\`. Same shape (\`new / cancel / is_cancelled / cancelled / reset\`) plus two new helpers: \`cancelled_now()\` (pre-cancelled sentinel) and \`check(reason)\` (returns \`Err(CognisError::Cancelled)\` if cancelled).
- \`cognisgraph::utils::timeout\` now re-exports from core — no breaking changes for existing call-sites.
- New variant \`CognisError::Cancelled(String)\`.
- New field \`RunnableConfig::cancellation_token: Option<CancellationToken>\` + matching \`ConfigPatch::with_cancellation_token(token)\` builder.
- New callback method \`CallbackHandler::on_agent_cancelled(reason, run_id, parent)\` (default no-op) and matching \`CallbackManager\` dispatcher.

### 2. \`AgentExecutor::run_with_cancel\`

- Existing \`AgentExecutor::run(&self, &[Message])\` stays as a thin wrapper that passes a fresh (never-cancelled) token.
- The loop \`check\`s the token at each iteration boundary.
- Model and tool calls wrapped in \`tokio::select!\` so in-flight work drops cleanly (\`reqwest\` request bodies are dropped automatically; child processes via \`tokio::process::Command\` are cleaned up on future-drop).
- Callback hooks (\`on_agent_cancelled\`, \`on_llm_error\`, \`on_tool_error\`, \`on_chain_error\`) fire on the cancel path.

### 3. ReAct & PlanAndExecute

Same pattern — \`ReActAgent::run_with_cancel\`, \`ReActAgent::run_with_trace_and_cancel\`, \`PlanAndExecuteAgent::run_with_cancel\`, \`PlanAndExecuteAgent::run_with_cancel_and_callback\`. Existing \`run()\` entry points preserved.

### 4. Tools — observable via \`RunnableConfig\`

The cancel token flows through \`RunnableConfig.cancellation_token\` to any \`Runnable\`, so LCEL sequences and Runnable-based tools observe it directly. Non-Runnable \`BaseTool\` implementers rely on the executor-level \`tokio::select!\` for future-drop cleanup (enough for \`tokio::process::Command\` spawns). Not changing the \`BaseTool::_run\` trait signature avoided a breaking change.

### 5. Approval-gate middleware (FR-3 interaction)

\`ApprovalGateMiddleware::with_cancellation_token(token)\` — \`wait_for_decision\` now races the resolver future against \`token.cancelled()\` via \`tokio::select!\`. On cancel, the pending approval entry is removed from the registry so no state leaks, and the middleware returns \`ApprovalError::Cancelled\`.

### 6. Runnable example

\`examples/agents/cancellation.rs\` spawns an executor and cancels it after 50 ms:
\`\`\`
running for 50ms then cancelling...
cancel signal sent
agent aborted cleanly: cancelled during model call
\`\`\`

## Scope

- 6 commits, ~1240 insertions, 75 deletions across 16 files
- 25 new tests: 10 in \`cognis_core::cancellation\`, 8 in \`crates/cognis/tests/agent_cancellation.rs\`, 5 in \`crates/cognis/tests/runnable_cancellation.rs\`, 2 in \`approval_gate::tests\`
- No new workspace deps — the existing in-house token was promoted, not replaced with \`tokio-util\`
- No breaking changes — every new entry point is purely additive

## Test Plan

- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --workspace --features all-providers -- -D warnings\`
- [x] \`cargo +1.95 clippy --workspace --features all-providers -- -D warnings\` (matches CI)
- [x] \`cargo test --workspace\` — 0 failures
- [x] \`cargo run --example cancellation -p cognis-examples --features cognis/all-providers\` — shows clean abort
- [ ] CI green on PR

## Deferred (explicit non-goals)

- Changing \`BaseTool::_run\` signature to take a \`RunnableConfig\` — would be breaking; the Runnable-config path + executor-level future-drop already delivers end-to-end cancellation semantics.
- Per-provider \`tokio-util::sync::CancellationToken\` adoption — not needed; \`reqwest\` honors future-drop, which is what the issue calls out.

Closes #8.