### PR TITLE
feat: V1 parity extras — Hierarchical/Consensus, PluginRegistry, HybridMemory, AgentEventBus, graph analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ Thumbs.db
 # Environment
 .env
 .env.local
+
+# Docs — global ignore covers docs/, but track the Mintlify site.
+!docs/
+docs/*
+!docs/mintlify/

--- a/crates/cognis/src/agent/memory.rs
+++ b/crates/cognis/src/agent/memory.rs
@@ -1040,3 +1040,135 @@ mod tests_entity_kg {
         assert_eq!(m.triples(), &[("X".into(), "rel".into(), "Y".into())]);
     }
 }
+
+// ────────────────────────────────────────────────────────────────────────
+// HybridMemory — combine N member memories. Writes fan out to every
+// member; seed() concatenates each member's contribution in registration
+// order. Use to compose specialized memories (e.g. recent buffer +
+// long-term summary + entity ledger + semantic vector recall).
+// ────────────────────────────────────────────────────────────────────────
+
+/// A memory composed of several member memories. Each `write` is
+/// broadcast to every member; `seed` concatenates each member's
+/// contribution in registration order.
+///
+/// Use to compose specialized memories — e.g. a `Window` for recent
+/// turns plus a `SummaryMemory` for older context plus an `EntityMemory`
+/// to surface known entities. Each member can do its own thing on write
+/// (the Window will trim, the SummaryMemory will compact, etc.); the
+/// agent sees a unified seed.
+pub struct HybridMemory {
+    members: Vec<Box<dyn Memory>>,
+    /// Tracks the raw write history so `read()` can return a `&[Message]`
+    /// without materializing across members. Members own their own
+    /// (possibly-transformed) buffers.
+    buf: Vec<Message>,
+}
+
+impl Default for HybridMemory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HybridMemory {
+    /// Empty hybrid with no members. Add members via [`HybridMemory::with`].
+    pub fn new() -> Self {
+        Self {
+            members: Vec::new(),
+            buf: Vec::new(),
+        }
+    }
+
+    /// Append a member memory. Builder-style.
+    pub fn with(mut self, member: impl Memory + 'static) -> Self {
+        self.members.push(Box::new(member));
+        self
+    }
+
+    /// Number of members.
+    pub fn member_count(&self) -> usize {
+        self.members.len()
+    }
+}
+
+impl Memory for HybridMemory {
+    fn read(&self) -> &[Message] {
+        &self.buf
+    }
+    fn write(&mut self, msg: Message) {
+        for m in &mut self.members {
+            m.write(msg.clone());
+        }
+        self.buf.push(msg);
+    }
+    fn clear(&mut self) {
+        for m in &mut self.members {
+            m.clear();
+        }
+        self.buf.clear();
+    }
+    fn seed(&self) -> Vec<Message> {
+        let mut out: Vec<Message> = Vec::new();
+        for m in &self.members {
+            out.extend(m.seed());
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests_hybrid {
+    use super::*;
+
+    #[test]
+    fn write_fans_out_to_every_member() {
+        let mut h = HybridMemory::new()
+            .with(Buffer::new())
+            .with(Window::new(10));
+        h.write(Message::human("a"));
+        h.write(Message::human("b"));
+        assert_eq!(h.read().len(), 2);
+        // Both members should have seen both writes.
+        let seed = h.seed();
+        // Buffer contributes 2 + Window contributes 2 = 4 (no dedup).
+        assert_eq!(seed.len(), 4);
+    }
+
+    #[test]
+    fn clear_empties_every_member() {
+        let mut h = HybridMemory::new()
+            .with(Buffer::new())
+            .with(Window::new(10));
+        h.write(Message::human("a"));
+        h.clear();
+        assert!(h.read().is_empty());
+        assert!(h.seed().is_empty());
+    }
+
+    #[test]
+    fn seed_concatenates_in_member_order() {
+        let mut h = HybridMemory::new()
+            .with(Buffer::new().with_system("recent context"))
+            .with(EntityMemory::new());
+        h.write(Message::human("Cognis is fast."));
+        let seed = h.seed();
+        // Buffer: system pin + 1 human msg → 2
+        // EntityMemory: synthesized "Known entities" system + 1 human → 2
+        assert_eq!(seed.len(), 4);
+        // First member's contribution comes first.
+        assert!(matches!(seed[0], Message::System(_)));
+        assert_eq!(seed[0].content(), "recent context");
+    }
+
+    #[test]
+    fn empty_hybrid_round_trips() {
+        let mut h = HybridMemory::new();
+        h.write(Message::human("a"));
+        // No members → seed is empty (only members contribute).
+        assert!(h.seed().is_empty());
+        // But read() reflects the canonical write-buffer.
+        assert_eq!(h.read().len(), 1);
+        assert_eq!(h.member_count(), 0);
+    }
+}

--- a/crates/cognis/src/agent/mod.rs
+++ b/crates/cognis/src/agent/mod.rs
@@ -11,6 +11,7 @@ pub mod health;
 pub mod lifecycle;
 pub mod memory;
 pub mod plugin;
+pub mod plugin_registry;
 pub mod state;
 pub mod think_node;
 pub mod tool_node;
@@ -27,6 +28,7 @@ pub use memory::{
     Window,
 };
 pub use plugin::{AgentPlugin, FnPlugin};
+pub use plugin_registry::{ClosurePlugin, LifecyclePlugin, PluginRegistry};
 pub use state::{AgentState, AgentStateUpdate};
 pub use think_node::ThinkNode;
 pub use tool_node::ToolDispatchNode;

--- a/crates/cognis/src/agent/mod.rs
+++ b/crates/cognis/src/agent/mod.rs
@@ -23,7 +23,7 @@ pub use default_graph::{default_react_graph, default_react_graph_with_limits};
 pub use health::AgentHealth;
 pub use lifecycle::{AgentLifecycle, OnStart};
 pub use memory::{
-    Buffer, EntityExtractor, EntityFact, EntityMemory, KnowledgeGraphMemory, Memory,
+    Buffer, EntityExtractor, EntityFact, EntityMemory, HybridMemory, KnowledgeGraphMemory, Memory,
     SummaryBufferMemory, SummaryMemory, TokenBufferMemory, Triple, TripleExtractor, VectorMemory,
     Window,
 };

--- a/crates/cognis/src/agent/plugin_registry.rs
+++ b/crates/cognis/src/agent/plugin_registry.rs
@@ -195,7 +195,7 @@ impl PluginRegistry {
     /// or references to unknown plugins.
     fn topo_order(&self) -> Result<Vec<String>> {
         let mut indeg: HashMap<String, usize> =
-            self.plugins.iter().map(|(n, _)| (n.clone(), 0)).collect();
+            self.plugins.keys().map(|n| (n.clone(), 0)).collect();
         let mut rev: HashMap<String, Vec<String>> = HashMap::new();
         for (name, p) in &self.plugins {
             for d in p.deps() {

--- a/crates/cognis/src/agent/plugin_registry.rs
+++ b/crates/cognis/src/agent/plugin_registry.rs
@@ -1,0 +1,440 @@
+//! Plugin registry with lifecycle and dependency resolution.
+//!
+//! Builds on [`super::AgentPlugin`] (single-shot consume-self installer)
+//! with a richer [`LifecyclePlugin`] trait that supports:
+//!
+//! - **Named plugins** — each plugin reports a unique `name()`.
+//! - **Declared dependencies** — `deps()` returns the names of plugins
+//!   that must be active before this one. The registry topo-sorts the
+//!   activation order and rejects cycles.
+//! - **Lifecycle** — `register` / `activate` / `deactivate` / `unregister`,
+//!   so plugins can clean up resources or be selectively disabled at
+//!   runtime.
+//!
+//! Use `LifecyclePlugin` when you ship multiple cooperating plugins
+//! that depend on each other; use the simpler [`super::AgentPlugin`]
+//! / [`super::FnPlugin`] when you just want one inline mutator.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Arc;
+
+use cognis_core::{CognisError, Result};
+
+use super::AgentBuilder;
+
+/// A plugin that participates in the lifecycle managed by a
+/// [`PluginRegistry`]. Implementations are `&self` so the registry can
+/// activate/deactivate the same plugin multiple times.
+pub trait LifecyclePlugin: Send + Sync {
+    /// Stable, unique plugin name.
+    fn name(&self) -> &str;
+
+    /// Names of plugins that must be active before this one. The registry
+    /// uses these to compute activation order.
+    fn deps(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    /// Mutate the builder. Called by [`PluginRegistry::activate_all`]
+    /// in topo-sorted order. Return an error to abort activation
+    /// (the registry rolls back to the pre-activation state).
+    fn activate(&self, builder: AgentBuilder) -> Result<AgentBuilder>;
+
+    /// Optional teardown — called on `deactivate`. Default is a no-op.
+    fn deactivate(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Closure-based [`LifecyclePlugin`] for inline registration.
+pub struct ClosurePlugin {
+    name: String,
+    deps: Vec<String>,
+    #[allow(clippy::type_complexity)]
+    activate_fn: Box<dyn Fn(AgentBuilder) -> Result<AgentBuilder> + Send + Sync>,
+}
+
+impl ClosurePlugin {
+    /// Build with a name + activation closure. Defaults to no deps.
+    pub fn new<F>(name: impl Into<String>, activate: F) -> Self
+    where
+        F: Fn(AgentBuilder) -> Result<AgentBuilder> + Send + Sync + 'static,
+    {
+        Self {
+            name: name.into(),
+            deps: Vec::new(),
+            activate_fn: Box::new(activate),
+        }
+    }
+
+    /// Declare a dependency on another plugin. Builder-style.
+    pub fn after(mut self, dep: impl Into<String>) -> Self {
+        self.deps.push(dep.into());
+        self
+    }
+}
+
+impl LifecyclePlugin for ClosurePlugin {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn deps(&self) -> Vec<String> {
+        self.deps.clone()
+    }
+    fn activate(&self, builder: AgentBuilder) -> Result<AgentBuilder> {
+        (self.activate_fn)(builder)
+    }
+}
+
+/// Registry of [`LifecyclePlugin`]s. Cheap to clone (plugins live behind
+/// `Arc`).
+#[derive(Clone, Default)]
+pub struct PluginRegistry {
+    plugins: HashMap<String, Arc<dyn LifecyclePlugin>>,
+    active: HashSet<String>,
+}
+
+impl PluginRegistry {
+    /// Empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a plugin under its `name()`. Errors on duplicate names.
+    pub fn register(&mut self, plugin: Arc<dyn LifecyclePlugin>) -> Result<()> {
+        let name = plugin.name().to_string();
+        if self.plugins.contains_key(&name) {
+            return Err(CognisError::Configuration(format!(
+                "PluginRegistry: duplicate plugin `{name}`"
+            )));
+        }
+        self.plugins.insert(name, plugin);
+        Ok(())
+    }
+
+    /// Unregister a plugin by name. If the plugin is currently active,
+    /// it is deactivated first.
+    pub fn unregister(&mut self, name: &str) -> Result<()> {
+        if self.active.contains(name) {
+            if let Some(p) = self.plugins.get(name) {
+                p.deactivate()?;
+            }
+            self.active.remove(name);
+        }
+        self.plugins.remove(name);
+        Ok(())
+    }
+
+    /// Names of every registered plugin (sorted).
+    pub fn names(&self) -> Vec<String> {
+        let mut v: Vec<String> = self.plugins.keys().cloned().collect();
+        v.sort();
+        v
+    }
+
+    /// Names of currently active plugins (sorted).
+    pub fn active(&self) -> Vec<String> {
+        let mut v: Vec<String> = self.active.iter().cloned().collect();
+        v.sort();
+        v
+    }
+
+    /// Activate every registered plugin in dependency order. Returns the
+    /// mutated builder. Errors if any plugin's `activate` fails or if
+    /// the dependency graph contains a cycle / unknown name. On error,
+    /// already-activated plugins are deactivated to keep registry state
+    /// consistent.
+    pub fn activate_all(&mut self, builder: AgentBuilder) -> Result<AgentBuilder> {
+        let order = self.topo_order()?;
+        let mut current = builder;
+        let mut newly_active: Vec<String> = Vec::new();
+        for name in order {
+            if self.active.contains(&name) {
+                continue;
+            }
+            let plugin = self.plugins.get(&name).expect("topo only returns known");
+            match plugin.activate(current) {
+                Ok(b) => {
+                    current = b;
+                    self.active.insert(name.clone());
+                    newly_active.push(name);
+                }
+                Err(e) => {
+                    // Roll back the plugins we activated this call so the
+                    // registry doesn't end up half-on.
+                    for n in newly_active.iter().rev() {
+                        if let Some(p) = self.plugins.get(n) {
+                            let _ = p.deactivate();
+                        }
+                        self.active.remove(n);
+                    }
+                    return Err(e);
+                }
+            }
+        }
+        Ok(current)
+    }
+
+    /// Deactivate every active plugin in reverse activation order.
+    pub fn deactivate_all(&mut self) -> Result<()> {
+        // Reverse-topo for shutdown so dependents tear down before their deps.
+        let mut order = self.topo_order()?;
+        order.reverse();
+        for name in order {
+            if !self.active.remove(&name) {
+                continue;
+            }
+            if let Some(p) = self.plugins.get(&name) {
+                p.deactivate()?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Topo-sort of the registered plugins by `deps`. Errors on cycles
+    /// or references to unknown plugins.
+    fn topo_order(&self) -> Result<Vec<String>> {
+        let mut indeg: HashMap<String, usize> =
+            self.plugins.iter().map(|(n, _)| (n.clone(), 0)).collect();
+        let mut rev: HashMap<String, Vec<String>> = HashMap::new();
+        for (name, p) in &self.plugins {
+            for d in p.deps() {
+                if !self.plugins.contains_key(&d) {
+                    return Err(CognisError::Configuration(format!(
+                        "PluginRegistry: `{name}` depends on unknown plugin `{d}`"
+                    )));
+                }
+                *indeg.get_mut(name).unwrap() += 1;
+                rev.entry(d).or_default().push(name.clone());
+            }
+        }
+        let mut ready: VecDeque<String> = indeg
+            .iter()
+            .filter_map(|(n, &k)| if k == 0 { Some(n.clone()) } else { None })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .collect();
+        // Sort the initial frontier deterministically.
+        let mut ready_vec: Vec<String> = ready.drain(..).collect();
+        ready_vec.sort();
+        let mut ready: VecDeque<String> = ready_vec.into_iter().collect();
+
+        let mut out = Vec::with_capacity(self.plugins.len());
+        while let Some(name) = ready.pop_front() {
+            out.push(name.clone());
+            if let Some(downstream) = rev.get(&name) {
+                let mut newly_ready: Vec<String> = Vec::new();
+                for d in downstream {
+                    let n = indeg.get_mut(d).unwrap();
+                    *n -= 1;
+                    if *n == 0 {
+                        newly_ready.push(d.clone());
+                    }
+                }
+                newly_ready.sort();
+                for n in newly_ready {
+                    ready.push_back(n);
+                }
+            }
+        }
+        if out.len() != self.plugins.len() {
+            return Err(CognisError::Configuration(
+                "PluginRegistry: dependency cycle".into(),
+            ));
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use super::super::AgentBuilder;
+    use super::*;
+
+    fn closure(
+        name: &str,
+        deps: Vec<&str>,
+        order: Arc<AtomicUsize>,
+        log: Arc<std::sync::Mutex<Vec<(String, usize)>>>,
+    ) -> Arc<dyn LifecyclePlugin> {
+        let n = name.to_string();
+        let mut p = ClosurePlugin::new(name, move |b| {
+            let i = order.fetch_add(1, Ordering::Relaxed);
+            log.lock().unwrap().push((n.clone(), i));
+            Ok(b)
+        });
+        for d in deps {
+            p = p.after(d);
+        }
+        Arc::new(p)
+    }
+
+    #[test]
+    fn duplicate_name_rejected() {
+        let mut reg = PluginRegistry::new();
+        reg.register(Arc::new(ClosurePlugin::new("a", Ok))).unwrap();
+        let err = reg
+            .register(Arc::new(ClosurePlugin::new("a", Ok)))
+            .unwrap_err();
+        assert!(err.to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn unknown_dep_rejected() {
+        let mut reg = PluginRegistry::new();
+        reg.register(Arc::new(ClosurePlugin::new("a", Ok).after("missing")))
+            .unwrap();
+        let err = match reg.activate_all(AgentBuilder::new()) {
+            Ok(_) => panic!("expected error"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("unknown plugin"), "got: {err}");
+    }
+
+    #[test]
+    fn cycle_rejected() {
+        let mut reg = PluginRegistry::new();
+        reg.register(Arc::new(ClosurePlugin::new("a", Ok).after("b")))
+            .unwrap();
+        reg.register(Arc::new(ClosurePlugin::new("b", Ok).after("a")))
+            .unwrap();
+        let err = match reg.activate_all(AgentBuilder::new()) {
+            Ok(_) => panic!("expected error"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("cycle"), "got: {err}");
+    }
+
+    #[test]
+    fn topo_orders_diamond_correctly() {
+        // a → b → d
+        // a → c → d
+        let order = Arc::new(AtomicUsize::new(0));
+        let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut reg = PluginRegistry::new();
+        reg.register(closure("a", vec![], order.clone(), log.clone()))
+            .unwrap();
+        reg.register(closure("b", vec!["a"], order.clone(), log.clone()))
+            .unwrap();
+        reg.register(closure("c", vec!["a"], order.clone(), log.clone()))
+            .unwrap();
+        reg.register(closure("d", vec!["b", "c"], order.clone(), log.clone()))
+            .unwrap();
+        reg.activate_all(AgentBuilder::new()).unwrap();
+        let log = log.lock().unwrap().clone();
+        let pos = |n: &str| log.iter().find(|(name, _)| name == n).unwrap().1;
+        assert!(pos("a") < pos("b"));
+        assert!(pos("a") < pos("c"));
+        assert!(pos("b") < pos("d"));
+        assert!(pos("c") < pos("d"));
+    }
+
+    #[test]
+    fn activate_rolls_back_on_error() {
+        let activated = Arc::new(AtomicUsize::new(0));
+        let act_clone = activated.clone();
+        let act_clone2 = activated.clone();
+        let mut reg = PluginRegistry::new();
+        // First plugin succeeds (and increments the counter).
+        reg.register(Arc::new(ClosurePlugin::new("ok", move |b| {
+            act_clone.fetch_add(1, Ordering::Relaxed);
+            Ok(b)
+        })))
+        .unwrap();
+        // Second plugin (depends on first) fails.
+        reg.register(Arc::new(
+            ClosurePlugin::new("boom", move |_| {
+                act_clone2.fetch_add(1, Ordering::Relaxed);
+                Err(CognisError::Internal("nope".into()))
+            })
+            .after("ok"),
+        ))
+        .unwrap();
+
+        let res = reg.activate_all(AgentBuilder::new());
+        assert!(res.is_err());
+        // Both plugins ran their activate (one succeeded, one failed)
+        assert_eq!(activated.load(Ordering::Relaxed), 2);
+        // But neither remains active after rollback.
+        assert!(reg.active().is_empty());
+    }
+
+    #[test]
+    fn unregister_deactivates_first() {
+        let deactivated = Arc::new(AtomicUsize::new(0));
+        struct Counted(Arc<AtomicUsize>);
+        impl LifecyclePlugin for Counted {
+            fn name(&self) -> &str {
+                "counted"
+            }
+            fn activate(&self, b: AgentBuilder) -> Result<AgentBuilder> {
+                Ok(b)
+            }
+            fn deactivate(&self) -> Result<()> {
+                self.0.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+        }
+        let mut reg = PluginRegistry::new();
+        reg.register(Arc::new(Counted(deactivated.clone())))
+            .unwrap();
+        reg.activate_all(AgentBuilder::new()).unwrap();
+        assert_eq!(reg.active(), vec!["counted".to_string()]);
+        reg.unregister("counted").unwrap();
+        assert_eq!(deactivated.load(Ordering::Relaxed), 1);
+        assert!(reg.active().is_empty());
+        assert!(reg.names().is_empty());
+    }
+
+    #[test]
+    fn deactivate_all_walks_in_reverse_topo() {
+        let order = Arc::new(AtomicUsize::new(0));
+        let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+        struct LoggingPlugin {
+            name: String,
+            deps: Vec<String>,
+            order: Arc<AtomicUsize>,
+            log: Arc<std::sync::Mutex<Vec<String>>>,
+        }
+        impl LifecyclePlugin for LoggingPlugin {
+            fn name(&self) -> &str {
+                &self.name
+            }
+            fn deps(&self) -> Vec<String> {
+                self.deps.clone()
+            }
+            fn activate(&self, b: AgentBuilder) -> Result<AgentBuilder> {
+                Ok(b)
+            }
+            fn deactivate(&self) -> Result<()> {
+                let _ = self.order.fetch_add(1, Ordering::Relaxed);
+                self.log.lock().unwrap().push(self.name.clone());
+                Ok(())
+            }
+        }
+        let mut reg = PluginRegistry::new();
+        reg.register(Arc::new(LoggingPlugin {
+            name: "a".into(),
+            deps: vec![],
+            order: order.clone(),
+            log: log.clone(),
+        }))
+        .unwrap();
+        reg.register(Arc::new(LoggingPlugin {
+            name: "b".into(),
+            deps: vec!["a".into()],
+            order: order.clone(),
+            log: log.clone(),
+        }))
+        .unwrap();
+        reg.activate_all(AgentBuilder::new()).unwrap();
+        reg.deactivate_all().unwrap();
+        let log = log.lock().unwrap().clone();
+        // Dependent (b) tears down before its dep (a).
+        let pos = |n: &str| log.iter().position(|x| x == n).unwrap();
+        assert!(pos("b") < pos("a"));
+    }
+}

--- a/crates/cognis/src/agent_events.rs
+++ b/crates/cognis/src/agent_events.rs
@@ -1,0 +1,286 @@
+//! Typed lifecycle events layered over [`AgentBus`].
+//!
+//! `AgentBus` is a generic topic pub/sub of `AgentMessage`s. This module
+//! adds a typed [`AgentEvent`] envelope so subscribers can match on
+//! variants (`Started`, `Finished`, `ToolCalled`, `ToolResult`, `Errored`,
+//! `Custom`) without parsing free-form text.
+//!
+//! Use [`AgentEventBus`] when you want a single channel of typed agent
+//! lifecycle events; use raw [`AgentBus`] for arbitrary topic routing.
+//!
+//! Wire format: events are serialized to JSON inside an [`AgentMessage`]
+//! payload (`metadata.event = ...`). Receivers deserialize back into
+//! `AgentEvent`. This means events survive the bus's broadcast
+//! semantics — every subscriber sees every event.
+
+use cognis_core::Message;
+use serde::{Deserialize, Serialize};
+
+use crate::agent_bus::{AgentBus, SubscribeError, Subscription};
+use crate::multi_agent::AgentMessage;
+
+/// Default topic for typed agent lifecycle events.
+pub const DEFAULT_EVENTS_TOPIC: &str = "agent.events";
+
+/// Typed agent-lifecycle event. Attach extra context via the `Custom`
+/// variant if you need data the built-in variants don't cover.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AgentEvent {
+    /// An agent run started.
+    Started {
+        /// Agent id.
+        agent_id: String,
+        /// First-turn input as plain text.
+        input: String,
+    },
+    /// An agent run completed successfully.
+    Finished {
+        /// Agent id.
+        agent_id: String,
+        /// Final output content.
+        output: String,
+        /// How many ReAct iterations the run took.
+        iterations: u32,
+    },
+    /// A tool call was issued by the agent.
+    ToolCalled {
+        /// Agent id.
+        agent_id: String,
+        /// Tool name (matches `Tool::name()`).
+        tool_name: String,
+        /// Tool input as JSON.
+        args: serde_json::Value,
+    },
+    /// A tool returned a result.
+    ToolResult {
+        /// Agent id.
+        agent_id: String,
+        /// Tool name.
+        tool_name: String,
+        /// Tool output as JSON.
+        result: serde_json::Value,
+    },
+    /// An agent run errored.
+    Errored {
+        /// Agent id.
+        agent_id: String,
+        /// Error message.
+        error: String,
+    },
+    /// Custom event for application-specific signals not covered by the
+    /// other variants.
+    Custom {
+        /// Agent id.
+        agent_id: String,
+        /// User-defined event tag.
+        tag: String,
+        /// Free-form payload.
+        payload: serde_json::Value,
+    },
+}
+
+impl AgentEvent {
+    /// Agent id for any variant.
+    pub fn agent_id(&self) -> &str {
+        match self {
+            AgentEvent::Started { agent_id, .. }
+            | AgentEvent::Finished { agent_id, .. }
+            | AgentEvent::ToolCalled { agent_id, .. }
+            | AgentEvent::ToolResult { agent_id, .. }
+            | AgentEvent::Errored { agent_id, .. }
+            | AgentEvent::Custom { agent_id, .. } => agent_id,
+        }
+    }
+}
+
+/// Typed event bus on top of [`AgentBus`]. Cheap to clone (the inner bus
+/// is `Arc`-backed).
+#[derive(Clone)]
+pub struct AgentEventBus {
+    inner: AgentBus,
+    topic: String,
+}
+
+impl Default for AgentEventBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AgentEventBus {
+    /// New typed bus on the default topic (`"agent.events"`) with a
+    /// fresh underlying `AgentBus`.
+    pub fn new() -> Self {
+        Self::with_bus(AgentBus::new())
+    }
+
+    /// New typed bus reusing an existing [`AgentBus`].
+    pub fn with_bus(bus: AgentBus) -> Self {
+        Self {
+            inner: bus,
+            topic: DEFAULT_EVENTS_TOPIC.into(),
+        }
+    }
+
+    /// Override the topic on which events are published.
+    pub fn with_topic(mut self, topic: impl Into<String>) -> Self {
+        self.topic = topic.into();
+        self
+    }
+
+    /// The underlying generic [`AgentBus`]. Useful for mixing typed
+    /// events with arbitrary point-to-point topics.
+    pub fn bus(&self) -> &AgentBus {
+        &self.inner
+    }
+
+    /// Publish an event. Returns the number of subscribers it reached.
+    pub async fn publish(&self, event: AgentEvent) -> usize {
+        let payload = serde_json::to_value(&event).unwrap_or(serde_json::Value::Null);
+        let agent_id = event.agent_id().to_string();
+        let envelope = AgentMessage {
+            from: agent_id,
+            to: self.topic.clone(),
+            content: Message::system("agent-event"),
+            metadata: serde_json::json!({ "event": payload }),
+        };
+        self.inner.publish(&self.topic, envelope).await
+    }
+
+    /// Subscribe to typed events.
+    pub async fn subscribe(&self) -> EventSubscription {
+        EventSubscription {
+            inner: self.inner.subscribe(&self.topic).await,
+        }
+    }
+
+    /// Total topics on the underlying bus.
+    pub async fn topic_count(&self) -> usize {
+        self.inner.topic_count().await
+    }
+
+    /// Subscriber count on the typed events topic.
+    pub async fn subscriber_count(&self) -> usize {
+        self.inner.subscriber_count(&self.topic).await
+    }
+}
+
+/// Typed-event subscription handle. Drop to unsubscribe.
+pub struct EventSubscription {
+    inner: Subscription,
+}
+
+impl EventSubscription {
+    /// Topic this subscription is bound to.
+    pub fn topic(&self) -> &str {
+        self.inner.topic()
+    }
+
+    /// Wait for the next event. Returns the deserialized `AgentEvent`,
+    /// or a [`SubscribeError`] if the bus closed / lagged / payload
+    /// failed to deserialize.
+    pub async fn recv(&mut self) -> Result<AgentEvent, SubscribeError> {
+        let envelope = self.inner.recv().await?;
+        decode_event(&envelope).map_err(|_| SubscribeError::Closed)
+    }
+}
+
+fn decode_event(env: &AgentMessage) -> Result<AgentEvent, serde_json::Error> {
+    let v = env
+        .metadata
+        .get("event")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    serde_json::from_value(v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn started_event_round_trip() {
+        let bus = AgentEventBus::new();
+        let mut sub = bus.subscribe().await;
+        let n = bus
+            .publish(AgentEvent::Started {
+                agent_id: "writer".into(),
+                input: "hello".into(),
+            })
+            .await;
+        assert_eq!(n, 1, "subscriber should receive the event");
+        match sub.recv().await.unwrap() {
+            AgentEvent::Started { agent_id, input } => {
+                assert_eq!(agent_id, "writer");
+                assert_eq!(input, "hello");
+            }
+            other => panic!("expected Started, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fanout_to_every_subscriber() {
+        let bus = AgentEventBus::new();
+        let mut a = bus.subscribe().await;
+        let mut b = bus.subscribe().await;
+        bus.publish(AgentEvent::Errored {
+            agent_id: "x".into(),
+            error: "boom".into(),
+        })
+        .await;
+        for sub in [&mut a, &mut b] {
+            match sub.recv().await.unwrap() {
+                AgentEvent::Errored { error, .. } => assert_eq!(error, "boom"),
+                _ => panic!("variant"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn custom_topic_isolates_subscriptions() {
+        let other = AgentEventBus::new().with_topic("alerts");
+        let mut sub = other.subscribe().await;
+        // Default-topic subscriber on a fresh bus shouldn't see this.
+        let unrelated = AgentEventBus::new();
+        let _unrelated_sub = unrelated.subscribe().await;
+        other
+            .publish(AgentEvent::Custom {
+                agent_id: "watchdog".into(),
+                tag: "alert".into(),
+                payload: serde_json::json!({"severity": "high"}),
+            })
+            .await;
+        match sub.recv().await.unwrap() {
+            AgentEvent::Custom { tag, .. } => assert_eq!(tag, "alert"),
+            _ => panic!("variant"),
+        }
+    }
+
+    #[tokio::test]
+    async fn shared_underlying_bus() {
+        // Two AgentEventBus on the same AgentBus + same topic see each
+        // other's events.
+        let inner = AgentBus::new();
+        let a = AgentEventBus::with_bus(inner.clone());
+        let b = AgentEventBus::with_bus(inner);
+        let mut sub = b.subscribe().await;
+        a.publish(AgentEvent::Started {
+            agent_id: "shared".into(),
+            input: "ok".into(),
+        })
+        .await;
+        match sub.recv().await.unwrap() {
+            AgentEvent::Started { agent_id, .. } => assert_eq!(agent_id, "shared"),
+            _ => panic!("variant"),
+        }
+    }
+
+    #[tokio::test]
+    async fn subscriber_count_tracks_active() {
+        let bus = AgentEventBus::new();
+        let _a = bus.subscribe().await;
+        let _b = bus.subscribe().await;
+        assert_eq!(bus.subscriber_count().await, 2);
+    }
+}

--- a/crates/cognis/src/lib.rs
+++ b/crates/cognis/src/lib.rs
@@ -97,8 +97,8 @@ pub use middleware::{
     WorkspaceLister,
 };
 pub use multi_agent::{
-    AgentMessage, HandoffStrategy, InMemoryMessageBus, MessageBus, MultiAgentOrchestrator,
-    ParallelVote, RoundRobin, Sequential, Supervisor,
+    AgentMessage, Consensus, HandoffStrategy, Hierarchical, InMemoryMessageBus, MessageBus,
+    MultiAgentOrchestrator, ParallelVote, RoundRobin, Sequential, Supervisor,
 };
 pub use observers::TracingObserver;
 pub use retrievers::{

--- a/crates/cognis/src/lib.rs
+++ b/crates/cognis/src/lib.rs
@@ -67,10 +67,10 @@ pub mod tools;
 pub use agent::{
     default_react_graph, default_react_graph_with_limits, Agent, AgentBuilder, AgentHealth,
     AgentLifecycle, AgentPlugin, AgentResponse, AgentState, AgentStateUpdate, Buffer,
-    ConversationMode, EntityExtractor, EntityFact, EntityMemory, FnPlugin, KnowledgeGraphMemory,
-    Memory, OnStart, SummaryBufferMemory, SummaryMemory, ThinkNode, TokenBufferMemory,
-    ToolDispatchNode, Triple, TripleExtractor, VectorMemory, Window, Workflow, WorkflowState,
-    WorkflowStateUpdate,
+    ClosurePlugin, ConversationMode, EntityExtractor, EntityFact, EntityMemory, FnPlugin,
+    KnowledgeGraphMemory, LifecyclePlugin, Memory, OnStart, PluginRegistry, SummaryBufferMemory,
+    SummaryMemory, ThinkNode, TokenBufferMemory, ToolDispatchNode, Triple, TripleExtractor,
+    VectorMemory, Window, Workflow, WorkflowState, WorkflowStateUpdate,
 };
 pub use agent_bus::{AgentBus, SubscribeError, Subscription};
 pub use backend::{

--- a/crates/cognis/src/lib.rs
+++ b/crates/cognis/src/lib.rs
@@ -68,9 +68,9 @@ pub use agent::{
     default_react_graph, default_react_graph_with_limits, Agent, AgentBuilder, AgentHealth,
     AgentLifecycle, AgentPlugin, AgentResponse, AgentState, AgentStateUpdate, Buffer,
     ClosurePlugin, ConversationMode, EntityExtractor, EntityFact, EntityMemory, FnPlugin,
-    KnowledgeGraphMemory, LifecyclePlugin, Memory, OnStart, PluginRegistry, SummaryBufferMemory,
-    SummaryMemory, ThinkNode, TokenBufferMemory, ToolDispatchNode, Triple, TripleExtractor,
-    VectorMemory, Window, Workflow, WorkflowState, WorkflowStateUpdate,
+    HybridMemory, KnowledgeGraphMemory, LifecyclePlugin, Memory, OnStart, PluginRegistry,
+    SummaryBufferMemory, SummaryMemory, ThinkNode, TokenBufferMemory, ToolDispatchNode, Triple,
+    TripleExtractor, VectorMemory, Window, Workflow, WorkflowState, WorkflowStateUpdate,
 };
 pub use agent_bus::{AgentBus, SubscribeError, Subscription};
 pub use backend::{

--- a/crates/cognis/src/lib.rs
+++ b/crates/cognis/src/lib.rs
@@ -49,6 +49,7 @@ pub use cognis_rag::{
 // New stage-5 modules.
 pub mod agent;
 pub mod agent_bus;
+pub mod agent_events;
 pub mod backend;
 #[cfg(feature = "cache-sqlite")]
 pub mod cache_sqlite;
@@ -73,6 +74,7 @@ pub use agent::{
     TripleExtractor, VectorMemory, Window, Workflow, WorkflowState, WorkflowStateUpdate,
 };
 pub use agent_bus::{AgentBus, SubscribeError, Subscription};
+pub use agent_events::{AgentEvent, AgentEventBus, EventSubscription, DEFAULT_EVENTS_TOPIC};
 pub use backend::{
     Backend, Blob, GrepHit, InMemoryStateBackend, InMemoryStorageBackend, LocalFsStorageBackend,
     MemoryBackend, SandboxedFsBackend, StateBackend, StorageBackend,

--- a/crates/cognis/src/multi_agent.rs
+++ b/crates/cognis/src/multi_agent.rs
@@ -372,6 +372,219 @@ impl HandoffStrategy for RoundRobin {
 }
 
 // ---------------------------------------------------------------------------
+// Hierarchical
+// ---------------------------------------------------------------------------
+
+/// Multi-level supervisor tree. Each level's agent receives the request,
+/// emits a routing decision, and delegates to a deeper agent. The leaf
+/// agent's response is the final answer.
+///
+/// Routing format defaults to `target_id: instruction` (same parser as
+/// [`Supervisor`]). Override via [`Hierarchical::with_parser`].
+///
+/// Walks at most `max_depth` levels before forcing the current agent's
+/// reply as the final result — guards against parse loops where every
+/// level keeps routing onward.
+pub struct Hierarchical {
+    parser: SupervisorParser,
+    max_depth: usize,
+}
+
+impl Default for Hierarchical {
+    fn default() -> Self {
+        Self {
+            parser: Arc::new(default_supervisor_parser),
+            max_depth: 8,
+        }
+    }
+}
+
+impl Hierarchical {
+    /// New tree walker with the default parser and depth cap.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Cap the maximum routing hops.
+    pub fn with_max_depth(mut self, n: usize) -> Self {
+        self.max_depth = n.max(1);
+        self
+    }
+
+    /// Override the routing parser. `Some((next_id, instruction))` to
+    /// delegate; `None` to halt with the current agent's response.
+    pub fn with_parser<F>(mut self, parser: F) -> Self
+    where
+        F: Fn(&str) -> Option<(String, String)> + Send + Sync + 'static,
+    {
+        self.parser = Arc::new(parser);
+        self
+    }
+}
+
+#[async_trait]
+impl HandoffStrategy for Hierarchical {
+    async fn run(
+        &self,
+        agents: &[(String, Arc<Mutex<Agent>>)],
+        input: Message,
+        bus: Arc<dyn MessageBus>,
+    ) -> Result<AgentResponse> {
+        if agents.is_empty() {
+            return Err(CognisError::Configuration(
+                "Hierarchical: no agents registered".into(),
+            ));
+        }
+        let (mut current_id, mut current_agent) = {
+            let (id, a) = &agents[0];
+            (id.clone(), a.clone())
+        };
+        let mut current_input = input;
+        let mut prev_id: String = "user".into();
+        for hop in 0..self.max_depth {
+            bus.publish(AgentMessage {
+                from: prev_id.clone(),
+                to: current_id.clone(),
+                content: current_input.clone(),
+                metadata: serde_json::json!({"strategy": "hierarchical", "hop": hop}),
+            })
+            .await?;
+            let response = {
+                let mut a = current_agent.lock().await;
+                a.run(current_input.clone()).await?
+            };
+            match (self.parser)(&response.content) {
+                Some((next_id, instruction)) => {
+                    let next = agents
+                        .iter()
+                        .find(|(id, _)| id == &next_id)
+                        .ok_or_else(|| {
+                            CognisError::Configuration(format!(
+                                "Hierarchical: routed to unknown agent `{next_id}`"
+                            ))
+                        })?;
+                    prev_id = current_id;
+                    current_id = next.0.clone();
+                    current_agent = next.1.clone();
+                    current_input = Message::human(instruction);
+                }
+                None => return Ok(response),
+            }
+        }
+        // Depth cap reached — run the current agent one more time and return.
+        let mut a = current_agent.lock().await;
+        a.run(current_input).await
+    }
+
+    fn name(&self) -> &str {
+        "Hierarchical"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Consensus
+// ---------------------------------------------------------------------------
+
+/// Weighted-quorum voting. Every registered agent runs in parallel with
+/// the same input; their replies are tallied by content equality with
+/// optional per-agent weights. The highest-weighted answer wins iff it
+/// clears `quorum`; otherwise [`CognisError::Configuration`] is returned
+/// with the tally.
+///
+/// Unlike [`ParallelVote`] (which always returns the plurality),
+/// `Consensus` is honest about the absence of agreement.
+pub struct Consensus {
+    quorum: f32,
+    weights: HashMap<String, f32>,
+}
+
+impl Default for Consensus {
+    fn default() -> Self {
+        Self::new(0.5)
+    }
+}
+
+impl Consensus {
+    /// Build with a quorum threshold expressed as a sum of agent weights.
+    /// Per-agent weight defaults to 1.0; e.g. `quorum=2.0` means at least
+    /// two unweighted agents must agree, `quorum=N` means all N.
+    pub fn new(quorum: f32) -> Self {
+        Self {
+            quorum: quorum.max(0.0),
+            weights: HashMap::new(),
+        }
+    }
+
+    /// Set the weight of an agent. Default is 1.0.
+    pub fn weight(mut self, agent_id: impl Into<String>, weight: f32) -> Self {
+        self.weights.insert(agent_id.into(), weight.max(0.0));
+        self
+    }
+
+    fn weight_of(&self, id: &str) -> f32 {
+        self.weights.get(id).copied().unwrap_or(1.0)
+    }
+}
+
+#[async_trait]
+impl HandoffStrategy for Consensus {
+    async fn run(
+        &self,
+        agents: &[(String, Arc<Mutex<Agent>>)],
+        input: Message,
+        _bus: Arc<dyn MessageBus>,
+    ) -> Result<AgentResponse> {
+        if agents.is_empty() {
+            return Err(CognisError::Configuration(
+                "Consensus: no agents registered".into(),
+            ));
+        }
+        let mut handles = Vec::with_capacity(agents.len());
+        for (id, agent) in agents {
+            let agent = agent.clone();
+            let id = id.clone();
+            let input = input.clone();
+            handles.push(tokio::spawn(async move {
+                let resp = agent.lock().await.run(input).await;
+                (id, resp)
+            }));
+        }
+        let mut tally: HashMap<String, (f32, AgentResponse)> = HashMap::new();
+        let mut total_weight = 0.0_f32;
+        for h in handles {
+            let (id, res) = h
+                .await
+                .map_err(|e| CognisError::Internal(format!("consensus join: {e}")))?;
+            let resp = res?;
+            let w = self.weight_of(&id);
+            total_weight += w;
+            tally
+                .entry(resp.content.clone())
+                .and_modify(|(acc, _)| *acc += w)
+                .or_insert_with(|| (w, resp));
+        }
+        let (winning_content, (winning_weight, winning_resp)) = tally
+            .into_iter()
+            .max_by(|(_, (a, _)), (_, (b, _))| {
+                a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .ok_or_else(|| CognisError::Internal("Consensus: no responses".into()))?;
+        if winning_weight >= self.quorum {
+            Ok(winning_resp)
+        } else {
+            Err(CognisError::Configuration(format!(
+                "Consensus: no answer reached quorum {} (best: {:.2}/{:.2} for {:?})",
+                self.quorum, winning_weight, total_weight, winning_content
+            )))
+        }
+    }
+
+    fn name(&self) -> &str {
+        "Consensus"
+    }
+}
+
+// ---------------------------------------------------------------------------
 // MultiAgentOrchestrator
 // ---------------------------------------------------------------------------
 
@@ -591,5 +804,71 @@ mod tests {
         assert_eq!(bus.drain("bob").await.unwrap().len(), 1);
         // Drained inboxes are now empty.
         assert!(bus.drain("alice").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn hierarchical_routes_through_two_levels() {
+        // ceo -> "vp_eng: build feature" → vp_eng -> "ic: implement" → ic
+        let ceo = agent_with_response("vp_eng: build feature");
+        let vp = agent_with_response("ic: implement");
+        let ic = agent_with_response("done implementing");
+        let orch = MultiAgentOrchestrator::new(Hierarchical::new())
+            .add("ceo", ceo)
+            .add("vp_eng", vp)
+            .add("ic", ic);
+        let resp = orch.run("ship X").await.unwrap();
+        assert_eq!(resp.content, "done implementing");
+    }
+
+    #[tokio::test]
+    async fn hierarchical_halts_on_unrouted_response() {
+        let ceo = agent_with_response("answering directly");
+        let vp = agent_with_response("would have routed");
+        let orch = MultiAgentOrchestrator::new(Hierarchical::new())
+            .add("ceo", ceo)
+            .add("vp", vp);
+        let resp = orch.run("hi").await.unwrap();
+        assert_eq!(resp.content, "answering directly");
+    }
+
+    #[tokio::test]
+    async fn hierarchical_unknown_route_target_errors() {
+        let ceo = agent_with_response("ghost: do work");
+        let orch = MultiAgentOrchestrator::new(Hierarchical::new()).add("ceo", ceo);
+        let res = orch.run("hi").await;
+        assert!(res.is_err(), "should fail on unknown route");
+    }
+
+    #[tokio::test]
+    async fn consensus_returns_winner_when_quorum_met() {
+        // 2 of 3 agree on "X" — quorum = 2.0 (default weights).
+        let orch = MultiAgentOrchestrator::new(Consensus::new(2.0))
+            .add("a", agent_with_response("X"))
+            .add("b", agent_with_response("X"))
+            .add("c", agent_with_response("Y"));
+        let resp = orch.run("q").await.unwrap();
+        assert_eq!(resp.content, "X");
+    }
+
+    #[tokio::test]
+    async fn consensus_errors_when_quorum_not_met() {
+        // 3 way tie, each with weight 1.0. Quorum 2.0 → no winner.
+        let orch = MultiAgentOrchestrator::new(Consensus::new(2.0))
+            .add("a", agent_with_response("X"))
+            .add("b", agent_with_response("Y"))
+            .add("c", agent_with_response("Z"));
+        let err = orch.run("q").await.unwrap_err();
+        assert!(err.to_string().contains("quorum"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn consensus_respects_weights() {
+        // Weighted: a=3.0 alone outvotes b+c (1.0 each).
+        let orch = MultiAgentOrchestrator::new(Consensus::new(2.5).weight("a", 3.0))
+            .add("a", agent_with_response("X"))
+            .add("b", agent_with_response("Y"))
+            .add("c", agent_with_response("Y"));
+        let resp = orch.run("q").await.unwrap();
+        assert_eq!(resp.content, "X");
     }
 }

--- a/crates/cognisgraph/src/analysis.rs
+++ b/crates/cognisgraph/src/analysis.rs
@@ -91,10 +91,9 @@ impl<S: GraphState> CompiledGraph<S> {
         };
 
         // Longest path: only meaningful for DAGs reachable from start.
-        let depth = if has_cycle || start.is_none() {
-            0
-        } else {
-            longest_path(start.unwrap(), &adj, &reachable)
+        let depth = match start {
+            Some(s) if !has_cycle => longest_path(s, &adj, &reachable),
+            _ => 0,
         };
 
         GraphAnalysis {
@@ -133,14 +132,13 @@ fn detect_cycle<'a>(
                 if m == "__END__" || !reachable.contains(m) {
                     continue;
                 }
-                match color.get(m) {
+                let recurse = match color.get(m) {
                     Some(Color::Gray) => return true, // back-edge → cycle
-                    Some(Color::White) => {
-                        if visit(m, adj, reachable, color) {
-                            return true;
-                        }
-                    }
-                    _ => {}
+                    Some(Color::White) => true,
+                    _ => false,
+                };
+                if recurse && visit(m, adj, reachable, color) {
+                    return true;
                 }
             }
         }

--- a/crates/cognisgraph/src/analysis.rs
+++ b/crates/cognisgraph/src/analysis.rs
@@ -1,0 +1,300 @@
+//! Static graph analysis — cycle detection, longest path, reachability.
+//!
+//! Operates on the **static** edges declared via [`crate::builder::Graph::edge`].
+//! Dynamic routing (a node returning `Goto::Send` to a peer that wasn't
+//! declared statically) is invisible here — by design, since this is a
+//! diagnostics tool for the graph topology you wrote, not its runtime
+//! behavior.
+//!
+//! ```ignore
+//! let analysis = compiled.analyze();
+//! if analysis.has_cycle {
+//!     eprintln!("cycle detected");
+//! }
+//! println!("longest path: {} hops", analysis.depth);
+//! ```
+//!
+//! `depth` is the longest *acyclic* path from the start node to any
+//! reachable node, measured in edge hops. For graphs with cycles, depth
+//! is `0` (it's only meaningful for DAGs).
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use crate::compiled::CompiledGraph;
+use crate::state::GraphState;
+use crate::viz::extract_edges;
+
+/// Output of [`CompiledGraph::analyze`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphAnalysis {
+    /// Number of registered nodes (excludes the synthetic `__END__`).
+    pub node_count: usize,
+    /// Number of static edges declared on the graph.
+    pub edge_count: usize,
+    /// `true` if the static edge graph contains a cycle reachable from
+    /// the start node.
+    pub has_cycle: bool,
+    /// Longest path from the start node to any reachable node, measured
+    /// in edges. `0` if the graph contains a cycle (depth is undefined
+    /// for non-DAGs) or has no start node.
+    pub depth: usize,
+    /// Nodes registered on the graph but not reachable from the start
+    /// via static edges. Sorted alphabetically.
+    pub unreachable: Vec<String>,
+}
+
+impl<S: GraphState> CompiledGraph<S> {
+    /// Compute static-graph diagnostics. See [`GraphAnalysis`].
+    pub fn analyze(&self) -> GraphAnalysis {
+        let nodes: Vec<&String> = self.graph.nodes.keys().collect();
+        let mut adj: HashMap<&str, Vec<&str>> = HashMap::new();
+        for node in &nodes {
+            adj.insert(node.as_str(), Vec::new());
+        }
+        let edges = extract_edges(self);
+        for e in &edges {
+            adj.entry(e.from.as_str()).or_default().push(e.to.as_str());
+        }
+
+        let start = self.graph.start.as_deref();
+
+        // Reachability via BFS from start. Skips the synthetic __END__
+        // sink — we care about whether registered nodes are reached.
+        let mut reachable: HashSet<&str> = HashSet::new();
+        if let Some(s) = start {
+            let mut q: VecDeque<&str> = VecDeque::from([s]);
+            reachable.insert(s);
+            while let Some(n) = q.pop_front() {
+                if let Some(nexts) = adj.get(n) {
+                    for &m in nexts {
+                        if m == "__END__" {
+                            continue;
+                        }
+                        if reachable.insert(m) {
+                            q.push_back(m);
+                        }
+                    }
+                }
+            }
+        }
+        let mut unreachable: Vec<String> = nodes
+            .iter()
+            .filter(|n| !reachable.contains(n.as_str()))
+            .map(|n| (*n).clone())
+            .collect();
+        unreachable.sort();
+
+        // Cycle detection over the reachable subgraph via DFS three-color.
+        let has_cycle = match start {
+            Some(s) => detect_cycle(s, &adj, &reachable),
+            None => false,
+        };
+
+        // Longest path: only meaningful for DAGs reachable from start.
+        let depth = if has_cycle || start.is_none() {
+            0
+        } else {
+            longest_path(start.unwrap(), &adj, &reachable)
+        };
+
+        GraphAnalysis {
+            node_count: self.graph.nodes.len(),
+            edge_count: edges.len(),
+            has_cycle,
+            depth,
+            unreachable,
+        }
+    }
+}
+
+fn detect_cycle<'a>(
+    start: &'a str,
+    adj: &HashMap<&'a str, Vec<&'a str>>,
+    reachable: &HashSet<&'a str>,
+) -> bool {
+    enum Color {
+        White,
+        Gray,
+        Black,
+    }
+    let mut color: HashMap<&str, Color> = HashMap::new();
+    for &n in reachable {
+        color.insert(n, Color::White);
+    }
+    fn visit<'a>(
+        node: &'a str,
+        adj: &HashMap<&'a str, Vec<&'a str>>,
+        reachable: &HashSet<&'a str>,
+        color: &mut HashMap<&'a str, Color>,
+    ) -> bool {
+        color.insert(node, Color::Gray);
+        if let Some(nexts) = adj.get(node) {
+            for &m in nexts {
+                if m == "__END__" || !reachable.contains(m) {
+                    continue;
+                }
+                match color.get(m) {
+                    Some(Color::Gray) => return true, // back-edge → cycle
+                    Some(Color::White) => {
+                        if visit(m, adj, reachable, color) {
+                            return true;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        color.insert(node, Color::Black);
+        false
+    }
+    visit(start, adj, reachable, &mut color)
+}
+
+fn longest_path<'a>(
+    start: &'a str,
+    adj: &HashMap<&'a str, Vec<&'a str>>,
+    reachable: &HashSet<&'a str>,
+) -> usize {
+    // Memoized DFS over the DAG. Caller must ensure no cycles.
+    fn dfs<'a>(
+        node: &'a str,
+        adj: &HashMap<&'a str, Vec<&'a str>>,
+        reachable: &HashSet<&'a str>,
+        memo: &mut HashMap<&'a str, usize>,
+    ) -> usize {
+        if let Some(&d) = memo.get(node) {
+            return d;
+        }
+        let mut best = 0;
+        if let Some(nexts) = adj.get(node) {
+            for &m in nexts {
+                if m == "__END__" || !reachable.contains(m) {
+                    continue;
+                }
+                let d = 1 + dfs(m, adj, reachable, memo);
+                if d > best {
+                    best = d;
+                }
+            }
+        }
+        memo.insert(node, best);
+        best
+    }
+    let mut memo: HashMap<&str, usize> = HashMap::new();
+    dfs(start, adj, reachable, &mut memo)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builder::Graph;
+    use crate::goto::Goto;
+    use crate::node::{node_fn, NodeOut};
+
+    #[derive(Default, Clone)]
+    struct S;
+    #[derive(Default)]
+    struct SU;
+    impl GraphState for S {
+        type Update = SU;
+        fn apply(&mut self, _: Self::Update) {}
+    }
+
+    fn nf(name: &'static str) -> impl crate::Node<S> + 'static {
+        node_fn::<S, _, _>(name, |_, _| async move {
+            Ok(NodeOut {
+                update: SU,
+                goto: Goto::end(),
+            })
+        })
+    }
+
+    #[test]
+    fn linear_three_node_chain_depth_2() {
+        // a → b → c
+        let g = Graph::<S>::new()
+            .node("a", nf("a"))
+            .node("b", nf("b"))
+            .node("c", nf("c"))
+            .edge("a", "b")
+            .edge("b", "c")
+            .start_at("a")
+            .compile()
+            .unwrap();
+        let r = g.analyze();
+        assert_eq!(r.node_count, 3);
+        assert_eq!(r.edge_count, 2);
+        assert!(!r.has_cycle);
+        assert_eq!(r.depth, 2);
+        assert!(r.unreachable.is_empty());
+    }
+
+    #[test]
+    fn diamond_depth_is_2() {
+        // a → b → d
+        // a → c → d
+        let g = Graph::<S>::new()
+            .node("a", nf("a"))
+            .node("b", nf("b"))
+            .node("c", nf("c"))
+            .node("d", nf("d"))
+            .edge("a", "b")
+            .edge("a", "c")
+            .edge("b", "d")
+            .edge("c", "d")
+            .start_at("a")
+            .compile()
+            .unwrap();
+        let r = g.analyze();
+        assert!(!r.has_cycle);
+        assert_eq!(r.depth, 2);
+    }
+
+    #[test]
+    fn self_loop_is_a_cycle() {
+        // a → a (cycle)
+        let g = Graph::<S>::new()
+            .node("a", nf("a"))
+            .edge("a", "a")
+            .start_at("a")
+            .compile()
+            .unwrap();
+        let r = g.analyze();
+        assert!(r.has_cycle);
+        assert_eq!(r.depth, 0, "depth undefined for graphs with cycles");
+    }
+
+    #[test]
+    fn detects_back_edge_cycle() {
+        // a → b → c → a
+        let g = Graph::<S>::new()
+            .node("a", nf("a"))
+            .node("b", nf("b"))
+            .node("c", nf("c"))
+            .edge("a", "b")
+            .edge("b", "c")
+            .edge("c", "a")
+            .start_at("a")
+            .compile()
+            .unwrap();
+        let r = g.analyze();
+        assert!(r.has_cycle);
+    }
+
+    #[test]
+    fn unreachable_nodes_listed() {
+        // a → b ;  c is registered but no edge to/from start.
+        let g = Graph::<S>::new()
+            .node("a", nf("a"))
+            .node("b", nf("b"))
+            .node("c", nf("c"))
+            .edge("a", "b")
+            .start_at("a")
+            .compile()
+            .unwrap();
+        let r = g.analyze();
+        assert_eq!(r.unreachable, vec!["c".to_string()]);
+        assert!(!r.has_cycle);
+        assert_eq!(r.depth, 1);
+    }
+}

--- a/crates/cognisgraph/src/lib.rs
+++ b/crates/cognisgraph/src/lib.rs
@@ -6,6 +6,7 @@
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 
+pub mod analysis;
 pub mod audit;
 pub mod barrier;
 pub mod builder;
@@ -26,6 +27,7 @@ pub mod subgraph;
 pub(crate) mod validate;
 pub mod viz;
 
+pub use analysis::GraphAnalysis;
 pub use audit::{AuditEntry, AuditKind, AuditLog, AuditLogObserver, InMemoryAuditLog};
 pub use barrier::BarrierNode;
 pub use builder::{Graph, LinearBuilder};

--- a/docs/mintlify/concepts/agents.mdx
+++ b/docs/mintlify/concepts/agents.mdx
@@ -1,0 +1,176 @@
+---
+title: "Agents"
+description: "Single-agent loops, multi-agent orchestration, memory, tools, and middleware."
+sidebarTitle: "Agents"
+---
+
+The `cognis` umbrella adds the agent layer on top of `core`, `llm`, `rag`, and `graph`. Agents are graphs in disguise — `AgentBuilder` wires the loop for you.
+
+## A tool-using agent
+
+```rust
+use cognis::agent::AgentBuilder;
+use cognis::llm::providers::openai::ChatOpenAI;
+use cognis::tools::tool;
+use serde::Deserialize;
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct Search { query: String }
+
+#[tool]
+async fn search(args: Search) -> anyhow::Result<String> {
+    Ok(format!("results for: {}", args.query))
+}
+
+let agent = AgentBuilder::new()
+    .model(ChatOpenAI::builder().model("gpt-4o-mini").build()?)
+    .tools(vec![search()])
+    .system("You are a research assistant. Use tools when needed.")
+    .build()?;
+
+let result = agent
+    .invoke("What's new in WebGPU?".to_string(), cfg)
+    .await?;
+```
+
+The builder produces a graph with `agent` and `tools` nodes wired into a loop. Stop conditions: no more tool calls, hit `recursion_limit`, or the model returns a stop reason.
+
+## Memory
+
+`Memory` is a trait — `read(thread_id)`, `write(thread_id, msgs)`, `clear(thread_id)`. Variants ship out of the box:
+
+| Variant | Behavior |
+|---|---|
+| `BufferMemory` | Keep all messages. |
+| `WindowMemory` | Last N messages. |
+| `TokenBufferMemory` | Trim to a token budget. |
+| `SummaryBufferMemory` | Summarize older turns into a running summary. |
+| `VectorMemory` | Embed and retrieve from a vector store. |
+| `EntityMemory` | Track entities mentioned across the conversation. |
+| `KnowledgeGraphMemory` | Triple store of subject-predicate-object facts. |
+
+```rust
+use cognis::agent::memory::{SummaryBufferMemory, MemoryBackend};
+
+let memory = SummaryBufferMemory::builder()
+    .summarizer(model.clone())
+    .max_token_limit(2000)
+    .build();
+
+let agent = AgentBuilder::new()
+    .model(model)
+    .memory(memory)
+    .build()?;
+```
+
+## Multi-agent orchestration
+
+`MultiAgentOrchestrator` runs multiple agents under a strategy.
+
+<Tabs>
+  <Tab title="Sequential">
+    Run agents in order; each receives the previous output.
+    ```rust
+    use cognis::agent::orchestrator::{MultiAgentOrchestrator, Strategy};
+
+    let orch = MultiAgentOrchestrator::new()
+        .with_strategy(Strategy::Sequential)
+        .add_agent("researcher", researcher_agent)
+        .add_agent("writer", writer_agent);
+    ```
+  </Tab>
+  <Tab title="Supervisor">
+    A supervisor LLM picks which sub-agent runs next.
+    ```rust
+    let orch = MultiAgentOrchestrator::new()
+        .with_strategy(Strategy::Supervisor(supervisor_model))
+        .add_agent("researcher", researcher_agent)
+        .add_agent("writer", writer_agent);
+    ```
+  </Tab>
+  <Tab title="ParallelVote">
+    Agents run in parallel; outputs are aggregated by a vote.
+    ```rust
+    let orch = MultiAgentOrchestrator::new()
+        .with_strategy(Strategy::ParallelVote)
+        .add_agent("a", a)
+        .add_agent("b", b)
+        .add_agent("c", c);
+    ```
+  </Tab>
+  <Tab title="RoundRobin">
+    Simple turn-taking — useful for debate/critique loops.
+    ```rust
+    let orch = MultiAgentOrchestrator::new()
+        .with_strategy(Strategy::RoundRobin { rounds: 3 })
+        .add_agent("proposer", proposer)
+        .add_agent("critic", critic);
+    ```
+  </Tab>
+</Tabs>
+
+## AgentBus
+
+Topic-based pub-sub for inter-agent broadcast — useful when agents emit events that other agents subscribe to.
+
+```rust
+use cognis::agent::bus::AgentBus;
+
+let bus = AgentBus::new();
+let mut sub = bus.subscribe::<MyEvent>("topic.events");
+bus.publish("topic.events", MyEvent { ... }).await?;
+let ev = sub.recv().await?;
+```
+
+## Middleware
+
+Cross-cutting policy that wraps every model call inside an agent.
+
+| Middleware | Effect |
+|---|---|
+| `RateLimiterMiddleware` | TokenBucket / SlidingWindow / CostBased / Composite. |
+| `ModelRetryMiddleware` | Retry on rate limits and transient errors. |
+| `ModelFallbackMiddleware` | Fallback to a cheaper model on failure. |
+| `PiiRedactionMiddleware` | Mask PII before sending to the provider. |
+| `PromptCachingMiddleware` | Reuse prompt-cache tokens (Anthropic, etc.). |
+| `PlanningMiddleware` | Inject a planning step before tool selection. |
+| `SummarizationMiddleware` | Summarize when context grows. |
+| `TodoMiddleware` | Maintain an internal task list. |
+
+```rust
+let agent = AgentBuilder::new()
+    .model(model)
+    .middleware(RateLimiterMiddleware::token_bucket(rate, burst))
+    .middleware(ModelRetryMiddleware::exponential(3))
+    .middleware(PromptCachingMiddleware::default())
+    .build()?;
+```
+
+## ToolOrchestrator
+
+For workflows that call several tools in a known DAG (no agent loop), use `ToolOrchestrator` directly.
+
+```rust
+use cognis::tools::orchestrator::{ToolOrchestrator, ExecutionPlan, ToolStep};
+
+let plan = ExecutionPlan::new()
+    .step(ToolStep::new("a", "fetch_user", json!({"id": 1})))
+    .step(ToolStep::new("b", "fetch_orders", json!({}))
+        .after(["a"]));
+
+let orch = ToolOrchestrator::new(registry);
+let outputs = orch.execute(plan).await?;
+```
+
+Dependencies declared via `.after([...])` schedule tools to run as soon as inputs are ready.
+
+## See also
+
+<CardGroup cols={2}>
+  <Card title="Graph" icon="diagram-project" href="/concepts/graph">
+    The mechanism behind the agent loop.
+  </Card>
+  <Card title="Trace" icon="chart-line" href="/concepts/trace">
+    Multi-agent traces nest cleanly in Langfuse.
+  </Card>
+</CardGroup>

--- a/docs/mintlify/concepts/graph.mdx
+++ b/docs/mintlify/concepts/graph.mdx
@@ -1,0 +1,178 @@
+---
+title: "Graph"
+description: "Stateful Graph<S> with Pregel execution, channels, checkpoints, interrupts, and streaming."
+sidebarTitle: "Graph"
+---
+
+`cognis-graph` builds stateful workflows that keep typed state across steps. Inspired by LangGraph; built around a typed `Graph<S>` and a Pregel-style engine.
+
+## Why a graph
+
+Linear chains break down once you need branching, loops, or human-in-the-loop. `Graph<S>` lets you express each step as a node that reads-and-writes a shared state struct, with edges (conditional or static) routing between them.
+
+## A minimal graph
+
+```rust
+use cognis::graph::{Graph, GraphState, START, END};
+
+#[derive(Clone, GraphState)]
+struct State {
+    #[reducer(append)]
+    messages: Vec<String>,
+    counter: u32, // last-value reducer (default)
+}
+
+let graph = Graph::<State>::new()
+    .add_node("greet", |s: State| async move {
+        State { messages: vec!["hello".into()], counter: s.counter + 1 }
+    })
+    .add_node("farewell", |s: State| async move {
+        State { messages: vec!["bye".into()], counter: s.counter + 1 }
+    })
+    .add_edge(START, "greet")
+    .add_edge("greet", "farewell")
+    .add_edge("farewell", END)
+    .compile()?;
+
+let final_state = graph.invoke(State::default(), cfg).await?;
+```
+
+## Reducers
+
+Each field on the state struct has a reducer that combines old + new values produced by a node.
+
+| `#[reducer(...)]` | Behavior |
+|---|---|
+| `last_value` (default) | Replace previous value. |
+| `append` | `Vec` concatenation. |
+| `merge` | `HashMap` merge. |
+| custom | Function `fn(prev: T, new: T) -> T`. |
+
+```rust
+#[derive(Clone, GraphState)]
+struct AgentState {
+    #[reducer(append)] messages: Vec<Message>,
+    #[reducer(merge)] tool_results: HashMap<String, Value>,
+    pending: Option<ToolCall>,
+}
+```
+
+## Conditional edges
+
+Route based on the current state.
+
+```rust
+graph
+    .add_node("agent", agent_node)
+    .add_node("tools", tool_node)
+    .add_conditional_edges("agent", |s: &AgentState| {
+        if s.pending.is_some() { Goto::Node("tools".into()) } else { Goto::End }
+    })
+    .add_edge("tools", "agent");
+```
+
+`Goto` is an enum: `Node(String)`, `Multiple(Vec<String>)`, `End`. Returning `Multiple` triggers parallel fan-out.
+
+## Checkpoints
+
+A `Checkpointer` persists state between supersteps. Three implementations, feature-gated.
+
+<Tabs>
+  <Tab title="InMemory">
+    ```rust
+    use cognis::graph::checkpoint::MemoryCheckpointer;
+
+    let cp = MemoryCheckpointer::new();
+    let graph = Graph::<S>::new()
+        .add_node(...)
+        .compile_with_checkpointer(cp)?;
+    ```
+  </Tab>
+  <Tab title="SQLite">
+    ```rust
+    use cognis::graph::checkpoint::SqliteCheckpointer;
+
+    let cp = SqliteCheckpointer::open("./graph.db").await?;
+    let graph = builder.compile_with_checkpointer(cp)?;
+    ```
+    Requires the `sqlite` feature.
+  </Tab>
+  <Tab title="Postgres">
+    ```rust
+    use cognis::graph::checkpoint::PostgresCheckpointer;
+
+    let cp = PostgresCheckpointer::connect(&dsn).await?;
+    let graph = builder.compile_with_checkpointer(cp)?;
+    ```
+    Requires the `postgres` feature.
+  </Tab>
+</Tabs>
+
+A `thread_id` on `RunnableConfig` selects the conversation. Same `thread_id` resumes; new id starts fresh.
+
+## Interrupts and human-in-the-loop
+
+Pause before a node, ask the human, then resume.
+
+```rust
+let graph = builder
+    .add_interrupt_before(["tools"]) // pause before any tool call
+    .compile_with_checkpointer(cp)?;
+
+// Run until interrupt
+let snapshot = graph.invoke(state, cfg.clone()).await?;
+// ... show snapshot to the user, get approval ...
+let resumed = graph.resume(cfg.with_thread_id("abc")).await?;
+```
+
+State inspection lets you see and edit the intermediate state:
+
+```rust
+let s = graph.get_state(&cfg).await?;
+graph.update_state(&cfg, |mut st| { st.counter += 100; st }).await?;
+let history = graph.get_state_history(&cfg).await?;
+```
+
+## Streaming
+
+All seven LangGraph stream modes are supported.
+
+```rust
+use cognis::graph::stream::StreamMode;
+
+let mut s = graph.stream(initial, cfg, StreamMode::Updates).await?;
+while let Some(item) = s.next().await {
+    println!("{:?}", item?);
+}
+```
+
+| Mode | What it emits |
+|---|---|
+| `Values` | Full state after each superstep. |
+| `Updates` | Per-node deltas. |
+| `Messages` | Streaming LLM tokens with parent context. |
+| `Tasks` | Task started / completed events. |
+| `Checkpoints` | Persisted snapshots. |
+| `Debug` | Everything (verbose). |
+| `Custom` | User-emitted via `StreamWriter` inside a node. |
+
+## Visualization
+
+```rust
+use cognis::graph::viz::{Dot, Mermaid, Ascii};
+
+println!("{}", Dot::render(&graph));     // GraphViz
+println!("{}", Mermaid::render(&graph)); // Mermaid
+println!("{}", Ascii::render(&graph));   // ASCII
+```
+
+## See also
+
+<CardGroup cols={2}>
+  <Card title="Agents" icon="robot" href="/concepts/agents">
+    Most agents are graphs under the hood.
+  </Card>
+  <Card title="Trace" icon="chart-line" href="/concepts/trace">
+    Graph nodes appear as nested spans in Langfuse.
+  </Card>
+</CardGroup>

--- a/docs/mintlify/concepts/llm.mdx
+++ b/docs/mintlify/concepts/llm.mdx
@@ -1,0 +1,190 @@
+---
+title: "LLM"
+description: "Chat models, providers, tool calling, structured output, streaming."
+sidebarTitle: "LLM"
+---
+
+`cognis-llm` defines the provider abstraction and ships concrete clients for the major vendors. Every chat model implements `Runnable<Vec<Message>, AiMessage>` (and `ChatModel` for richer features).
+
+## Providers
+
+All providers are feature-gated. Enable only what you ship.
+
+<Tabs>
+  <Tab title="OpenAI">
+    ```rust
+    use cognis::llm::providers::openai::ChatOpenAI;
+
+    let model = ChatOpenAI::builder()
+        .model("gpt-4o")
+        .temperature(0.7)
+        .api_key_from_env("OPENAI_API_KEY")?
+        .build()?;
+    ```
+  </Tab>
+  <Tab title="Anthropic">
+    ```rust
+    use cognis::llm::providers::anthropic::ChatAnthropic;
+
+    let model = ChatAnthropic::builder()
+        .model("claude-sonnet-4")
+        .api_key_from_env("ANTHROPIC_API_KEY")?
+        .build()?;
+    ```
+  </Tab>
+  <Tab title="Google">
+    ```rust
+    use cognis::llm::providers::google::ChatGoogle;
+
+    let model = ChatGoogle::builder()
+        .model("gemini-2.0-flash")
+        .api_key_from_env("GOOGLE_API_KEY")?
+        .build()?;
+    ```
+  </Tab>
+  <Tab title="Ollama">
+    ```rust
+    use cognis::llm::providers::ollama::ChatOllama;
+
+    // local — no key
+    let model = ChatOllama::builder()
+        .model("llama3.2:1b")
+        .base_url("http://localhost:11434")
+        .build()?;
+    ```
+  </Tab>
+  <Tab title="Azure">
+    ```rust
+    use cognis::llm::providers::azure::ChatAzureOpenAI;
+
+    let model = ChatAzureOpenAI::builder()
+        .deployment("gpt-4o-prod")
+        .api_version("2024-08-06")
+        .endpoint(env::var("AZURE_OPENAI_ENDPOINT")?)
+        .api_key_from_env("AZURE_OPENAI_API_KEY")?
+        .build()?;
+    ```
+  </Tab>
+  <Tab title="OpenRouter">
+    ```rust
+    use cognis::llm::providers::openai::ChatOpenAI;
+
+    // OpenRouter is OpenAI-compatible
+    let model = ChatOpenAI::builder()
+        .model("anthropic/claude-sonnet-4")
+        .base_url("https://openrouter.ai/api/v1")
+        .api_key_from_env("OPENROUTER_API_KEY")?
+        .with_extra_header("HTTP-Referer", "https://yourapp.com")
+        .build()?;
+    ```
+  </Tab>
+</Tabs>
+
+## Messages and content parts
+
+```rust
+use cognis::core::message::{Message, ContentPart};
+
+let messages = vec![
+    Message::system("You are a careful assistant."),
+    Message::human("Summarize this image:"),
+    Message::human_with_parts(vec![
+        ContentPart::Text("Describe the chart.".into()),
+        ContentPart::ImageUrl { url: image_url, detail: None },
+    ]),
+];
+```
+
+`Message` is an enum — `Human`, `Ai`, `System`, `Tool`. `ContentPart` covers text, images, and files.
+
+## Tool calling
+
+Define a tool with the `#[tool]` macro. Tools are also Runnables.
+
+```rust
+use cognis::tools::tool;
+use serde::Deserialize;
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct GetWeather {
+    /// City name, e.g. "Tokyo".
+    city: String,
+}
+
+#[tool]
+async fn get_weather(args: GetWeather) -> anyhow::Result<String> {
+    Ok(format!("It's 22°C and clear in {}.", args.city))
+}
+
+let bound = model.bind_tools(vec![get_weather()]);
+let resp: AiMessage = bound.invoke(messages, cfg).await?;
+for call in resp.tool_calls {
+    let result = registry.call(&call.name, call.arguments).await?;
+}
+```
+
+Or run a full agent loop with [`AgentBuilder`](/concepts/agents).
+
+## Structured output
+
+Two paths — pick based on whether the provider supports JSON Schema natively.
+
+<CodeGroup>
+
+```rust StructuredOutputParser
+use cognis::core::output_parsers::StructuredOutputParser;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct Recipe { name: String, steps: Vec<String> }
+
+let parser = StructuredOutputParser::<Recipe>::new();
+let chain = prompt.pipe(model).pipe(parser);
+let r: Recipe = chain.invoke(query, cfg).await?;
+```
+
+```rust with_structured_output
+let typed = model.with_structured_output::<Recipe>()?;
+let r: Recipe = typed.invoke(messages, cfg).await?;
+```
+
+</CodeGroup>
+
+`with_structured_output` uses the provider's JSON-mode / response-format API. `StructuredOutputParser` works with any provider by injecting schema instructions into the prompt — slower but provider-agnostic.
+
+## Streaming
+
+Use `stream` for token-level streaming.
+
+```rust
+let mut s = model.stream(messages, cfg).await?;
+while let Some(chunk) = s.next().await {
+    print!("{}", chunk?.content_text());
+    std::io::stdout().flush()?;
+}
+```
+
+For richer event-level streaming (start/token/end events), use `stream_events`.
+
+## Caching, retries, fallbacks
+
+Wrap any model with `cognis::core::wrappers`. Examples:
+
+```rust
+let model = ChatOpenAI::builder().model("gpt-4o").build()?
+    .with_cache(SqliteCache::new("./cache.db")?)
+    .with_retry(RetryConfig::exponential(3))
+    .with_fallback(ChatAnthropic::builder().model("claude-haiku-4").build()?);
+```
+
+See [Runnable](/concepts/runnable#wrappers) for the full list.
+
+## See also
+
+<CardGroup cols={2}>
+  <Card title="Agents" icon="robot" href="/concepts/agents">
+    Build a tool-calling loop with memory.
+  </Card>
+  <Card title="Trace" icon="chart-line" href="/concepts/trace">
+    Token usage, cost, and latency in Langfuse out of the box.
+  </Card>
+</CardGroup>

--- a/docs/mintlify/concepts/rag.mdx
+++ b/docs/mintlify/concepts/rag.mdx
@@ -1,0 +1,173 @@
+---
+title: "RAG"
+description: "Embeddings, vector stores, retrievers, splitters, and the indexing pipeline."
+sidebarTitle: "RAG"
+---
+
+`cognis-rag` provides the building blocks for retrieval-augmented generation: turning documents into embeddings, storing them, retrieving relevant chunks at query time, and composing the result into a prompt.
+
+## Documents
+
+A `Document` is the unit of indexing — text plus metadata.
+
+```rust
+use cognis::rag::document::Document;
+
+let doc = Document::new("Cognis is a Rust-native LLM framework.")
+    .with_metadata("source", "readme")
+    .with_metadata("section", "intro");
+```
+
+## Splitters
+
+Long inputs need to be chunked before embedding.
+
+```rust
+use cognis::rag::splitter::RecursiveCharacterTextSplitter;
+
+let splitter = RecursiveCharacterTextSplitter::new(1000, 100); // chunk_size, overlap
+let chunks: Vec<Document> = splitter.split_documents(vec![doc]).await?;
+```
+
+Other splitters: `CharacterTextSplitter`, `MarkdownHeaderTextSplitter`, `TokenTextSplitter`.
+
+## Embeddings
+
+`Embeddings` is a trait — implement once, use everywhere. Built-in implementations:
+
+| Type | Use case |
+|---|---|
+| `OpenAIEmbeddings` | text-embedding-3-small / -large |
+| `GoogleEmbeddings` | text-embedding-004, gemini-embedding |
+| `OllamaEmbeddings` | local embeddings via Ollama |
+| `VoyageEmbeddings` | Voyage AI |
+| `FakeEmbeddings` | deterministic fakes for tests |
+| `CachedEmbeddings` | wraps any embeddings with a hash-keyed cache |
+| `BatchedEmbeddings` | batches calls to honor provider rate limits |
+| `RouterEmbeddings` | dispatches by document metadata |
+
+```rust
+use cognis::rag::embeddings::OpenAIEmbeddings;
+
+let embed = OpenAIEmbeddings::builder()
+    .model("text-embedding-3-small")
+    .api_key_from_env("OPENAI_API_KEY")?
+    .build()?;
+```
+
+## Vector stores
+
+`VectorStore` is the trait. Implementations are feature-gated.
+
+<Tabs>
+  <Tab title="In-memory">
+    ```rust
+    use cognis::rag::vectorstore::InMemoryVectorStore;
+
+    let store = InMemoryVectorStore::new(embed.clone());
+    store.add_documents(chunks).await?;
+    let hits = store.similarity_search("rust llm", 5).await?;
+    ```
+  </Tab>
+  <Tab title="FAISS">
+    ```rust
+    use cognis::rag::vectorstore::FaissVectorStore;
+
+    let store = FaissVectorStore::open("./index.faiss", embed.clone())?;
+    store.add_documents(chunks).await?;
+    ```
+    Requires the `faiss` feature.
+  </Tab>
+  <Tab title="Qdrant / Chroma / Pinecone / Weaviate">
+    Hosted backends share the same interface; configure with the corresponding builder.
+    ```rust
+    use cognis::rag::vectorstore::QdrantVectorStore;
+
+    let store = QdrantVectorStore::builder()
+        .url("https://qdrant.example.com")
+        .api_key_from_env("QDRANT_API_KEY")?
+        .collection("my_docs")
+        .embeddings(embed.clone())
+        .build()?;
+    ```
+  </Tab>
+</Tabs>
+
+## Retrievers
+
+A `Retriever` implements `Runnable<String, Vec<Document>>`. Use one directly or compose retrievers.
+
+```rust
+use cognis::rag::retriever::VectorStoreRetriever;
+
+let retriever = VectorStoreRetriever::new(store.clone()).top_k(5);
+let docs = retriever.invoke("how does the bridge work?".into(), cfg).await?;
+```
+
+Other retrievers: `MultiQueryRetriever`, `EnsembleRetriever`, `ContextualCompressionRetriever`, `MMRRetriever`.
+
+## Indexing pipeline
+
+`IndexingPipeline` keeps a `VectorStore` in sync with a source. A `RecordManager` tracks which documents have been seen so re-indexing is incremental.
+
+```rust
+use cognis::rag::indexing::{IndexingPipeline, RecordManager, IndexingMode};
+
+let manager = RecordManager::sqlite("./record.db")?;
+let pipeline = IndexingPipeline::new(store.clone(), manager)
+    .with_splitter(splitter)
+    .with_mode(IndexingMode::Incremental);
+
+pipeline.index(loader).await?;
+```
+
+`IndexingMode::Incremental` only re-embeds new or changed documents. `Full` rebuilds the index from scratch.
+
+## Transformers
+
+Operate on retrieved documents before they reach the model.
+
+| Transformer | Effect |
+|---|---|
+| `Dedup` | drop near-duplicate chunks |
+| `Enrichment` | attach extra metadata via a side query |
+| `MetadataTransformer` | rewrite or filter on metadata |
+| `LongContextReorder` | move most-relevant chunks to the prompt edges |
+
+```rust
+use cognis::rag::transformers::{Dedup, LongContextReorder};
+
+let pipeline = retriever
+    .pipe(Dedup::default())
+    .pipe(LongContextReorder::default());
+```
+
+## End-to-end RAG chain
+
+```rust
+let format_docs = lambda(|docs: Vec<Document>| {
+    docs.iter().map(|d| d.page_content.clone()).collect::<Vec<_>>().join("\n\n")
+});
+
+let prompt = ChatPromptTemplate::new()
+    .system("Answer the question using only the context.\n\nContext:\n{context}")
+    .human("{question}");
+
+let rag = parallel!{
+    "context" => retriever.pipe(format_docs),
+    "question" => passthrough(),
+}.pipe(prompt).pipe(model).pipe(StrOutputParser);
+
+let answer: String = rag.invoke("how does the bridge work?".into(), cfg).await?;
+```
+
+## See also
+
+<CardGroup cols={2}>
+  <Card title="Agents" icon="robot" href="/concepts/agents">
+    Hand the retriever to an agent as a tool.
+  </Card>
+  <Card title="Trace" icon="chart-line" href="/concepts/trace">
+    Retriever calls show up as `Retriever` spans in Langfuse.
+  </Card>
+</CardGroup>

--- a/docs/mintlify/concepts/runnable.mdx
+++ b/docs/mintlify/concepts/runnable.mdx
@@ -1,0 +1,140 @@
+---
+title: "Runnable"
+description: "The unified Runnable<I, O> trait — one contract every primitive implements."
+sidebarTitle: "Runnable"
+---
+
+`Runnable<I, O>` is the trait every Cognis primitive implements: prompts, chat models, output parsers, tools, retrievers, chains, agents. Generic over input and output, so types flow through composition.
+
+```rust
+#[async_trait]
+pub trait Runnable<I, O>: Send + Sync
+where I: Send + 'static, O: Send + 'static
+{
+    async fn invoke(&self, input: I, config: RunnableConfig) -> Result<O>;
+
+    // Provided defaults — override only when you can do better.
+    async fn batch(&self, inputs: Vec<I>, config: RunnableConfig) -> Result<Vec<O>> { ... }
+    async fn stream(&self, input: I, config: RunnableConfig) -> Result<RunnableStream<O>> { ... }
+    async fn stream_events(&self, input: I, config: RunnableConfig) -> Result<EventStream> { ... }
+    fn name(&self) -> &str { ... }
+    fn input_schema(&self) -> Option<Value> { None }
+    fn output_schema(&self) -> Option<Value> { None }
+}
+```
+
+Implementing `invoke` is enough; the rest comes for free.
+
+## RunnableConfig
+
+Per-call configuration that travels with every invocation.
+
+```rust
+let cfg = RunnableConfig::default()
+    .with_max_concurrency(8)
+    .with_tag("prod")
+    .with_observer(my_observer);
+```
+
+| Field | Purpose |
+|---|---|
+| `recursion_limit` | Hard cap on graph depth; errors with `RecursionLimit`. |
+| `max_concurrency` | Bound on `batch` / fan-out tasks. |
+| `tags`, `metadata` | Free-form telemetry. |
+| `observers` | Subscribers receive `Event` values during execution. |
+| `run_id` | Correlation id; defaults to a fresh UUID. |
+| `parent_run_id` | Set automatically by composition sites for trace nesting. |
+| `cancel_token` | Cooperative cancellation. |
+| `deadline` | Hard wall-clock cutoff. |
+
+## Composition
+
+`pipe`, `branch`, `parallel`, `each`, `passthrough`, `lambda` — the operators in `cognis::core::compose`.
+
+<CodeGroup>
+
+```rust pipe
+// Type flows: String → Vec<Message> → AiMessage → MyStruct
+let chain = prompt.pipe(model).pipe(parser);
+let out: MyStruct = chain.invoke(input, cfg).await?;
+```
+
+```rust branch
+use cognis::core::compose::Branch;
+
+let routed = Branch::new(|q: &Query| match q.kind {
+    QueryKind::Code => "code",
+    QueryKind::Text => "text",
+})
+.add("code", code_chain)
+.add("text", text_chain);
+```
+
+```rust parallel
+use cognis::core::compose::Parallel;
+
+let p = Parallel::new()
+    .add("summary", summary_chain)
+    .add("entities", entity_chain);
+let out: HashMap<String, Value> = p.invoke(doc, cfg).await?;
+```
+
+```rust each
+use cognis::core::compose::Each;
+
+let per_doc = Each::new(summarize_chain);
+let summaries: Vec<String> = per_doc.invoke(docs, cfg).await?;
+```
+
+</CodeGroup>
+
+## Wrappers
+
+Cross-cutting behavior is added with wrappers from `cognis::core::wrappers`.
+
+```rust
+let model = ChatOpenAI::builder().model("gpt-4o").build()?
+    .with_retry(RetryConfig::exponential(3))
+    .with_timeout(Duration::from_secs(30))
+    .with_fallback(ChatOpenAI::builder().model("gpt-4o-mini").build()?)
+    .with_listeners(LoggingListener);
+```
+
+| Wrapper | Effect |
+|---|---|
+| `with_retry` | Retry on `Result::Err` per a `RetryConfig`. |
+| `with_timeout` | Bound a single `invoke` with a timeout. |
+| `with_fallback` | Try secondary on error. |
+| `with_cache` | Cache by hashed input. |
+| `with_bind` | Pre-bind constant arguments (e.g. system prompt). |
+| `with_configurable` | Expose runtime-swappable parameters. |
+| `with_listeners` | Pre-/post-invoke hooks. |
+
+## Streaming events
+
+Every Runnable can emit a structured event stream useful for observability and progress UIs.
+
+```rust
+let mut events = chain.stream_events(input, cfg).await?;
+while let Some(ev) = events.next().await {
+    match ev {
+        Event::OnStart { runnable, run_id, .. } => {}
+        Event::OnEnd { runnable, output, .. } => {}
+        Event::OnError { error, .. } => {}
+        _ => {}
+    }
+}
+```
+
+Pair this with [`cognis-trace`](/concepts/trace) to ship the same events to Langfuse or OTel.
+
+## See also
+
+<CardGroup cols={2}>
+  <Card title="LLM clients" icon="plug" href="/concepts/llm">
+    Chat models implement `Runnable<Vec<Message>, AiMessage>`.
+  </Card>
+  <Card title="Graph" icon="diagram-project" href="/concepts/graph">
+    Compiled graphs are also Runnables — drop-in composability.
+  </Card>
+</CardGroup>

--- a/docs/mintlify/concepts/trace.mdx
+++ b/docs/mintlify/concepts/trace.mdx
@@ -1,0 +1,186 @@
+---
+title: "Trace"
+description: "Pluggable observability — bridge CallbackHandler events to Langfuse, LangSmith, or OpenTelemetry."
+sidebarTitle: "Trace"
+---
+
+`cognis-trace` ships LLM-aware observability. A single `TracingHandler` translates lifecycle events from `cognis_core::CallbackHandler` into typed `Span` and `Generation` records, then fans them out to one or more `TraceExporter` implementations.
+
+## What it captures
+
+<CardGroup cols={2}>
+  <Card title="Trace tree" icon="diagram-project">
+    Chains, tools, retrievers, and graph nodes nest correctly via `parent_run_id` propagation.
+  </Card>
+  <Card title="Token usage + cost" icon="dollar-sign">
+    Input/output/cache-read/cache-write tokens and structured USD cost from a price table.
+  </Card>
+  <Card title="Sessions and users" icon="users">
+    `session_id`, `user_id`, tags, environment — populated from `RunnableConfig.metadata`.
+  </Card>
+  <Card title="Prompts and scores" icon="star">
+    Pull versioned prompts from Langfuse; push numeric / categorical / boolean scores back.
+  </Card>
+</CardGroup>
+
+## Wire Langfuse
+
+<Steps>
+  <Step title="Add the dependency">
+    ```toml
+    cognis-trace = { version = "0.2", features = ["langfuse"] }
+    ```
+  </Step>
+  <Step title="Set credentials">
+    ```bash
+    export LANGFUSE_PUBLIC_KEY=pk-lf-...
+    export LANGFUSE_SECRET_KEY=sk-lf-...
+    export LANGFUSE_HOST=https://cloud.langfuse.com   # optional
+    ```
+  </Step>
+  <Step title="Build a TracingHandler">
+    ```rust
+    use std::sync::Arc;
+    use cognis_trace::{LangfuseExporter, TracingHandler};
+    use cognis::core::callbacks::HandlerObserver;
+
+    let handler = TracingHandler::builder()
+        .with_exporter(LangfuseExporter::from_env()?)
+        .with_default_pricing()
+        .build();
+    ```
+  </Step>
+  <Step title="Attach to invocations">
+    ```rust
+    use cognis::core::stream::Observer;
+
+    let observer: Arc<dyn Observer> = Arc::new(HandlerObserver(handler));
+    let cfg = RunnableConfig::default().with_observer(observer);
+
+    chain.invoke(input, cfg).await?;
+    ```
+  </Step>
+  <Step title="Drain on shutdown">
+    Call `handler.shutdown().await` before process exit so in-flight batches flush.
+  </Step>
+</Steps>
+
+## Trace metadata
+
+Use `TraceMeta` helpers to attach session, user, tags, and environment to the trace root.
+
+```rust
+use cognis_trace::{TraceMeta, meta::merge_into};
+use serde_json::Value;
+
+let metadata = [
+    TraceMeta::session("session-abc"),
+    TraceMeta::user("user-123"),
+    TraceMeta::release("v1.4.2"),
+    TraceMeta::environment("production"),
+]
+.into_iter()
+.fold(Value::Null, merge_into);
+
+let cfg = RunnableConfig::default()
+    .with_observer(observer)
+    .with_metadata(metadata)
+    .with_tag("checkout");
+```
+
+The bridge promotes these to trace-level fields when the trace root closes.
+
+## Cost tracking
+
+`TracingHandler` computes USD cost on every `on_llm_end` using a `PriceTable`. Defaults are a 2026-05 snapshot for the major providers; override per-model when your contract differs.
+
+```rust
+use cognis_trace::{ModelPrice, PriceTable, TracingHandler};
+
+let pricing = PriceTable::with_defaults();
+
+let handler = TracingHandler::builder()
+    .with_exporter(LangfuseExporter::from_env()?)
+    .with_pricing(pricing)
+    .override_price("gpt-4o", ModelPrice {
+        input: 2.50,
+        output: 10.00,
+        cache_read: 1.25,
+        cache_write: 0.0,
+    })
+    .build();
+```
+
+Costs land on each `Generation` span as `cost: { input, output, cache_read, cache_write, total }` and on the corresponding Langfuse `costDetails` field.
+
+## Prompt management
+
+Pull versioned prompts straight from Langfuse.
+
+```rust
+use cognis_trace::{LangfusePromptClient, LangfuseConfig, PromptStore};
+
+let client = LangfusePromptClient::new(LangfuseConfig::from_env()?)?;
+let prompt = client.get("greeting").await?;            // latest
+let prompt = client.get_version("greeting", 3).await?; // pinned
+let prompt = client.get_label("greeting", "production").await?;
+```
+
+`Prompt` carries `name`, `version`, `body` (text or chat), `config`, and `labels`. The bridge automatically stamps `prompt_name` and `prompt_version` on the resulting generation when you wire the prompt into your chain.
+
+## Evaluation scores
+
+Submit a numeric / categorical / boolean score for any run, in-band via the handler or out-of-band via `LangfuseScorer`.
+
+<CodeGroup>
+
+```rust In-band
+use cognis_trace::{ScoreRecord, ScoreValue};
+
+handler.record_score(ScoreRecord {
+    run_id,
+    trace_id: None,
+    session_id: None,
+    name: "novelty".into(),
+    value: ScoreValue::Numeric(0.87),
+    comment: Some("rated by eval pipeline".into()),
+});
+```
+
+```rust Out-of-band
+use cognis_trace::{LangfuseScorer, ScoreSink};
+
+let scorer = LangfuseScorer::new(LangfuseConfig::from_env()?)?;
+scorer.submit(ScoreRecord { ... }).await?;
+```
+
+</CodeGroup>
+
+## Multiple exporters
+
+Stack `Stdout` for local dev and `Langfuse` for production observability.
+
+```rust
+let handler = TracingHandler::builder()
+    .with_exporter(StdoutExporter::compact())
+    .with_exporter(LangfuseExporter::from_env()?)
+    .with_default_pricing()
+    .build();
+```
+
+Each exporter has its own bounded background batcher, so a slow Langfuse never blocks the `Stdout` path or the user's chain invocation. Failures are logged and counted in `handler.stats(name)`.
+
+<Note>
+LangSmith and OpenTelemetry exporters are on the roadmap. Until they ship, use a generic OTel collector pointed at your backend, or implement `TraceExporter` for your stack.
+</Note>
+
+## See also
+
+<CardGroup cols={2}>
+  <Card title="Runnable" icon="code" href="/concepts/runnable">
+    `stream_events()` is the source of trace data.
+  </Card>
+  <Card title="Feature flags" icon="toggle-on" href="/reference/feature-flags">
+    `langfuse` is the only feature `cognis-trace` ships in v1.
+  </Card>
+</CardGroup>

--- a/docs/mintlify/docs.json
+++ b/docs/mintlify/docs.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "mint",
+  "name": "Cognis",
+  "description": "Rust-native LLM framework. Type-safe Runnable, agent loop, graph state, RAG pipeline, and observability.",
+  "colors": {
+    "primary": "#D97706",
+    "light": "#F59E0B",
+    "dark": "#92400E"
+  },
+  "favicon": "/favicon.svg",
+  "navigation": {
+    "tabs": [
+      {
+        "tab": "Documentation",
+        "icon": "book-open",
+        "groups": [
+          {
+            "group": "Get started",
+            "icon": "rocket",
+            "pages": [
+              "introduction",
+              "quickstart",
+              "installation"
+            ]
+          },
+          {
+            "group": "Concepts",
+            "icon": "lightbulb",
+            "pages": [
+              "concepts/runnable",
+              "concepts/llm",
+              "concepts/rag",
+              "concepts/graph",
+              "concepts/agents",
+              "concepts/trace"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Reference",
+        "icon": "book",
+        "groups": [
+          {
+            "group": "Reference",
+            "pages": [
+              "reference/crates",
+              "reference/feature-flags"
+            ]
+          }
+        ]
+      }
+    ],
+    "global": {
+      "anchors": [
+        {
+          "anchor": "GitHub",
+          "icon": "github",
+          "href": "https://github.com/0xvasanth/cognis"
+        },
+        {
+          "anchor": "crates.io",
+          "icon": "box",
+          "href": "https://crates.io/crates/cognis"
+        }
+      ]
+    }
+  },
+  "footer": {
+    "socials": {
+      "github": "https://github.com/0xvasanth/cognis"
+    }
+  }
+}

--- a/docs/mintlify/installation.mdx
+++ b/docs/mintlify/installation.mdx
@@ -1,0 +1,126 @@
+---
+title: "Installation"
+description: "Add cognis to a Cargo project. Choose the umbrella crate or pull individual capability crates."
+sidebarTitle: "Installation"
+---
+
+## Prerequisites
+
+- Rust 1.75 or newer (workspace edition is 2021).
+- A tokio runtime — most APIs are `async`.
+
+## Pick the entry point
+
+<Tabs>
+  <Tab title="Umbrella (recommended)">
+    `cognis` re-exports `core`, `llm`, `rag`, `graph`, plus the agent layer.
+
+    ```toml
+    [dependencies]
+    cognis = { version = "0.2", features = ["openai", "anthropic"] }
+    tokio = { version = "1", features = ["full"] }
+    ```
+
+    Use this when you want one dependency and the convenient `cognis::*` re-exports.
+  </Tab>
+  <Tab title="Per-crate">
+    Pull only what you need to keep the dependency tree slim.
+
+    ```toml
+    [dependencies]
+    cognis-core = "0.1"
+    cognis-llm = { version = "0.2", features = ["openai"] }
+    cognis-rag = { version = "0.2", features = ["faiss"] }
+    cognis-graph = { version = "0.2", features = ["sqlite"] }
+    cognis-trace = { version = "0.2", features = ["langfuse"] }
+    ```
+
+    `cognis-core` is the foundation. The others depend on it but not on each other.
+  </Tab>
+</Tabs>
+
+## Feature flags
+
+Most provider integrations and storage backends are feature-gated so the core crates compile with no network deps.
+
+| Feature | Crate | Pulls in |
+|---|---|---|
+| `openai` | `cognis` / `cognis-llm` | OpenAI Chat Completions |
+| `anthropic` | `cognis` / `cognis-llm` | Anthropic Messages |
+| `google` | `cognis` / `cognis-llm` | Gemini |
+| `ollama` | `cognis` / `cognis-llm` | local Ollama |
+| `azure` | `cognis` / `cognis-llm` | Azure OpenAI |
+| `openrouter` | `cognis` / `cognis-llm` | OpenRouter aggregation |
+| `all-providers` | `cognis` | every provider above |
+| `faiss` | `cognis-rag` | FAISS vector store |
+| `chroma`, `qdrant`, `pinecone`, `weaviate` | `cognis-rag` | hosted vector stores |
+| `voyage` | `cognis-rag` | Voyage embeddings |
+| `pdf`, `yaml`, `toml-loader` | `cognis` | document loaders |
+| `cache-sqlite` | `cognis` | SQLite-backed model cache |
+| `tools-http` | `cognis` | HTTP tool primitives |
+| `sqlite`, `postgres` | `cognis-graph` | checkpointer backends |
+| `langfuse` | `cognis-trace` | Langfuse exporter + prompts + scores |
+
+See [Feature flags](/reference/feature-flags) for the complete table.
+
+## Set credentials
+
+<Note>
+Cognis never reads `.env` files. Configure secrets via your shell, `direnv` + `envchain`, or your platform's secret manager.
+</Note>
+
+<CodeGroup>
+
+```bash direnv + envchain
+# In .envrc (safe to commit):
+if command -v envchain >/dev/null 2>&1; then
+  vars=$(envchain --list myapp 2>/dev/null | paste -sd '|' -)
+  if [ -n "$vars" ]; then
+    eval "$(envchain myapp env | grep -E "^(${vars})=" | sed 's/^/export /')"
+  fi
+fi
+
+# Then store keys interactively:
+envchain --set myapp OPENAI_API_KEY
+envchain --set myapp ANTHROPIC_API_KEY
+direnv allow
+```
+
+```bash plain shell
+export OPENAI_API_KEY=sk-...
+export ANTHROPIC_API_KEY=sk-ant-...
+export GOOGLE_API_KEY=...
+```
+
+</CodeGroup>
+
+## Verify
+
+```bash
+cargo check
+```
+
+If you set up the umbrella with `openai`, you should be able to write:
+
+```rust
+use cognis::llm::providers::openai::ChatOpenAI;
+let _ = ChatOpenAI::builder().model("gpt-4o-mini");
+```
+
+## Workspace builds
+
+If you're building the cognis workspace itself (e.g. contributing or pinning to `path = "..."` deps), the build commands are:
+
+```bash
+cargo build --workspace
+cargo build -p cognis --features all-providers
+cargo test --workspace
+```
+
+Each capability crate has its own focused test suite:
+
+```bash
+cargo test -p cognis-core
+cargo test -p cognis-trace --features langfuse
+cargo test -p cognis-graph --features sqlite
+```

--- a/docs/mintlify/introduction.mdx
+++ b/docs/mintlify/introduction.mdx
@@ -1,0 +1,79 @@
+---
+title: "Cognis"
+description: "Rust-native LLM framework — typed Runnable, agent loop, graph state, RAG pipeline, observability."
+sidebarTitle: "Introduction"
+---
+
+Cognis translates the conceptual surface of LangChain, LangGraph, and DeepAgents into idiomatic Rust. It is not a line-by-line port; the goal is to keep the *intent* (Runnables, agents, graphs, RAG, traces) and discard the dynamism by leaning on Rust's type system.
+
+## What you get
+
+<CardGroup cols={2}>
+  <Card title="Typed Runnable<I, O>" icon="code">
+    Every primitive is a `Runnable` generic over input and output. Pipe, branch, parallelize without losing types.
+  </Card>
+  <Card title="LLM providers" icon="plug">
+    OpenAI, Anthropic, Google, Ollama, Azure, OpenRouter — feature-gated, behind one trait.
+  </Card>
+  <Card title="Graph state" icon="diagram-project">
+    `Graph<S>` with reducers, channels, checkpoints, interrupts, time-travel, all 7 stream modes.
+  </Card>
+  <Card title="RAG building blocks" icon="database">
+    Embeddings, vector stores, retrievers, splitters, an indexing pipeline with a record manager.
+  </Card>
+  <Card title="Agents" icon="robot">
+    Single-agent and multi-agent orchestration, memory variants, tool registry, middleware.
+  </Card>
+  <Card title="Observability" icon="chart-line">
+    Bridge `CallbackHandler` events to Langfuse, LangSmith, or any OTLP backend.
+  </Card>
+</CardGroup>
+
+## Workspace at a glance
+
+| Crate | Responsibility |
+|---|---|
+| `cognis-core` | `Runnable`, `Message`, prompts, output parsers, callbacks, compose. Zero internal deps. |
+| `cognis-llm` | Provider abstractions and impls (feature-gated). Tools, structured output, streaming. |
+| `cognis-rag` | Embeddings, vector stores, retrievers, splitters, loaders, indexing pipeline. |
+| `cognis-graph` | Stateful `Graph<S>`, Pregel engine, reducers, checkpointers, interrupts. |
+| `cognis-trace` | Pluggable observability — Langfuse first, LangSmith and OTel pluggable. |
+| `cognis-macros` | `#[tool]`, `#[derive(GraphState)]`. |
+| `cognis` | Umbrella + agent layer. Re-exports the four siblings. |
+
+## Design principles
+
+<AccordionGroup>
+  <Accordion title="Generic Runnable, not Value-typed">
+    `Runnable<I, O>` is generic — never `Value`-typed at trait boundaries. Use `serde_json::Value` only at system edges (user input, persistence, wire serialization). Heterogeneous composition uses type-erased wrappers (`DynRunnable`).
+  </Accordion>
+  <Accordion title="Traits over class hierarchies">
+    Each capability is a trait with a small required surface and generous provided defaults. New `Memory` impls reuse the same `read`/`write`/`clear` shape. New `RateLimiter` impls reuse the `acquire(estimated_tokens)` signature.
+  </Accordion>
+  <Accordion title="Builders return Self">
+    `with_X(self, x) -> Self`. Constructors don't take optional args — promote them to builder methods.
+  </Accordion>
+  <Accordion title="Enums for closed sets">
+    Where Python uses union types or magic strings, Rust uses enums with exhaustive matching. `Message`, `ContentPart`, `ToolChoice`, `StreamMode`, `Goto`, `Durability`.
+  </Accordion>
+  <Accordion title="Errors are actionable">
+    Each crate defines its own `thiserror` enum. The caller can match on the variant and decide what to do — retry, fall back, surface to the user.
+  </Accordion>
+</AccordionGroup>
+
+## Where to next
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="bolt" href="/quickstart">
+    A 5-minute hello-world chain.
+  </Card>
+  <Card title="Installation" icon="download" href="/installation">
+    Workspace setup and feature flags.
+  </Card>
+  <Card title="Concepts" icon="book" href="/concepts/runnable">
+    Start with `Runnable`, then pick the crate that matches your task.
+  </Card>
+  <Card title="Trace" icon="chart-line" href="/concepts/trace">
+    Wire a chain to Langfuse in three lines.
+  </Card>
+</CardGroup>

--- a/docs/mintlify/quickstart.mdx
+++ b/docs/mintlify/quickstart.mdx
@@ -1,0 +1,149 @@
+---
+title: "Quickstart"
+description: "A working chain in five minutes."
+sidebarTitle: "Quickstart"
+---
+
+This page builds a minimal chain that takes a topic, asks an LLM to explain it, and parses the answer into a struct.
+
+## 1. Add cognis to your project
+
+<CodeGroup>
+
+```toml Cargo.toml
+[dependencies]
+cognis = { version = "0.2", features = ["openai"] }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+```
+
+```bash cargo add
+cargo add cognis --features openai
+cargo add tokio --features full
+cargo add serde --features derive
+```
+
+</CodeGroup>
+
+## 2. Set the API key
+
+<Note>
+Cognis never reads `.env` files. Use environment variables loaded by your shell, `direnv`, or `envchain`.
+</Note>
+
+```bash
+export OPENAI_API_KEY=sk-...
+```
+
+## 3. Build and run a chain
+
+<Steps>
+  <Step title="Define the output shape">
+    A struct annotated with `serde::Deserialize` and `schemars::JsonSchema` so the parser knows the format.
+    ```rust
+    use schemars::JsonSchema;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, JsonSchema)]
+    struct Explanation {
+        topic: String,
+        summary: String,
+        difficulty: u8,
+    }
+    ```
+  </Step>
+  <Step title="Compose prompt → model → parser">
+    `pipe` keeps types flowing: `String → Vec<Message> → AiMessage → Explanation`.
+    ```rust
+    use cognis::core::{ChatPromptTemplate, Runnable, RunnableConfig};
+    use cognis::llm::providers::openai::ChatOpenAI;
+    use cognis::core::output_parsers::StructuredOutputParser;
+
+    let prompt = ChatPromptTemplate::new()
+        .system("Explain the topic in two sentences for a beginner.")
+        .human("{topic}");
+
+    let model = ChatOpenAI::builder()
+        .model("gpt-4o-mini")
+        .api_key_from_env("OPENAI_API_KEY")?
+        .build()?;
+
+    let parser = StructuredOutputParser::<Explanation>::new();
+
+    let chain = prompt.pipe(model).pipe(parser);
+    ```
+  </Step>
+  <Step title="Invoke">
+    ```rust
+    let out: Explanation = chain
+        .invoke("monads".to_string(), RunnableConfig::default())
+        .await?;
+    println!("{:#?}", out);
+    ```
+  </Step>
+</Steps>
+
+## Full file
+
+```rust src/main.rs
+use cognis::core::{ChatPromptTemplate, Runnable, RunnableConfig};
+use cognis::core::output_parsers::StructuredOutputParser;
+use cognis::llm::providers::openai::ChatOpenAI;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct Explanation {
+    topic: String,
+    summary: String,
+    difficulty: u8,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let prompt = ChatPromptTemplate::new()
+        .system("Explain the topic in two sentences for a beginner.")
+        .human("{topic}");
+
+    let model = ChatOpenAI::builder()
+        .model("gpt-4o-mini")
+        .api_key_from_env("OPENAI_API_KEY")?
+        .build()?;
+
+    let parser = StructuredOutputParser::<Explanation>::new();
+    let chain = prompt.pipe(model).pipe(parser);
+
+    let out: Explanation = chain
+        .invoke("monads".to_string(), RunnableConfig::default())
+        .await?;
+    println!("{:#?}", out);
+    Ok(())
+}
+```
+
+```bash
+cargo run
+```
+
+## What just happened
+
+- `ChatPromptTemplate` produced a `Vec<Message>` with `system` + `human` roles.
+- `ChatOpenAI` generated an `AiMessage`. The chain knows the input it expects because of types.
+- `StructuredOutputParser<Explanation>` injected JSON Schema instructions into the prompt and parsed the response into `Explanation`. If parsing fails, wrap the parser with `OutputFixingParser` or `RetryParser`.
+
+## Next
+
+<CardGroup cols={2}>
+  <Card title="The Runnable trait" icon="code" href="/concepts/runnable">
+    `pipe`, `branch`, `parallel`, `each` — and how types stay typed across them.
+  </Card>
+  <Card title="Switch providers" icon="plug" href="/concepts/llm">
+    Anthropic, Google, Ollama, Azure, OpenRouter share the trait.
+  </Card>
+  <Card title="Add memory & tools" icon="robot" href="/concepts/agents">
+    Promote the chain to an agent with memory and tool calling.
+  </Card>
+  <Card title="Trace this chain" icon="chart-line" href="/concepts/trace">
+    Ship every invocation to Langfuse with three extra lines.
+  </Card>
+</CardGroup>

--- a/docs/mintlify/reference/crates.mdx
+++ b/docs/mintlify/reference/crates.mdx
@@ -1,0 +1,98 @@
+---
+title: "Workspace map"
+description: "What each crate does, what depends on what, and where to find things."
+sidebarTitle: "Workspace map"
+---
+
+## Crates
+
+```
+crates/
+├── cognis-core    # Foundation. Zero internal-crate deps.
+├── cognis-llm     # LLM clients + provider impls (feature-gated).
+├── cognis-rag     # Embeddings, vector stores, retrievers, splitters, indexing.
+├── cognis-graph   # Crate name "cognis-graph". Stateful Graph<S>, Pregel engine.
+├── cognis-trace   # Pluggable observability. Langfuse first.
+├── cognis-macros  # Proc macros: #[tool], #[derive(GraphState)].
+├── cognis         # Umbrella + agent layer. Re-exports the four siblings.
+└── examples       # Non-publishable. Demo programs.
+```
+
+## Dependency rules
+
+- `cognis-core` has **zero** internal-crate dependencies.
+- `cognis-llm`, `cognis-rag`, `cognis-graph`, `cognis-trace` each depend only on `cognis-core` (and `cognis-macros` where they use a derive). They do **not** depend on each other.
+- `cognis` is the only crate that depends on the four siblings together.
+- `cognis-macros` is proc-macro-only.
+
+```mermaid
+graph TD
+    core[cognis-core]
+    macros[cognis-macros]
+    llm[cognis-llm] --> core
+    rag[cognis-rag] --> core
+    graph[cognis-graph] --> core
+    trace[cognis-trace] --> core
+    llm --> macros
+    rag --> macros
+    graph --> macros
+    cognis[cognis umbrella] --> core
+    cognis --> llm
+    cognis --> rag
+    cognis --> graph
+    cognis --> trace
+```
+
+## Where new code goes
+
+| Concept | Crate |
+|---|---|
+| LLM client, provider, chat options, tool dispatch, structured output | `cognis-llm` |
+| Embeddings, vector stores, retrievers, splitters, loaders, indexing | `cognis-rag` |
+| `Graph<S>`, nodes, channels, reducers, checkpointers, viz | `cognis-graph` |
+| Tracing / observability adapter (Langfuse, OTel, …) | `cognis-trace` |
+| Agent loop, multi-agent, agent bus, middleware, built-in tools, memory | `cognis` |
+| `Runnable`, prompts, output parsers, error, `Message`, callbacks | `cognis-core` |
+| Anything that does I/O against an external service | feature-gated, opt-in |
+
+If a feature could plausibly live in two places, default to the smaller crate (closer to `cognis-core`).
+
+## Re-exports from the umbrella
+
+The `cognis` umbrella re-exports the four siblings under module paths so you can write `cognis::core::Runnable`, `cognis::llm::providers::openai::ChatOpenAI`, etc.
+
+| Path | Source |
+|---|---|
+| `cognis::core::*` | `cognis-core` |
+| `cognis::llm::*` | `cognis-llm` |
+| `cognis::rag::*` | `cognis-rag` |
+| `cognis::graph::*` | `cognis-graph` |
+| `cognis::agent::*` | (lives in `cognis`) |
+| `cognis::tools::*` | (lives in `cognis`) |
+| `cognis::middleware::*` | (lives in `cognis`) |
+
+`cognis-trace` is intentionally **not** re-exported through the umbrella — keep observability deps out of code that just wants to invoke a chain.
+
+## API reference
+
+Per-crate rustdoc lives on docs.rs.
+
+<CardGroup cols={3}>
+  <Card title="cognis-core" icon="code" href="https://docs.rs/cognis-core" />
+  <Card title="cognis-llm" icon="plug" href="https://docs.rs/cognis-llm" />
+  <Card title="cognis-rag" icon="database" href="https://docs.rs/cognis-rag" />
+  <Card title="cognis-graph" icon="diagram-project" href="https://docs.rs/cognis-graph" />
+  <Card title="cognis-trace" icon="chart-line" href="https://docs.rs/cognis-trace" />
+  <Card title="cognis" icon="box" href="https://docs.rs/cognis" />
+</CardGroup>
+
+## Workspace metadata
+
+Workspace metadata is hoisted: `version`, `edition`, `license`, `authors` live in `[workspace.package]`. Member crates use `version.workspace = true`.
+
+```bash
+cargo build --workspace
+cargo test --workspace
+cargo build -p cognis --features all-providers
+cargo test -p cognis-trace --features langfuse
+```

--- a/docs/mintlify/reference/feature-flags.mdx
+++ b/docs/mintlify/reference/feature-flags.mdx
@@ -1,0 +1,130 @@
+---
+title: "Feature flags"
+description: "Every feature flag in the workspace, what it pulls in, and where it lives."
+sidebarTitle: "Feature flags"
+---
+
+Cognis is feature-light by default — every external integration (HTTP providers, database backends, vector store clients) is feature-gated so the core crates compile with no network deps.
+
+## cognis (umbrella)
+
+| Feature | Pulls in |
+|---|---|
+| `openai` | `cognis-llm/openai` — OpenAI chat + tools + structured output |
+| `anthropic` | `cognis-llm/anthropic` — Anthropic Messages API |
+| `google` | `cognis-llm/google` — Gemini |
+| `ollama` | `cognis-llm/ollama` — local Ollama |
+| `azure` | `cognis-llm/azure` — Azure OpenAI |
+| `openrouter` | `cognis-llm/openrouter` — attribution headers + extra-headers helpers |
+| `all-providers` | every provider above |
+| `pdf` | `cognis-rag/pdf` — PDF document loader |
+| `yaml` | `cognis-rag/yaml` — YAML loader |
+| `toml-loader` | `cognis-rag/toml-loader` — TOML loader |
+| `cache-sqlite` | SQLite-backed model cache |
+| `tools-http` | HTTP request primitives for tools |
+
+```bash
+cargo add cognis --features openai,anthropic,pdf
+cargo add cognis --features all-providers,cache-sqlite
+```
+
+## cognis-llm
+
+| Feature | Effect |
+|---|---|
+| `openai` | `reqwest` + OpenAI client |
+| `anthropic` | `reqwest` + Anthropic client |
+| `google` | `reqwest` + Gemini client |
+| `ollama` | `reqwest` + Ollama client (no key) |
+| `azure` | `reqwest` + Azure OpenAI client |
+| `openrouter` | OpenAI-compatible client targeted at OpenRouter |
+| `all-providers` | every provider above |
+
+Default: no provider features; the trait surface compiles offline.
+
+## cognis-rag
+
+### Vector stores
+
+| Feature | Backend |
+|---|---|
+| `faiss` | local FAISS index |
+| `chroma` | Chroma server |
+| `qdrant` | Qdrant server |
+| `pinecone` | Pinecone (managed) |
+| `weaviate` | Weaviate server |
+
+### Embeddings
+
+| Feature | Provider |
+|---|---|
+| `openai` | OpenAI text-embedding-3-* |
+| `voyage` | Voyage AI |
+| `google` | Google text-embedding-004, gemini-embedding |
+
+### Loaders
+
+| Feature | Loader |
+|---|---|
+| `pdf` | PDF |
+| `yaml` | YAML |
+| `toml-loader` | TOML |
+
+`cognis-rag` ships with `InMemoryVectorStore`, `FakeEmbeddings`, `CachedEmbeddings`, `BatchedEmbeddings`, and the indexing pipeline always available.
+
+## cognis-graph
+
+| Feature | Pulls in |
+|---|---|
+| `sqlite` | `sqlx/sqlite` — SQLite checkpointer |
+| `postgres` | `sqlx/postgres` — Postgres checkpointer |
+
+`MemoryCheckpointer` and the engine itself are always available.
+
+## cognis-trace
+
+| Feature | Pulls in |
+|---|---|
+| `stdout` | `StdoutExporter` (default) |
+| `langfuse` | `reqwest` + Langfuse exporter, prompt client, scorer |
+| `all` | every backend above |
+| `integration_tests` | enables tests that hit real services (off by default) |
+
+```toml
+cognis-trace = { version = "0.2", features = ["langfuse"] }
+```
+
+`MockExporter` is always built — useful in tests.
+
+## cognis-core, cognis-macros
+
+These crates compile with **no** network features ever. Anything that does I/O lives in a sibling crate.
+
+## Picking the minimum set
+
+<Tabs>
+  <Tab title="Local Ollama only">
+    ```toml
+    cognis = { version = "0.2", features = ["ollama"] }
+    ```
+  </Tab>
+  <Tab title="OpenAI + RAG with FAISS">
+    ```toml
+    cognis = { version = "0.2", features = ["openai"] }
+    cognis-rag = { version = "0.2", features = ["faiss", "openai"] }
+    ```
+  </Tab>
+  <Tab title="Multi-provider with traces">
+    ```toml
+    cognis = { version = "0.2", features = ["all-providers", "cache-sqlite"] }
+    cognis-trace = { version = "0.2", features = ["langfuse"] }
+    ```
+  </Tab>
+  <Tab title="Stateful agents on Postgres">
+    ```toml
+    cognis = { version = "0.2", features = ["openai"] }
+    cognis-graph = { version = "0.2", features = ["postgres"] }
+    cognis-trace = { version = "0.2", features = ["langfuse"] }
+    ```
+  </Tab>
+</Tabs>


### PR DESCRIPTION
Closes the remaining V1-parity gaps called out in the latest parity report.

Each lands as its own commit; build green between commits.

## What's in here

### Hierarchical + Consensus handoff strategies (`cf268ad`)
- **`Hierarchical`** — multi-level supervisor tree. Each level emits \"target_id: instruction\"; orchestrator walks down until a leaf returns or `max_depth` is hit. Same parser surface as `Supervisor`, override via `with_parser`.
- **`Consensus`** — weighted-quorum voting. All agents run in parallel; the highest-weighted answer wins iff it clears `quorum`. Errors with the tally if it doesn't (distinct from `ParallelVote` which always returns the plurality).

### `PluginRegistry` with lifecycle (`fb7c7ef` + `73f187a`)
- New `LifecyclePlugin` trait alongside `AgentPlugin`. `&self` so the registry can activate/deactivate the same plugin multiple times. Declares deps via `deps()`, optional teardown via `deactivate()`.
- `PluginRegistry`: register / unregister with duplicate-name rejection; `activate_all` topo-sorts by deps (Kahn's), errors on cycles + unknown refs, rolls back already-activated plugins on any failure; `deactivate_all` walks reverse-topo so dependents tear down before deps.
- `ClosurePlugin` for inline registration.

### `HybridMemory` (`51cb13c`)
- Composes N `Box<dyn Memory>` members behind one. Writes fan out; `seed()` concatenates each member's contribution in registration order.
- Pattern: `Window` for recent + `SummaryMemory` for long-term + `EntityMemory` for ledger + `VectorMemory` for semantic recall, each pulling its own weight on every turn.

### `AgentEventBus` typed events (`674fe6e`)
- Layered over `AgentBus`. `AgentEvent` variants: `Started` / `Finished` / `ToolCalled` / `ToolResult` / `Errored` / `Custom`. Serde-encoded into `AgentMessage.metadata`.
- `AgentEventBus::with_bus()` lets typed events share the underlying transport with arbitrary point-to-point topics.
- `EventSubscription::recv()` returns deserialized `AgentEvent`.

### Graph static analysis (`27f159d` + `aac287a`)
- `CompiledGraph::analyze()` returns `GraphAnalysis { node_count, edge_count, has_cycle, depth, unreachable }`.
- Cycle detection: DFS three-color over the subgraph reachable from start (back-edge detection).
- `depth`: memoized DFS for longest path (in edges) — only meaningful for DAGs, returns 0 if `has_cycle`.
- `unreachable`: nodes registered but unreached from start via static edges.
- Static-edge-only by design — diagnoses the topology you wrote, not runtime `Goto::Send` behavior.

## Test plan

- [x] `cargo test --workspace --lib` — green (all tests across all crates).
- [x] `cargo clippy --workspace --features all-providers --tests -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- New tests added per feature:
  - multi_agent: 6 new (`hierarchical_*` x3 + `consensus_*` x3)
  - plugin_registry: 7 new (duplicate / unknown_dep / cycle / diamond / rollback / unregister / reverse-topo)
  - memory tests_hybrid: 4 new (fan-out / clear / seed concat / empty)
  - agent_events: 5 new (round-trip / fanout / topic isolation / shared bus / sub count)
  - analysis: 5 new (linear / diamond / self-loop / back-edge / unreachable)

## Re-exports added at the `cognis` umbrella

- `Consensus`, `Hierarchical` (multi_agent)
- `LifecyclePlugin`, `PluginRegistry`, `ClosurePlugin` (agent::plugin_registry)
- `HybridMemory` (agent::memory)
- `AgentEvent`, `AgentEventBus`, `EventSubscription`, `DEFAULT_EVENTS_TOPIC` (agent_events)
- `GraphAnalysis` (cognis-graph)

## Net diff
6 commits, ~1.4k lines added. No churn outside the new modules and their re-export sites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Hierarchical`/`Consensus` orchestration, a lifecycle `PluginRegistry`, `HybridMemory`, a typed `AgentEventBus`, and static graph analysis to close the remaining V1 parity gaps, plus a Mintlify docs site under `docs/mintlify`. Improves orchestration, plugin management, memory composition, event observability, graph diagnostics, and developer onboarding.

- **New Features**
  - Multi-agent: `Hierarchical` multi-level routing (parser overridable) and `Consensus` weighted-quorum voting that errors if quorum isn’t met.
  - Plugins: `LifecyclePlugin` and `PluginRegistry` with deps, topo-sorted `activate_all`, rollback on failure; `ClosurePlugin` for inline plugins.
  - Memory: `HybridMemory` fans out writes to member memories; `seed()` concatenates contributions in registration order.
  - Events: `AgentEventBus` with `AgentEvent` variants (`Started`, `Finished`, `ToolCalled`, `ToolResult`, `Errored`, `Custom`), shares underlying `AgentBus`, topic configurable.
  - Graph: `CompiledGraph::analyze()` returns `GraphAnalysis` (node/edge counts, cycle check, longest acyclic path depth, unreachable nodes); static-edge analysis only.
  - Re-exports at `cognis`: `Consensus`, `Hierarchical`, `LifecyclePlugin`, `PluginRegistry`, `ClosurePlugin`, `HybridMemory`, `AgentEvent`, `AgentEventBus`, `EventSubscription`, `DEFAULT_EVENTS_TOPIC`, `GraphAnalysis`.

<sup>Written for commit aafd3aefc18fcbd4c0a3f5504f0eeb4371e0be88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

