### PR TITLE
chore: bump workspace to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "cognis"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "cognis-core",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "cognis-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "cognis-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "cognisagent"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "cognis",
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "cognisgraph"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ secrecy = { version = "0.10", features = ["serde"] }
 tracing = "0.1"
 
 
-cognis = { path = "crates/cognis", version = "0.2.0" }
-cognis-core = { path = "crates/cognis-core", version = "0.2.0" }
-cognis-macros = { path = "crates/cognis-macros", version = "0.2.0" }
-cognisgraph = { path = "crates/cognisgraph", version = "0.2.0" }
-cognisagent = { path = "crates/cognisagent", version = "0.2.0" }
+cognis = { path = "crates/cognis", version = "0.2.1" }
+cognis-core = { path = "crates/cognis-core", version = "0.2.1" }
+cognis-macros = { path = "crates/cognis-macros", version = "0.2.1" }
+cognisgraph = { path = "crates/cognisgraph", version = "0.2.1" }
+cognisagent = { path = "crates/cognisagent", version = "0.2.1" }

--- a/crates/cognis-core/Cargo.toml
+++ b/crates/cognis-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cognis-core"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license.workspace = true
 description = "Core traits and types for the Cognis LLM framework"

--- a/crates/cognis-macros/Cargo.toml
+++ b/crates/cognis-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cognis-macros"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license.workspace = true
 description = "Standalone derive macros for generating OpenAPI-compatible JSON schemas from Rust structs"

--- a/crates/cognis/Cargo.toml
+++ b/crates/cognis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cognis"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license.workspace = true
 description = "LLM application framework built on cognis-core"

--- a/crates/cognisagent/Cargo.toml
+++ b/crates/cognisagent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cognisagent"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license.workspace = true
 description = "Batteries-included agent framework built on cognis and cognisgraph"

--- a/crates/cognisgraph/Cargo.toml
+++ b/crates/cognisgraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cognisgraph"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license.workspace = true
 description = "State graph orchestration framework for multi-actor agent workflows"


### PR DESCRIPTION
Patch bump rolling up:

- #21 feat: OpenRouter attribution + extra-headers on `ChatOpenAI` (closes #10)

Mirrors the convention of #20 (0.1.x → 0.2.0 release bump).