### PR TITLE
chore: bump workspace to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "cognis"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "cognis-core",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "cognis-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "cognis-macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "cognisagent"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "cognis",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "cognisgraph"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ reqwest = { version = "0.12", features = ["json", "stream"] }
 secrecy = { version = "0.10", features = ["serde"] }
 
 
-cognis = { path = "crates/cognis", version = "0.1.0" }
-cognis-core = { path = "crates/cognis-core", version = "0.1.0" }
-cognis-macros = { path = "crates/cognis-macros", version = "0.1.0" }
-cognisgraph = { path = "crates/cognisgraph", version = "0.1.0" }
-cognisagent = { path = "crates/cognisagent", version = "0.1.0" }
+cognis = { path = "crates/cognis", version = "0.2.0" }
+cognis-core = { path = "crates/cognis-core", version = "0.2.0" }
+cognis-macros = { path = "crates/cognis-macros", version = "0.2.0" }
+cognisgraph = { path = "crates/cognisgraph", version = "0.2.0" }
+cognisagent = { path = "crates/cognisagent", version = "0.2.0" }

--- a/crates/cognis-core/Cargo.toml
+++ b/crates/cognis-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cognis-core"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 description = "Core traits and types for the Cognis LLM framework"

--- a/crates/cognis-macros/Cargo.toml
+++ b/crates/cognis-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cognis-macros"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 description = "Standalone derive macros for generating OpenAPI-compatible JSON schemas from Rust structs"

--- a/crates/cognis/Cargo.toml
+++ b/crates/cognis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cognis"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 description = "LLM application framework built on cognis-core"

--- a/crates/cognisagent/Cargo.toml
+++ b/crates/cognisagent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cognisagent"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 description = "Batteries-included agent framework built on cognis and cognisgraph"

--- a/crates/cognisgraph/Cargo.toml
+++ b/crates/cognisgraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cognisgraph"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 description = "State graph orchestration framework for multi-actor agent workflows"


### PR DESCRIPTION
Bumps all five publishable crates to **0.2.0**:

- \`cognis-core\`
- \`cognis-macros\`
- \`cognis\`
- \`cognisgraph\`
- \`cognisagent\`

### Why 0.2.0 (minor)

New user-facing features since 0.1.0:
- #[cognis::tool] attribute macro for typed tools (#18)
- Typed tool-output Value preservation in callbacks (#15)
- AgentExecutor::astream_events (#14)
- Async approval-gate middleware (#17)

Additive, non-breaking — so minor, not major.

### Release plan

1. Merge this PR.
2. Tag \`v0.2.0\` on the merge commit.
3. Publish a GitHub Release with auto-generated notes.

crates.io publish is deliberately out of scope for this PR — ask before pushing, since the version number can't be reclaimed after publish.

### Test Plan

- [x] \`cargo build --workspace --features all-providers\` (clean, 29s)
- [x] Cargo.lock picks up new versions cleanly (path deps)
- [ ] CI green on PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `cognis-core`, `cognis-macros`, `cognis`, `cognisgraph`, and `cognisagent` to 0.2.0 to ship new, additive features across the workspace. Keeps the semver cohort in sync.

- **New Features**
  - `#[cognis::tool]` attribute macro for typed tools.
  - Preserve typed tool-output Value in callbacks.
  - `AgentExecutor::astream_events` for async event streaming.
  - Async approval-gate middleware.

<sup>Written for commit beb6d6dc7eaf09c4714b22112246cd8d747fccf7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

