### PR TITLE
feat: OpenRouter attribution + extra-headers on ChatOpenAI (closes #10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml 0.8.23",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +200,7 @@ dependencies = [
  "toml 0.8.23",
  "tracing",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -401,6 +412,24 @@ checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
@@ -776,6 +805,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,6 +883,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +902,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1323,6 +1365,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3234,6 +3286,29 @@ name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "postgres", "js
 base64 = "0.22"
 reqwest = { version = "0.12", features = ["json", "stream"] }
 secrecy = { version = "0.10", features = ["serde"] }
+tracing = "0.1"
 
 
 cognis = { path = "crates/cognis", version = "0.2.0" }

--- a/crates/cognis/Cargo.toml
+++ b/crates/cognis/Cargo.toml
@@ -58,3 +58,4 @@ all-providers = ["openai", "anthropic", "google", "ollama", "azure", "yaml", "to
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }
 tempfile = "3"
+wiremock = "0.6"

--- a/crates/cognis/Cargo.toml
+++ b/crates/cognis/Cargo.toml
@@ -17,6 +17,7 @@ thiserror.workspace = true
 uuid.workspace = true
 futures.workspace = true
 tokio-stream.workspace = true
+tracing.workspace = true
 regex = "1"
 csv = "1"
 glob = "0.3"

--- a/crates/cognis/src/chat_models/mod.rs
+++ b/crates/cognis/src/chat_models/mod.rs
@@ -27,6 +27,8 @@ pub mod load_balancer;
 pub mod ollama;
 #[cfg(feature = "openai")]
 pub mod openai;
+#[cfg(feature = "openai")]
+pub mod openrouter;
 pub mod rate_limited;
 pub mod retrying;
 pub mod routing;

--- a/crates/cognis/src/chat_models/openai.rs
+++ b/crates/cognis/src/chat_models/openai.rs
@@ -37,6 +37,7 @@ pub struct ChatOpenAIBuilder {
     stop: Option<Vec<String>>,
     max_retries: Option<u32>,
     streaming: Option<bool>,
+    extra_headers: HashMap<String, String>,
 }
 
 impl ChatOpenAIBuilder {
@@ -56,6 +57,7 @@ impl ChatOpenAIBuilder {
             stop: None,
             max_retries: None,
             streaming: None,
+            extra_headers: HashMap::new(),
         }
     }
 
@@ -137,6 +139,46 @@ impl ChatOpenAIBuilder {
         self
     }
 
+    /// Add a custom HTTP header that will be sent on every request.
+    ///
+    /// Useful for OpenAI-compatible gateways that require attribution or
+    /// routing headers — for example OpenRouter's `HTTP-Referer` and
+    /// `X-Title`, or Together.ai's custom routing tags. Calling this method
+    /// multiple times with the same key overwrites the prior value.
+    ///
+    /// The standard `Authorization`, `Content-Type`, and `OpenAI-Organization`
+    /// headers are applied after extra headers, so they cannot be
+    /// accidentally overridden.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use cognis::chat_models::openai::ChatOpenAI;
+    ///
+    /// let model = ChatOpenAI::builder()
+    ///     .model("meta-llama/llama-3.3-70b-instruct:free")
+    ///     .api_key("sk-or-...")
+    ///     .base_url("https://openrouter.ai/api")
+    ///     .extra_header("HTTP-Referer", "https://mysite.com")
+    ///     .extra_header("X-Title", "my-app")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn extra_header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.extra_headers.insert(key.into(), value.into());
+        self
+    }
+
+    /// Replace the entire set of extra HTTP headers.
+    ///
+    /// Prefer [`extra_header`](Self::extra_header) for additive use. This
+    /// method is intended for cases where the caller already has a header
+    /// map (e.g. loaded from config).
+    pub fn extra_headers(mut self, headers: HashMap<String, String>) -> Self {
+        self.extra_headers = headers;
+        self
+    }
+
     /// Build the [`ChatOpenAI`] instance.
     ///
     /// Returns an error if `model` is not set or if the API key cannot be
@@ -174,6 +216,7 @@ impl ChatOpenAIBuilder {
             stop: self.stop,
             max_retries: self.max_retries.unwrap_or(2),
             streaming: self.streaming.unwrap_or(false),
+            extra_headers: self.extra_headers,
             client: Client::new(),
             bound_tools: Vec::new(),
             tool_choice: None,
@@ -230,6 +273,11 @@ pub struct ChatOpenAI {
     pub max_retries: u32,
     /// Whether streaming is the default mode.
     pub streaming: bool,
+    /// Custom HTTP headers applied to every request, used for attribution or
+    /// routing on OpenAI-compatible gateways (OpenRouter, Together.ai, Groq,
+    /// Fireworks, etc.). Applied before the standard auth/content-type
+    /// headers so those cannot be overridden.
+    pub extra_headers: HashMap<String, String>,
     /// HTTP client.
     client: Client,
     /// Tools bound via `bind_tools`.
@@ -567,9 +615,13 @@ impl ChatOpenAI {
         let mut last_error = CognisError::Other("No attempts made".into());
 
         for attempt in 0..=self.max_retries {
-            let mut req = self
-                .client
-                .post(&url)
+            let mut req = self.client.post(&url);
+
+            for (k, v) in &self.extra_headers {
+                req = req.header(k.as_str(), v.as_str());
+            }
+
+            req = req
                 .header(
                     "Authorization",
                     format!("Bearer {}", self.api_key.expose_secret()),
@@ -618,9 +670,13 @@ impl ChatOpenAI {
     ) -> Result<std::pin::Pin<Box<dyn futures::Stream<Item = Result<Value>> + Send>>> {
         let url = format!("{}/v1/chat/completions", self.base_url);
 
-        let mut req = self
-            .client
-            .post(&url)
+        let mut req = self.client.post(&url);
+
+        for (k, v) in &self.extra_headers {
+            req = req.header(k.as_str(), v.as_str());
+        }
+
+        req = req
             .header(
                 "Authorization",
                 format!("Bearer {}", self.api_key.expose_secret()),
@@ -756,6 +812,7 @@ impl BaseChatModel for ChatOpenAI {
             stop: self.stop.clone(),
             max_retries: self.max_retries,
             streaming: self.streaming,
+            extra_headers: self.extra_headers.clone(),
             client: self.client.clone(),
             bound_tools,
             tool_choice,
@@ -1033,6 +1090,62 @@ mod tests {
         assert_eq!(payload["messages"].as_array().unwrap().len(), 1);
         assert!(payload.get("stream").is_none());
         assert!(payload.get("tools").is_none());
+    }
+
+    #[test]
+    fn test_extra_headers_on_builder() {
+        let model = ChatOpenAI::builder()
+            .model("gpt-4o")
+            .api_key("test-key")
+            .extra_header("HTTP-Referer", "https://mysite.com")
+            .extra_header("X-Title", "assistant")
+            .build()
+            .unwrap();
+
+        assert_eq!(model.extra_headers.len(), 2);
+        assert_eq!(
+            model.extra_headers.get("HTTP-Referer").map(String::as_str),
+            Some("https://mysite.com"),
+        );
+        assert_eq!(
+            model.extra_headers.get("X-Title").map(String::as_str),
+            Some("assistant"),
+        );
+    }
+
+    #[test]
+    fn test_extra_header_overwrites_same_key() {
+        let model = ChatOpenAI::builder()
+            .model("gpt-4o")
+            .api_key("test-key")
+            .extra_header("X-Title", "first")
+            .extra_header("X-Title", "second")
+            .build()
+            .unwrap();
+
+        assert_eq!(model.extra_headers.len(), 1);
+        assert_eq!(
+            model.extra_headers.get("X-Title").map(String::as_str),
+            Some("second"),
+        );
+    }
+
+    #[test]
+    fn test_extra_headers_map_replaces_all() {
+        let mut headers = HashMap::new();
+        headers.insert("X-Custom".to_string(), "value".to_string());
+
+        let model = ChatOpenAI::builder()
+            .model("gpt-4o")
+            .api_key("test-key")
+            .extra_header("HTTP-Referer", "https://old.com")
+            .extra_headers(headers)
+            .build()
+            .unwrap();
+
+        assert_eq!(model.extra_headers.len(), 1);
+        assert!(model.extra_headers.contains_key("X-Custom"));
+        assert!(!model.extra_headers.contains_key("HTTP-Referer"));
     }
 
     #[test]

--- a/crates/cognis/src/chat_models/openai.rs
+++ b/crates/cognis/src/chat_models/openai.rs
@@ -171,14 +171,17 @@ impl ChatOpenAIBuilder {
     /// ```no_run
     /// use cognis::chat_models::openai::ChatOpenAI;
     ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let model = ChatOpenAI::builder()
     ///     .model("meta-llama/llama-3.3-70b-instruct:free")
     ///     .api_key("sk-or-...")
     ///     .base_url("https://openrouter.ai/api")
     ///     .extra_header("HTTP-Referer", "https://mysite.com")
     ///     .extra_header("X-Title", "my-app")
-    ///     .build()
-    ///     .unwrap();
+    ///     .build()?;
+    /// # let _ = model;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn extra_header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         let key = key.into();

--- a/crates/cognis/src/chat_models/openai.rs
+++ b/crates/cognis/src/chat_models/openai.rs
@@ -812,6 +812,44 @@ impl ChatOpenAI {
             "function": function
         })
     }
+
+    /// Bind tools and return a concrete [`ChatOpenAI`] (not a trait object).
+    ///
+    /// This is the concrete counterpart to
+    /// [`BaseChatModel::bind_tools`](cognis_core::language_models::chat_model::BaseChatModel::bind_tools),
+    /// which returns `Box<dyn BaseChatModel>`. Preserving the concrete type is
+    /// useful for tests and for callers that need to inspect or further
+    /// configure the bound model before boxing.
+    ///
+    /// All state from `self` — including `extra_headers` — is cloned into the
+    /// returned `ChatOpenAI`.
+    pub fn bind_tools_concrete(
+        &self,
+        tools: &[ToolSchema],
+        tool_choice: Option<ToolChoice>,
+    ) -> ChatOpenAI {
+        let bound_tools: Vec<Value> = tools.iter().map(Self::tool_schema_to_openai).collect();
+
+        ChatOpenAI {
+            model: self.model.clone(),
+            api_key: self.api_key.clone(),
+            base_url: self.base_url.clone(),
+            organization: self.organization.clone(),
+            max_tokens: self.max_tokens,
+            temperature: self.temperature,
+            top_p: self.top_p,
+            frequency_penalty: self.frequency_penalty,
+            presence_penalty: self.presence_penalty,
+            seed: self.seed,
+            stop: self.stop.clone(),
+            max_retries: self.max_retries,
+            streaming: self.streaming,
+            extra_headers: self.extra_headers.clone(),
+            client: self.client.clone(),
+            bound_tools,
+            tool_choice,
+        }
+    }
 }
 
 #[async_trait]
@@ -845,27 +883,7 @@ impl BaseChatModel for ChatOpenAI {
         tools: &[ToolSchema],
         tool_choice: Option<ToolChoice>,
     ) -> Result<Box<dyn BaseChatModel>> {
-        let bound_tools: Vec<Value> = tools.iter().map(Self::tool_schema_to_openai).collect();
-
-        Ok(Box::new(ChatOpenAI {
-            model: self.model.clone(),
-            api_key: self.api_key.clone(),
-            base_url: self.base_url.clone(),
-            organization: self.organization.clone(),
-            max_tokens: self.max_tokens,
-            temperature: self.temperature,
-            top_p: self.top_p,
-            frequency_penalty: self.frequency_penalty,
-            presence_penalty: self.presence_penalty,
-            seed: self.seed,
-            stop: self.stop.clone(),
-            max_retries: self.max_retries,
-            streaming: self.streaming,
-            extra_headers: self.extra_headers.clone(),
-            client: self.client.clone(),
-            bound_tools,
-            tool_choice,
-        }))
+        Ok(Box::new(self.bind_tools_concrete(tools, tool_choice)))
     }
 
     fn profile(&self) -> ModelProfile {
@@ -1245,6 +1263,66 @@ mod tests {
 
         assert_eq!(model.extra_headers.len(), 1);
         assert!(model.extra_headers.contains_key("X-Title"));
+    }
+
+    #[test]
+    fn extra_headers_survive_bind_tools() {
+        let model = ChatOpenAI::builder()
+            .model("gpt-4o")
+            .api_key("test-key")
+            .extra_header("X-Title", "assistant")
+            .extra_header("HTTP-Referer", "https://mysite.com")
+            .build()
+            .unwrap();
+
+        // bind_tools_concrete returns a concrete ChatOpenAI so we can inspect
+        // extra_headers directly without needing `Any` downcasting on the
+        // trait object returned by `BaseChatModel::bind_tools`.
+        let bound = model.bind_tools_concrete(&[], None);
+
+        assert_eq!(
+            bound.extra_headers.get("X-Title").map(String::as_str),
+            Some("assistant"),
+        );
+        assert_eq!(
+            bound.extra_headers.get("HTTP-Referer").map(String::as_str),
+            Some("https://mysite.com"),
+        );
+        assert_eq!(bound.extra_headers.len(), 2);
+    }
+
+    #[test]
+    fn extra_headers_survive_bind_tools_with_real_tools() {
+        use cognis_core::tools::ToolSchema;
+
+        let model = ChatOpenAI::builder()
+            .model("gpt-4o")
+            .api_key("test-key")
+            .extra_header("X-Title", "assistant")
+            .build()
+            .unwrap();
+
+        let tools = vec![ToolSchema {
+            name: "search".to_string(),
+            description: "Search the web".to_string(),
+            parameters: Some(json!({
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"}
+                }
+            })),
+            extras: None,
+        }];
+
+        let bound = model.bind_tools_concrete(&tools, Some(ToolChoice::Auto));
+
+        // Headers survive even when tools and tool_choice are actually provided.
+        assert_eq!(
+            bound.extra_headers.get("X-Title").map(String::as_str),
+            Some("assistant"),
+        );
+        // And the tools were actually bound.
+        assert_eq!(bound.bound_tools.len(), 1);
     }
 
     #[test]

--- a/crates/cognis/src/chat_models/openai.rs
+++ b/crates/cognis/src/chat_models/openai.rs
@@ -21,6 +21,16 @@ use cognis_core::messages::{
 use cognis_core::outputs::{ChatGeneration, ChatGenerationChunk, ChatResult};
 use cognis_core::tools::ToolSchema;
 
+/// Case-insensitive check for headers the framework owns and must not let
+/// callers override via `extra_header` / `extra_headers`. Keeps auth and
+/// content-type policy authoritative regardless of what the caller passes.
+fn is_reserved_header(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "authorization" | "content-type" | "openai-organization"
+    )
+}
+
 /// Builder for constructing a [`ChatOpenAI`] instance.
 #[derive(Debug)]
 pub struct ChatOpenAIBuilder {
@@ -147,8 +157,14 @@ impl ChatOpenAIBuilder {
     /// multiple times with the same key overwrites the prior value.
     ///
     /// The standard `Authorization`, `Content-Type`, and `OpenAI-Organization`
-    /// headers are applied after extra headers, so they cannot be
-    /// accidentally overridden.
+    /// headers are reserved — passing any of those as an extra header is
+    /// ignored (with a `tracing::warn!`), since the framework sets them
+    /// itself.
+    ///
+    /// Header names are stored case-sensitively internally. To avoid sending
+    /// duplicate headers with different casings, pick a single canonical
+    /// casing per header (e.g. `X-Title`, not a mix of `x-title` and
+    /// `X-Title`).
     ///
     /// # Example
     ///
@@ -165,7 +181,16 @@ impl ChatOpenAIBuilder {
     ///     .unwrap();
     /// ```
     pub fn extra_header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
-        self.extra_headers.insert(key.into(), value.into());
+        let key = key.into();
+        if is_reserved_header(&key) {
+            tracing::warn!(
+                header = %key,
+                "ChatOpenAIBuilder::extra_header: reserved header ignored \
+                 (framework sets this itself)",
+            );
+            return self;
+        }
+        self.extra_headers.insert(key, value.into());
         self
     }
 
@@ -174,8 +199,26 @@ impl ChatOpenAIBuilder {
     /// Prefer [`extra_header`](Self::extra_header) for additive use. This
     /// method is intended for cases where the caller already has a header
     /// map (e.g. loaded from config).
+    ///
+    /// Reserved headers (`Authorization`, `Content-Type`,
+    /// `OpenAI-Organization`) are filtered out of the incoming map with a
+    /// `tracing::warn!`, matching the contract of
+    /// [`extra_header`](Self::extra_header).
     pub fn extra_headers(mut self, headers: HashMap<String, String>) -> Self {
-        self.extra_headers = headers;
+        self.extra_headers = headers
+            .into_iter()
+            .filter(|(k, _)| {
+                if is_reserved_header(k) {
+                    tracing::warn!(
+                        header = %k,
+                        "ChatOpenAIBuilder::extra_headers: reserved header ignored",
+                    );
+                    false
+                } else {
+                    true
+                }
+            })
+            .collect();
         self
     }
 
@@ -618,6 +661,9 @@ impl ChatOpenAI {
             let mut req = self.client.post(&url);
 
             for (k, v) in &self.extra_headers {
+                if is_reserved_header(k) {
+                    continue;
+                }
                 req = req.header(k.as_str(), v.as_str());
             }
 
@@ -673,6 +719,9 @@ impl ChatOpenAI {
         let mut req = self.client.post(&url);
 
         for (k, v) in &self.extra_headers {
+            if is_reserved_header(k) {
+                continue;
+            }
             req = req.header(k.as_str(), v.as_str());
         }
 
@@ -1146,6 +1195,56 @@ mod tests {
         assert_eq!(model.extra_headers.len(), 1);
         assert!(model.extra_headers.contains_key("X-Custom"));
         assert!(!model.extra_headers.contains_key("HTTP-Referer"));
+    }
+
+    #[test]
+    fn extra_header_filters_reserved_authorization() {
+        let model = ChatOpenAI::builder()
+            .model("gpt-4o")
+            .api_key("test-key")
+            .extra_header("Authorization", "Bearer stolen")
+            .build()
+            .unwrap();
+
+        // The reserved header must have been filtered at insert time.
+        assert!(!model.extra_headers.contains_key("Authorization"));
+        assert!(!model.extra_headers.contains_key("authorization"));
+    }
+
+    #[test]
+    fn extra_header_reserved_filter_is_case_insensitive() {
+        let model = ChatOpenAI::builder()
+            .model("gpt-4o")
+            .api_key("test-key")
+            .extra_header("authorization", "Bearer stolen")
+            .extra_header("CONTENT-TYPE", "text/plain")
+            .extra_header("OpenAI-Organization", "org-evil")
+            .extra_header("X-Title", "keepme")
+            .build()
+            .unwrap();
+
+        assert_eq!(model.extra_headers.len(), 1);
+        assert_eq!(
+            model.extra_headers.get("X-Title").map(String::as_str),
+            Some("keepme"),
+        );
+    }
+
+    #[test]
+    fn extra_headers_map_filters_reserved() {
+        let mut headers = HashMap::new();
+        headers.insert("Authorization".to_string(), "Bearer stolen".to_string());
+        headers.insert("X-Title".to_string(), "keepme".to_string());
+
+        let model = ChatOpenAI::builder()
+            .model("gpt-4o")
+            .api_key("test-key")
+            .extra_headers(headers)
+            .build()
+            .unwrap();
+
+        assert_eq!(model.extra_headers.len(), 1);
+        assert!(model.extra_headers.contains_key("X-Title"));
     }
 
     #[test]

--- a/crates/cognis/src/chat_models/openrouter.rs
+++ b/crates/cognis/src/chat_models/openrouter.rs
@@ -1,0 +1,231 @@
+//! Convenience builder for OpenRouter — a thin wrapper over `ChatOpenAI`
+//! that defaults the base URL and exposes named setters for OpenRouter's
+//! attribution headers (`HTTP-Referer` via [`ChatOpenRouterBuilder::app_url`],
+//! `X-Title` via [`ChatOpenRouterBuilder::app_name`]).
+//!
+//! [`ChatOpenRouterBuilder::build`] returns [`ChatOpenAI`]. All HTTP,
+//! retry, streaming, and tool-calling behavior is the same as
+//! `ChatOpenAI` — this module is purely about discoverability and the
+//! default endpoint.
+//!
+//! [#10](https://github.com/0xvasanth/cognis/issues/10).
+
+use std::collections::HashMap;
+
+use cognis_core::error::Result;
+
+use crate::chat_models::openai::{ChatOpenAI, ChatOpenAIBuilder};
+
+const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api";
+
+/// Namespace type — entry point for the OpenRouter builder.
+///
+/// # Example
+///
+/// ```no_run
+/// use cognis::chat_models::openrouter::ChatOpenRouter;
+///
+/// let model = ChatOpenRouter::builder()
+///     .model("meta-llama/llama-3.3-70b-instruct:free")
+///     .api_key("sk-or-...")
+///     .app_name("my-assistant")
+///     .app_url("https://example.com")
+///     .build()
+///     .unwrap();
+/// ```
+pub struct ChatOpenRouter;
+
+impl ChatOpenRouter {
+    /// Start building a [`ChatOpenAI`] pre-configured for OpenRouter.
+    pub fn builder() -> ChatOpenRouterBuilder {
+        ChatOpenRouterBuilder::new()
+    }
+}
+
+/// Builder that configures [`ChatOpenAI`] for OpenRouter.
+///
+/// Wraps [`ChatOpenAIBuilder`] and pre-sets the OpenRouter base URL
+/// (`https://openrouter.ai/api`). Adds
+/// [`app_name`](Self::app_name) / [`app_url`](Self::app_url) setters
+/// for OpenRouter's attribution headers (`X-Title` and `HTTP-Referer`).
+/// Common model parameters are delegated through to the inner builder.
+pub struct ChatOpenRouterBuilder {
+    inner: ChatOpenAIBuilder,
+}
+
+impl ChatOpenRouterBuilder {
+    fn new() -> Self {
+        Self {
+            inner: ChatOpenAI::builder().base_url(OPENROUTER_BASE_URL),
+        }
+    }
+
+    /// Set the OpenRouter model identifier, e.g.
+    /// `"meta-llama/llama-3.3-70b-instruct:free"`.
+    pub fn model(mut self, model: impl Into<String>) -> Self {
+        self.inner = self.inner.model(model);
+        self
+    }
+
+    /// Set the OpenRouter API key. Falls back to `OPENAI_API_KEY` env var
+    /// if not provided (delegated from [`ChatOpenAIBuilder::api_key`]).
+    pub fn api_key(mut self, key: impl Into<String>) -> Self {
+        self.inner = self.inner.api_key(key);
+        self
+    }
+
+    /// Set the application name — sent as the `X-Title` HTTP header.
+    ///
+    /// OpenRouter's public app leaderboard uses this header; set it if
+    /// you want your app to appear there.
+    pub fn app_name(mut self, name: impl Into<String>) -> Self {
+        self.inner = self.inner.extra_header("X-Title", name);
+        self
+    }
+
+    /// Set the application URL — sent as the `HTTP-Referer` HTTP header.
+    ///
+    /// OpenRouter uses this for attribution and its app leaderboard.
+    pub fn app_url(mut self, url: impl Into<String>) -> Self {
+        self.inner = self.inner.extra_header("HTTP-Referer", url);
+        self
+    }
+
+    /// Override the default base URL (`https://openrouter.ai/api`).
+    ///
+    /// Rarely needed — provided for staging / proxy scenarios.
+    pub fn base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.inner = self.inner.base_url(base_url);
+        self
+    }
+
+    /// Sampling temperature (0.0 - 2.0).
+    pub fn temperature(mut self, temperature: f64) -> Self {
+        self.inner = self.inner.temperature(temperature);
+        self
+    }
+
+    /// Maximum tokens to generate.
+    pub fn max_tokens(mut self, max_tokens: u32) -> Self {
+        self.inner = self.inner.max_tokens(max_tokens);
+        self
+    }
+
+    /// Maximum retry attempts on transient errors.
+    pub fn max_retries(mut self, max_retries: u32) -> Self {
+        self.inner = self.inner.max_retries(max_retries);
+        self
+    }
+
+    /// Default streaming mode. Per-call streaming still uses `stream()`.
+    pub fn streaming(mut self, streaming: bool) -> Self {
+        self.inner = self.inner.streaming(streaming);
+        self
+    }
+
+    /// Add an additional custom header beyond `X-Title` / `HTTP-Referer`.
+    ///
+    /// Delegates to [`ChatOpenAIBuilder::extra_header`], which filters
+    /// reserved headers (`Authorization`, `Content-Type`,
+    /// `OpenAI-Organization`).
+    pub fn extra_header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.inner = self.inner.extra_header(key, value);
+        self
+    }
+
+    /// Replace all extra headers. See
+    /// [`ChatOpenAIBuilder::extra_headers`] for filtering semantics.
+    pub fn extra_headers(mut self, headers: HashMap<String, String>) -> Self {
+        self.inner = self.inner.extra_headers(headers);
+        self
+    }
+
+    /// Finish building — returns a configured [`ChatOpenAI`].
+    pub fn build(self) -> Result<ChatOpenAI> {
+        self.inner.build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_defaults_base_url_to_openrouter() {
+        let model = ChatOpenRouter::builder()
+            .model("meta-llama/llama-3.3-70b-instruct:free")
+            .api_key("sk-or-test")
+            .build()
+            .unwrap();
+
+        assert_eq!(model.base_url, OPENROUTER_BASE_URL);
+    }
+
+    #[test]
+    fn app_name_sets_x_title_header() {
+        let model = ChatOpenRouter::builder()
+            .model("gpt-4o")
+            .api_key("sk-or-test")
+            .app_name("my-assistant")
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            model.extra_headers.get("X-Title").map(String::as_str),
+            Some("my-assistant"),
+        );
+    }
+
+    #[test]
+    fn app_url_sets_http_referer_header() {
+        let model = ChatOpenRouter::builder()
+            .model("gpt-4o")
+            .api_key("sk-or-test")
+            .app_url("https://example.com")
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            model.extra_headers.get("HTTP-Referer").map(String::as_str),
+            Some("https://example.com"),
+        );
+    }
+
+    #[test]
+    fn app_name_and_app_url_coexist_with_extra_header() {
+        let model = ChatOpenRouter::builder()
+            .model("gpt-4o")
+            .api_key("sk-or-test")
+            .app_name("assistant")
+            .app_url("https://example.com")
+            .extra_header("X-Custom", "value")
+            .build()
+            .unwrap();
+
+        assert_eq!(model.extra_headers.len(), 3);
+        assert_eq!(
+            model.extra_headers.get("X-Title").map(String::as_str),
+            Some("assistant"),
+        );
+        assert_eq!(
+            model.extra_headers.get("HTTP-Referer").map(String::as_str),
+            Some("https://example.com"),
+        );
+        assert_eq!(
+            model.extra_headers.get("X-Custom").map(String::as_str),
+            Some("value"),
+        );
+    }
+
+    #[test]
+    fn base_url_override_is_respected() {
+        let model = ChatOpenRouter::builder()
+            .model("gpt-4o")
+            .api_key("sk-or-test")
+            .base_url("https://staging.openrouter.example")
+            .build()
+            .unwrap();
+
+        assert_eq!(model.base_url, "https://staging.openrouter.example");
+    }
+}

--- a/crates/cognis/src/chat_models/openrouter.rs
+++ b/crates/cognis/src/chat_models/openrouter.rs
@@ -9,6 +9,33 @@
 //! default endpoint.
 //!
 //! [#10](https://github.com/0xvasanth/cognis/issues/10).
+//!
+//! # Example
+//!
+//! ```no_run
+//! use cognis::chat_models::openrouter::ChatOpenRouter;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let model = ChatOpenRouter::builder()
+//!     .model("meta-llama/llama-3.3-70b-instruct:free")
+//!     .api_key("sk-or-...")
+//!     .app_name("my-assistant")
+//!     .app_url("https://example.com")
+//!     .build()?;
+//! # let _ = model;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # When to drop to `ChatOpenAI` directly
+//!
+//! This wrapper is deliberately focused on OpenRouter-relevant setters.
+//! If you need OpenAI-specific configuration such as the `organization`
+//! setter (sent as the `OpenAI-Organization` header), construct
+//! [`ChatOpenAI::builder`] directly and pass
+//! `.base_url("https://openrouter.ai/api")`.
+//!
+//! [`ChatOpenAI::builder`]: crate::chat_models::openai::ChatOpenAI::builder
 
 use std::collections::HashMap;
 

--- a/crates/cognis/tests/openai_extra_headers.rs
+++ b/crates/cognis/tests/openai_extra_headers.rs
@@ -1,0 +1,62 @@
+//! Integration: verify ChatOpenAI's extra_headers reach the wire.
+//!
+//! Relevant to [#10](https://github.com/0xvasanth/cognis/issues/10) — OpenRouter
+//! and other OpenAI-compatible gateways require attribution headers on every
+//! request. This test spins up a wiremock server, sends a single chat
+//! completion, and asserts both the custom headers AND the standard
+//! Authorization header are present as expected.
+
+#![cfg(feature = "openai")]
+
+use cognis::chat_models::openai::ChatOpenAI;
+use cognis_core::language_models::chat_model::BaseChatModel;
+use cognis_core::messages::{HumanMessage, Message};
+use serde_json::json;
+use wiremock::matchers::{header, header_exists, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn extra_headers_reach_the_wire_on_invoke() {
+    let server = MockServer::start().await;
+
+    // A minimal OpenAI-compatible chat completion response.
+    let body = json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "gpt-4o",
+        "choices": [{
+            "index": 0,
+            "message": { "role": "assistant", "content": "hi" },
+            "finish_reason": "stop"
+        }],
+        "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 }
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .and(header("HTTP-Referer", "https://mysite.com"))
+        .and(header("X-Title", "cognis-test-app"))
+        .and(header_exists("Authorization"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let model = ChatOpenAI::builder()
+        .model("gpt-4o")
+        .api_key("sk-test-key")
+        .base_url(server.uri())
+        .extra_header("HTTP-Referer", "https://mysite.com")
+        .extra_header("X-Title", "cognis-test-app")
+        .build()
+        .unwrap();
+
+    let messages = vec![Message::Human(HumanMessage::new("hello"))];
+    let result = model._generate(&messages, None).await;
+
+    assert!(result.is_ok(), "generate returned error: {:?}", result);
+    // wiremock's `.expect(1)` + `MockServer::drop` automatically assert the
+    // request was received. If headers didn't match, the mock would not
+    // intercept it and the request would 404 / 500.
+}


### PR DESCRIPTION
## Summary

Closes #10.

`ChatOpenAI` now accepts arbitrary HTTP headers via `ChatOpenAIBuilder::extra_header(k, v)` / `extra_headers(map)`. Headers are applied on every request (invoke retry path + streaming path) before the standard `Authorization` / `Content-Type` so those stay authoritative. Reserved headers (`Authorization`, `Content-Type`, `OpenAI-Organization`) are filtered at both insert and send time — case-insensitively — so callers can't accidentally override auth by passing the wrong key. Survives `bind_tools` cloning.

Also adds `ChatOpenRouter` — a thin convenience builder that defaults the base URL to OpenRouter and exposes named setters:
- `.app_name(s)` → `X-Title` header
- `.app_url(u)` → `HTTP-Referer` header

`ChatOpenRouterBuilder::build()` returns `ChatOpenAI`. Zero duplicated HTTP/retry/streaming code.

## Why

OpenRouter ranks apps by whether they send attribution headers. `ChatOpenAI` previously had no way to set per-request headers. This also unlocks Together.ai routing tags, Groq / Fireworks custom headers, and any future OpenAI-compatible gateway that wants per-request metadata.

## Test plan

- [x] Unit tests on `ChatOpenAIBuilder`: setter semantics, overwrite-same-key, replace-all map, reserved-header filter (case-insensitive), bind_tools survival (x2 — empty tools and with a real tool)
- [x] Integration test via `wiremock`: spins up a fake OpenAI endpoint, asserts `HTTP-Referer` + `X-Title` + `Authorization` all reach the outgoing POST
- [x] Unit tests on `ChatOpenRouterBuilder`: default base URL, `app_name` → `X-Title`, `app_url` → `HTTP-Referer`, coexistence with `extra_header`, `base_url` override
- [x] Doc-tests for both public surfaces (no_run)
- [x] `cargo test --workspace --features all-providers` — 10,579 passed, 0 failed
- [x] `cargo clippy --workspace --features all-providers -- -D warnings` (clippy 1.95, matches CI) — clean
- [x] `cargo fmt --all -- --check` — clean

## Example

\`\`\`rust
use cognis::chat_models::openrouter::ChatOpenRouter;

let model = ChatOpenRouter::builder()
    .model("meta-llama/llama-3.3-70b-instruct:free")
    .api_key(key)
    .app_name("my-assistant")
    .app_url("https://mysite.com")
    .build()?;
\`\`\`

## Commits

1. \`8e0dffd\` feat(openai): extra_header builder for OpenAI-compatible gateways
2. \`381a33c\` fix(openai): filter reserved headers in extra_headers
3. \`fe26eef\` test(openai): pin extra_headers survival across bind_tools clone
4. \`2ecd787\` test(openai): integration test that extra_headers reach the wire
5. \`491caa8\` feat(openrouter): add ChatOpenRouter convenience builder
6. \`e500cbb\` docs(openai): runnable doc-test examples for extra_header & OpenRouter

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-request HTTP headers to `ChatOpenAI` and introduces `ChatOpenRouter` for OpenRouter attribution. Closes #10 by enabling `HTTP-Referer` and `X-Title` headers across both standard and streaming requests.

- **New Features**
  - `ChatOpenAIBuilder::extra_header(k, v)` and `extra_headers(map)` add headers to every request; applied before `Authorization`/`Content-Type`.
  - Filters reserved headers (`Authorization`, `Content-Type`, `OpenAI-Organization`) case-insensitively at insert and send time.
  - Headers persist through `bind_tools` via a new `bind_tools_concrete`.
  - New `ChatOpenRouter` builder: defaults `base_url` to OpenRouter and maps `.app_name()` → `X-Title`, `.app_url()` → `HTTP-Referer`; `build()` returns `ChatOpenAI`.

- **Dependencies**
  - Added `tracing` and dev dependency `wiremock`.

<sup>Written for commit e500cbbd56d126c87195d3dbc40769db1c8199d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

