### PR TITLE
feat:Message envelope, tool perms, eval reports, conversation views, threshold alerts, graph annotations

### DIFF
--- a/crates/cognis-llm/src/tools/mod.rs
+++ b/crates/cognis-llm/src/tools/mod.rs
@@ -69,11 +69,45 @@ impl ToolDefinition {
     }
 }
 
+/// Per-tool runtime state — enabled/disabled flag + call counter.
+#[derive(Default)]
+struct ToolEntry {
+    tool: Option<Arc<dyn Tool>>,
+    enabled: bool,
+    /// Total successful + failed calls served via [`ToolRegistry::execute`].
+    calls: std::sync::atomic::AtomicUsize,
+    /// Optional permission predicate: `agent_id → allowed?`.
+    #[allow(clippy::type_complexity)]
+    permission: Option<Arc<dyn Fn(&str) -> bool + Send + Sync>>,
+}
+
+impl Clone for ToolEntry {
+    fn clone(&self) -> Self {
+        Self {
+            tool: self.tool.clone(),
+            enabled: self.enabled,
+            calls: std::sync::atomic::AtomicUsize::new(
+                self.calls.load(std::sync::atomic::Ordering::Relaxed),
+            ),
+            permission: self.permission.clone(),
+        }
+    }
+}
+
 /// HashMap-backed tool registry. The agent layer uses this to dispatch
 /// tool calls returned by the LLM.
-#[derive(Default)]
+///
+/// Per-tool controls (added in V2):
+/// - [`ToolRegistry::enable`] / [`ToolRegistry::disable`] toggle
+///   availability without unregistering.
+/// - [`ToolRegistry::set_permission`] attaches an `agent_id → allowed`
+///   predicate. [`ToolRegistry::is_allowed`] checks; [`ToolRegistry::execute_for`]
+///   enforces.
+/// - [`ToolRegistry::call_count`] returns the cumulative dispatch count
+///   for any tool (incremented on every `execute*` call).
+#[derive(Default, Clone)]
 pub struct ToolRegistry {
-    tools: HashMap<String, Arc<dyn Tool>>,
+    entries: HashMap<String, ToolEntry>,
 }
 
 impl ToolRegistry {
@@ -82,22 +116,41 @@ impl ToolRegistry {
         Self::default()
     }
 
-    /// Register a tool. Replaces any existing tool with the same name.
+    /// Register a tool. Replaces any existing tool with the same name
+    /// (preserving its enabled flag and call counter? no — replaces
+    /// wholesale; the new tool starts enabled with count = 0).
     pub fn register(&mut self, tool: Arc<dyn Tool>) {
-        self.tools.insert(tool.name().to_string(), tool);
+        let name = tool.name().to_string();
+        self.entries.insert(
+            name,
+            ToolEntry {
+                tool: Some(tool),
+                enabled: true,
+                calls: std::sync::atomic::AtomicUsize::new(0),
+                permission: None,
+            },
+        );
     }
 
     /// Register `alias` to point at the same tool as `name`. No-op when
     /// `name` is not registered.
     pub fn register_alias(&mut self, alias: impl Into<String>, name: &str) {
-        if let Some(t) = self.tools.get(name).cloned() {
-            self.tools.insert(alias.into(), t);
+        if let Some(t) = self.entries.get(name).and_then(|e| e.tool.clone()) {
+            self.entries.insert(
+                alias.into(),
+                ToolEntry {
+                    tool: Some(t),
+                    enabled: true,
+                    calls: std::sync::atomic::AtomicUsize::new(0),
+                    permission: None,
+                },
+            );
         }
     }
 
     /// Remove a tool by name. Returns `true` if it was present.
     pub fn unregister(&mut self, name: &str) -> bool {
-        self.tools.remove(name).is_some()
+        self.entries.remove(name).is_some()
     }
 
     /// Filter the registry: keep only tools whose name passes `predicate`.
@@ -107,7 +160,7 @@ impl ToolRegistry {
         F: FnMut(&str) -> bool,
     {
         let mut removed = Vec::new();
-        self.tools.retain(|k, _| {
+        self.entries.retain(|k, _| {
             let keep = predicate(k);
             if !keep {
                 removed.push(k.clone());
@@ -117,46 +170,168 @@ impl ToolRegistry {
         removed
     }
 
-    /// Get a tool by name.
+    /// Get a tool by name. Returns the inner `Arc` only if the tool is
+    /// **enabled** — disabled tools are invisible to dispatch.
     pub fn get(&self, name: &str) -> Option<&Arc<dyn Tool>> {
-        self.tools.get(name)
+        let e = self.entries.get(name)?;
+        if !e.enabled {
+            return None;
+        }
+        e.tool.as_ref()
     }
 
-    /// True if a tool with this name is registered.
+    /// True if a tool with this name is registered (regardless of enabled state).
     pub fn contains(&self, name: &str) -> bool {
-        self.tools.contains_key(name)
+        self.entries.contains_key(name)
     }
 
-    /// All registered tool names.
+    /// True if a tool with this name is registered AND enabled.
+    pub fn is_enabled(&self, name: &str) -> bool {
+        self.entries.get(name).is_some_and(|e| e.enabled)
+    }
+
+    /// Disable a tool without unregistering it. Disabled tools are
+    /// hidden from `get` / `tool_names` / `definitions` / `execute`,
+    /// but their call counters and permissions persist for when they're
+    /// re-enabled. No-op if the tool isn't registered.
+    pub fn disable(&mut self, name: &str) -> bool {
+        match self.entries.get_mut(name) {
+            Some(e) => {
+                e.enabled = false;
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Re-enable a previously-disabled tool. No-op if not registered.
+    pub fn enable(&mut self, name: &str) -> bool {
+        match self.entries.get_mut(name) {
+            Some(e) => {
+                e.enabled = true;
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Attach a permission predicate `agent_id → allowed`. Replace by
+    /// calling again. Pass [`ToolRegistry::clear_permission`] to remove.
+    pub fn set_permission<F>(&mut self, name: &str, predicate: F) -> bool
+    where
+        F: Fn(&str) -> bool + Send + Sync + 'static,
+    {
+        match self.entries.get_mut(name) {
+            Some(e) => {
+                e.permission = Some(Arc::new(predicate));
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Drop the permission predicate. The tool reverts to "any agent allowed".
+    pub fn clear_permission(&mut self, name: &str) {
+        if let Some(e) = self.entries.get_mut(name) {
+            e.permission = None;
+        }
+    }
+
+    /// True if the tool exists, is enabled, and `agent_id` passes the
+    /// permission predicate (or no predicate is set). Disabled tools
+    /// always return false.
+    pub fn is_allowed(&self, name: &str, agent_id: &str) -> bool {
+        let Some(e) = self.entries.get(name) else {
+            return false;
+        };
+        if !e.enabled {
+            return false;
+        }
+        match &e.permission {
+            Some(p) => p(agent_id),
+            None => true,
+        }
+    }
+
+    /// Number of times the tool was dispatched via `execute` /
+    /// `execute_for` (across all agents, including failed dispatches).
+    /// Returns 0 if the tool isn't registered.
+    pub fn call_count(&self, name: &str) -> usize {
+        self.entries
+            .get(name)
+            .map(|e| e.calls.load(std::sync::atomic::Ordering::Relaxed))
+            .unwrap_or(0)
+    }
+
+    /// All registered + enabled tool names.
     pub fn tool_names(&self) -> Vec<&str> {
-        self.tools.keys().map(|s| s.as_str()).collect()
+        self.entries
+            .iter()
+            .filter(|(_, e)| e.enabled)
+            .map(|(k, _)| k.as_str())
+            .collect()
     }
 
-    /// Build `ToolDefinition`s for every registered tool.
+    /// Build `ToolDefinition`s for every registered + enabled tool.
     pub fn definitions(&self) -> Vec<ToolDefinition> {
-        self.tools
+        self.entries
             .values()
+            .filter(|e| e.enabled)
+            .filter_map(|e| e.tool.as_ref())
             .map(|t| ToolDefinition::from_tool(t.as_ref()))
             .collect()
     }
 
-    /// Execute a tool by name with the given input.
+    /// Execute a tool by name with the given input. Increments the
+    /// per-tool call counter regardless of success/failure. Errors if
+    /// the tool isn't registered or is disabled.
     pub async fn execute(&self, name: &str, input: ToolInput) -> Result<ToolOutput> {
-        let t = self.get(name).ok_or_else(|| CognisError::Tool {
+        let entry = self.entries.get(name).ok_or_else(|| CognisError::Tool {
             name: name.to_string(),
             reason: "not registered".into(),
         })?;
+        if !entry.enabled {
+            return Err(CognisError::Tool {
+                name: name.to_string(),
+                reason: "disabled".into(),
+            });
+        }
+        let t = entry.tool.as_ref().ok_or_else(|| CognisError::Tool {
+            name: name.to_string(),
+            reason: "no implementation".into(),
+        })?;
+        entry
+            .calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         t._run(input).await
     }
 
-    /// Number of registered tools.
+    /// Like [`ToolRegistry::execute`] but also enforces the permission
+    /// predicate against `agent_id`. Errors with a permission error if
+    /// the predicate returns false.
+    pub async fn execute_for(
+        &self,
+        name: &str,
+        agent_id: &str,
+        input: ToolInput,
+    ) -> Result<ToolOutput> {
+        if !self.is_allowed(name, agent_id) {
+            return Err(CognisError::Tool {
+                name: name.to_string(),
+                reason: format!("not allowed for agent `{agent_id}`"),
+            });
+        }
+        self.execute(name, input).await
+    }
+
+    /// Number of registered tools (including disabled ones).
     pub fn len(&self) -> usize {
-        self.tools.len()
+        self.entries.len()
     }
 
     /// True if no tools are registered.
     pub fn is_empty(&self) -> bool {
-        self.tools.is_empty()
+        self.entries.is_empty()
     }
 }
 
@@ -215,5 +390,76 @@ mod tests {
         assert_eq!(d.name, "echo");
         assert_eq!(d.description, "echoes input");
         assert!(d.parameters.is_some());
+    }
+
+    #[tokio::test]
+    async fn disable_hides_from_dispatch_and_listing() {
+        let mut reg = ToolRegistry::new();
+        reg.register(Arc::new(Echo));
+        assert!(reg.disable("echo"));
+        assert!(reg.contains("echo"), "still registered");
+        assert!(!reg.is_enabled("echo"));
+        assert!(reg.tool_names().is_empty());
+        assert!(reg.definitions().is_empty());
+        let err = reg
+            .execute("echo", ToolInput::Text("x".into()))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("disabled"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn enable_restores() {
+        let mut reg = ToolRegistry::new();
+        reg.register(Arc::new(Echo));
+        reg.disable("echo");
+        reg.enable("echo");
+        assert!(reg.is_enabled("echo"));
+        assert!(reg
+            .execute("echo", ToolInput::Text("x".into()))
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn call_count_increments_on_execute() {
+        let mut reg = ToolRegistry::new();
+        reg.register(Arc::new(Echo));
+        assert_eq!(reg.call_count("echo"), 0);
+        for _ in 0..3 {
+            reg.execute("echo", ToolInput::Text("hi".into()))
+                .await
+                .unwrap();
+        }
+        assert_eq!(reg.call_count("echo"), 3);
+        assert_eq!(reg.call_count("missing"), 0);
+    }
+
+    #[tokio::test]
+    async fn permission_predicate_blocks_disallowed_agents() {
+        let mut reg = ToolRegistry::new();
+        reg.register(Arc::new(Echo));
+        reg.set_permission("echo", |agent_id: &str| agent_id == "writer");
+        assert!(reg.is_allowed("echo", "writer"));
+        assert!(!reg.is_allowed("echo", "intruder"));
+        let ok = reg
+            .execute_for("echo", "writer", ToolInput::Text("hi".into()))
+            .await;
+        assert!(ok.is_ok());
+        let denied = reg
+            .execute_for("echo", "intruder", ToolInput::Text("hi".into()))
+            .await
+            .unwrap_err();
+        assert!(denied.to_string().contains("not allowed"), "got: {denied}");
+    }
+
+    #[tokio::test]
+    async fn clear_permission_reopens_dispatch() {
+        let mut reg = ToolRegistry::new();
+        reg.register(Arc::new(Echo));
+        reg.set_permission("echo", |_: &str| false);
+        assert!(!reg.is_allowed("echo", "anyone"));
+        reg.clear_permission("echo");
+        assert!(reg.is_allowed("echo", "anyone"));
     }
 }

--- a/crates/cognis/src/agent_bus.rs
+++ b/crates/cognis/src/agent_bus.rs
@@ -180,6 +180,7 @@ mod tests {
             to: "broadcast".into(),
             content: Message::human(text),
             metadata: serde_json::Value::Null,
+            ..Default::default()
         }
     }
 

--- a/crates/cognis/src/agent_events.rs
+++ b/crates/cognis/src/agent_events.rs
@@ -144,6 +144,7 @@ impl AgentEventBus {
             to: self.topic.clone(),
             content: Message::system("agent-event"),
             metadata: serde_json::json!({ "event": payload }),
+            ..Default::default()
         };
         self.inner.publish(&self.topic, envelope).await
     }

--- a/crates/cognis/src/conversation.rs
+++ b/crates/cognis/src/conversation.rs
@@ -1,0 +1,262 @@
+//! Typed value types over `Vec<Message>` history.
+//!
+//! V2 stores conversations as flat `Vec<Message>` — that's the canonical
+//! shape for LLM APIs. This module gives ergonomic typed views:
+//!
+//! - [`ConversationTurn`] — one user input + the assistant's reply +
+//!   any tool messages that happened in between.
+//! - [`ConversationSummary`] — aggregate counts and quick previews
+//!   (first user input, last AI output, total characters).
+//! - [`turns_from_messages`] / [`summarize`] convert flat history into
+//!   either view.
+//!
+//! These are *views*, not new storage — `cognis::history` /
+//! `cognis::session` still own the message list. Reach for these when
+//! you want to render a transcript, generate a conversation summary, or
+//! emit metrics per turn.
+//!
+//! ```
+//! use cognis::conversation::{summarize, turns_from_messages};
+//! use cognis_core::Message;
+//!
+//! let history = vec![
+//!     Message::system("be brief"),
+//!     Message::human("hello"),
+//!     Message::ai("hi"),
+//!     Message::human("how are you?"),
+//!     Message::ai("good"),
+//! ];
+//! let turns = turns_from_messages(&history);
+//! assert_eq!(turns.len(), 2);
+//!
+//! let s = summarize(&history);
+//! assert_eq!(s.turn_count, 2);
+//! ```
+
+use cognis_core::Message;
+
+/// One user-input → assistant-reply turn. Tool calls and tool result
+/// messages that landed between the user and assistant entries are
+/// captured in `tool_messages`. System messages are not part of any
+/// turn (they're conversation-wide context).
+#[derive(Debug, Clone)]
+pub struct ConversationTurn {
+    /// The user's input. `None` for an "AI-initiated" first turn (rare —
+    /// happens when an agent runs with seed context but no user prompt).
+    pub user: Option<Message>,
+    /// The assistant's reply. `None` for an "incomplete" trailing turn
+    /// — i.e. the user has spoken but the agent hasn't responded yet.
+    pub assistant: Option<Message>,
+    /// Tool messages (calls + results) that occurred in this turn.
+    pub tool_messages: Vec<Message>,
+}
+
+impl ConversationTurn {
+    /// `true` if the turn has both a user input and an assistant reply.
+    pub fn is_complete(&self) -> bool {
+        self.user.is_some() && self.assistant.is_some()
+    }
+
+    /// Total messages in this turn (user + assistant + tools).
+    pub fn message_count(&self) -> usize {
+        self.user.as_ref().map_or(0, |_| 1)
+            + self.assistant.as_ref().map_or(0, |_| 1)
+            + self.tool_messages.len()
+    }
+}
+
+/// Aggregate stats over a conversation's message list.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ConversationSummary {
+    /// Total turns (complete + incomplete).
+    pub turn_count: usize,
+    /// Number of complete turns (user + assistant pair present).
+    pub complete_turn_count: usize,
+    /// Total messages across the whole history.
+    pub message_count: usize,
+    /// Per-role breakdowns.
+    pub user_message_count: usize,
+    /// Per-role breakdowns.
+    pub ai_message_count: usize,
+    /// Per-role breakdowns.
+    pub tool_message_count: usize,
+    /// Per-role breakdowns.
+    pub system_message_count: usize,
+    /// First user input as plain text (truncated at 200 chars).
+    pub first_user_input: Option<String>,
+    /// Last AI output as plain text (truncated at 200 chars).
+    pub last_ai_output: Option<String>,
+    /// Sum of `Message::content().len()` across every message.
+    pub total_chars: usize,
+}
+
+/// Group flat messages into [`ConversationTurn`]s.
+///
+/// Algorithm: walk the history left-to-right; on each `Human` message,
+/// open a new turn; collect subsequent tool messages onto its
+/// `tool_messages`; close the turn at the next `Ai`. System messages
+/// are ignored (they're not part of any turn). A trailing user message
+/// with no AI reply yet is emitted as an incomplete turn.
+pub fn turns_from_messages(messages: &[Message]) -> Vec<ConversationTurn> {
+    let mut out: Vec<ConversationTurn> = Vec::new();
+    let mut current: Option<ConversationTurn> = None;
+    for m in messages {
+        match m {
+            Message::System(_) => continue,
+            Message::Human(_) => {
+                // Close the prior turn, if any (it had no AI reply).
+                if let Some(t) = current.take() {
+                    out.push(t);
+                }
+                current = Some(ConversationTurn {
+                    user: Some(m.clone()),
+                    assistant: None,
+                    tool_messages: Vec::new(),
+                });
+            }
+            Message::Ai(_) => {
+                let mut t = current.take().unwrap_or(ConversationTurn {
+                    user: None,
+                    assistant: None,
+                    tool_messages: Vec::new(),
+                });
+                t.assistant = Some(m.clone());
+                out.push(t);
+            }
+            Message::Tool(_) => match current.as_mut() {
+                Some(t) => t.tool_messages.push(m.clone()),
+                None => {
+                    // Tool message with no open turn — start one.
+                    current = Some(ConversationTurn {
+                        user: None,
+                        assistant: None,
+                        tool_messages: vec![m.clone()],
+                    });
+                }
+            },
+        }
+    }
+    if let Some(t) = current.take() {
+        out.push(t);
+    }
+    out
+}
+
+/// Compute a [`ConversationSummary`] from flat messages.
+pub fn summarize(messages: &[Message]) -> ConversationSummary {
+    let mut s = ConversationSummary {
+        message_count: messages.len(),
+        ..Default::default()
+    };
+    for m in messages {
+        s.total_chars += m.content().len();
+        match m {
+            Message::System(_) => s.system_message_count += 1,
+            Message::Human(_) => {
+                s.user_message_count += 1;
+                if s.first_user_input.is_none() {
+                    s.first_user_input = Some(truncate(m.content(), 200));
+                }
+            }
+            Message::Ai(_) => {
+                s.ai_message_count += 1;
+                s.last_ai_output = Some(truncate(m.content(), 200));
+            }
+            Message::Tool(_) => s.tool_message_count += 1,
+        }
+    }
+    let turns = turns_from_messages(messages);
+    s.turn_count = turns.len();
+    s.complete_turn_count = turns.iter().filter(|t| t.is_complete()).count();
+    s
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn h(s: &str) -> Message {
+        Message::human(s)
+    }
+    fn a(s: &str) -> Message {
+        Message::ai(s)
+    }
+    fn sys(s: &str) -> Message {
+        Message::system(s)
+    }
+
+    #[test]
+    fn empty_messages_produce_empty_summary() {
+        let s = summarize(&[]);
+        assert_eq!(s, ConversationSummary::default());
+        assert!(turns_from_messages(&[]).is_empty());
+    }
+
+    #[test]
+    fn pairs_user_with_next_ai() {
+        let msgs = vec![h("hi"), a("hello"), h("how"), a("good")];
+        let turns = turns_from_messages(&msgs);
+        assert_eq!(turns.len(), 2);
+        assert!(turns.iter().all(|t| t.is_complete()));
+    }
+
+    #[test]
+    fn trailing_user_is_incomplete_turn() {
+        let msgs = vec![h("hi"), a("hello"), h("waiting")];
+        let turns = turns_from_messages(&msgs);
+        assert_eq!(turns.len(), 2);
+        assert!(turns[0].is_complete());
+        assert!(!turns[1].is_complete());
+        assert_eq!(turns[1].user.as_ref().unwrap().content(), "waiting");
+        assert!(turns[1].assistant.is_none());
+    }
+
+    #[test]
+    fn system_messages_dont_count_as_turns() {
+        let msgs = vec![sys("preamble"), h("hi"), a("hello")];
+        let turns = turns_from_messages(&msgs);
+        assert_eq!(turns.len(), 1);
+        let s = summarize(&msgs);
+        assert_eq!(s.system_message_count, 1);
+        assert_eq!(s.turn_count, 1);
+    }
+
+    #[test]
+    fn summary_aggregates_counts_and_previews() {
+        let msgs = vec![
+            sys("be brief"),
+            h("first question"),
+            a("first reply"),
+            h("second question"),
+            a("second reply"),
+        ];
+        let s = summarize(&msgs);
+        assert_eq!(s.message_count, 5);
+        assert_eq!(s.user_message_count, 2);
+        assert_eq!(s.ai_message_count, 2);
+        assert_eq!(s.system_message_count, 1);
+        assert_eq!(s.turn_count, 2);
+        assert_eq!(s.complete_turn_count, 2);
+        assert_eq!(s.first_user_input.as_deref(), Some("first question"));
+        assert_eq!(s.last_ai_output.as_deref(), Some("second reply"));
+    }
+
+    #[test]
+    fn truncates_long_previews() {
+        let long = "a".repeat(500);
+        let msgs = vec![h(&long), a(&long)];
+        let s = summarize(&msgs);
+        let preview = s.first_user_input.unwrap();
+        assert!(preview.chars().count() <= 200);
+        assert!(preview.ends_with('…'));
+    }
+}

--- a/crates/cognis/src/eval/mod.rs
+++ b/crates/cognis/src/eval/mod.rs
@@ -91,9 +91,123 @@ impl<O> EvalReport<O> {
         self.rows.iter().filter(|r| r.score >= threshold).count()
     }
 
+    /// Pass rate at `threshold` in `[0.0, 1.0]`. `0.0` for empty.
+    pub fn pass_rate(&self, threshold: f32) -> f32 {
+        if self.rows.is_empty() {
+            return 0.0;
+        }
+        self.passing(threshold) as f32 / self.rows.len() as f32
+    }
+
+    /// Lowest scoring case (or `None` for empty).
+    pub fn worst(&self) -> Option<&EvalRow<O>> {
+        self.rows.iter().min_by(|a, b| {
+            a.score
+                .partial_cmp(&b.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+    }
+
+    /// Highest scoring case (or `None` for empty).
+    pub fn best(&self) -> Option<&EvalRow<O>> {
+        self.rows.iter().max_by(|a, b| {
+            a.score
+                .partial_cmp(&b.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+    }
+
     /// Total case count.
     pub fn total(&self) -> usize {
         self.rows.len()
+    }
+
+    /// Render a plain-text summary suitable for stdout / logs:
+    ///
+    /// ```text
+    /// case        score   status
+    /// hello       1.00    PASS
+    /// world       0.50    FAIL
+    /// (unnamed)   1.00    PASS
+    /// ───
+    /// total: 3   pass: 2 (66.7%)   mean: 0.83
+    /// ```
+    ///
+    /// `pass_threshold` is the floor for the PASS / FAIL column. Pass
+    /// `0.5` for binary 0/1 evaluators, `0.8` for tighter cutoffs, etc.
+    pub fn summary(&self, pass_threshold: f32) -> String {
+        let mut out = String::new();
+        if self.rows.is_empty() {
+            out.push_str("(empty report)\n");
+            return out;
+        }
+        let name_width = self
+            .rows
+            .iter()
+            .map(|r| r.name.as_deref().unwrap_or("(unnamed)").len())
+            .max()
+            .unwrap_or(8)
+            .max(4);
+        out.push_str(&format!(
+            "{:<width$}  {:>6}  {}\n",
+            "case",
+            "score",
+            "status",
+            width = name_width
+        ));
+        for r in &self.rows {
+            let status = if r.score >= pass_threshold {
+                "PASS"
+            } else {
+                "FAIL"
+            };
+            let name = r.name.as_deref().unwrap_or("(unnamed)");
+            out.push_str(&format!(
+                "{:<width$}  {:>6.2}  {}\n",
+                name,
+                r.score,
+                status,
+                width = name_width
+            ));
+        }
+        let pass = self.passing(pass_threshold);
+        let total = self.total();
+        let pass_pct = self.pass_rate(pass_threshold) * 100.0;
+        out.push_str("───\n");
+        out.push_str(&format!(
+            "total: {total}   pass: {pass} ({pass_pct:.1}%)   mean: {:.2}\n",
+            self.mean()
+        ));
+        out
+    }
+
+    /// Markdown table summary. Same data as [`EvalReport::summary`] but
+    /// renders as a GitHub-flavored markdown table for PR comments / docs.
+    pub fn markdown(&self, pass_threshold: f32) -> String {
+        let mut out = String::new();
+        if self.rows.is_empty() {
+            out.push_str("_(empty report)_\n");
+            return out;
+        }
+        out.push_str("| case | score | status |\n");
+        out.push_str("|------|------:|--------|\n");
+        for r in &self.rows {
+            let status = if r.score >= pass_threshold {
+                "PASS"
+            } else {
+                "FAIL"
+            };
+            let name = r.name.as_deref().unwrap_or("(unnamed)");
+            out.push_str(&format!("| {name} | {:.2} | {status} |\n", r.score));
+        }
+        out.push_str(&format!(
+            "\n**total**: {} · **pass**: {} ({:.1}%) · **mean**: {:.2}\n",
+            self.total(),
+            self.passing(pass_threshold),
+            self.pass_rate(pass_threshold) * 100.0,
+            self.mean()
+        ));
+        out
     }
 }
 
@@ -166,5 +280,66 @@ where
             });
         }
         Ok(EvalReport { rows })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report_with(rows: Vec<(Option<&str>, f32)>) -> EvalReport<String> {
+        EvalReport {
+            rows: rows
+                .into_iter()
+                .map(|(n, s)| EvalRow {
+                    name: n.map(str::to_string),
+                    score: s,
+                    actual: String::new(),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn pass_rate_and_passing() {
+        let r = report_with(vec![(Some("a"), 1.0), (Some("b"), 0.4), (Some("c"), 0.9)]);
+        assert_eq!(r.passing(0.5), 2);
+        assert!((r.pass_rate(0.5) - 0.6666).abs() < 0.01);
+    }
+
+    #[test]
+    fn best_and_worst() {
+        let r = report_with(vec![(Some("a"), 0.3), (Some("b"), 0.9), (Some("c"), 0.5)]);
+        assert_eq!(r.best().unwrap().name.as_deref(), Some("b"));
+        assert_eq!(r.worst().unwrap().name.as_deref(), Some("a"));
+    }
+
+    #[test]
+    fn empty_report_extremes() {
+        let r: EvalReport<String> = EvalReport { rows: vec![] };
+        assert!(r.best().is_none());
+        assert!(r.worst().is_none());
+        assert_eq!(r.pass_rate(0.5), 0.0);
+        assert!(r.summary(0.5).contains("empty"));
+    }
+
+    #[test]
+    fn summary_renders_pass_fail_and_aggregates() {
+        let r = report_with(vec![(Some("hello"), 1.0), (Some("world"), 0.4)]);
+        let s = r.summary(0.5);
+        assert!(s.contains("hello"));
+        assert!(s.contains("PASS"));
+        assert!(s.contains("FAIL"));
+        assert!(s.contains("total: 2"));
+        assert!(s.contains("pass: 1"));
+    }
+
+    #[test]
+    fn markdown_renders_table() {
+        let r = report_with(vec![(Some("hello"), 1.0)]);
+        let md = r.markdown(0.5);
+        assert!(md.contains("| case |"));
+        assert!(md.contains("| hello | 1.00 | PASS |"));
+        assert!(md.contains("**mean**"));
     }
 }

--- a/crates/cognis/src/lib.rs
+++ b/crates/cognis/src/lib.rs
@@ -99,8 +99,8 @@ pub use middleware::{
     WorkspaceLister,
 };
 pub use multi_agent::{
-    AgentMessage, Consensus, HandoffStrategy, Hierarchical, InMemoryMessageBus, MessageBus,
-    MultiAgentOrchestrator, ParallelVote, RoundRobin, Sequential, Supervisor,
+    sort_by_priority, AgentMessage, Consensus, HandoffStrategy, Hierarchical, InMemoryMessageBus,
+    MessageBus, MultiAgentOrchestrator, ParallelVote, Priority, RoundRobin, Sequential, Supervisor,
 };
 pub use observers::TracingObserver;
 pub use retrievers::{

--- a/crates/cognis/src/lib.rs
+++ b/crates/cognis/src/lib.rs
@@ -53,6 +53,7 @@ pub mod agent_events;
 pub mod backend;
 #[cfg(feature = "cache-sqlite")]
 pub mod cache_sqlite;
+pub mod conversation;
 pub mod eval;
 pub mod history;
 pub mod middleware;
@@ -79,6 +80,7 @@ pub use backend::{
     Backend, Blob, GrepHit, InMemoryStateBackend, InMemoryStorageBackend, LocalFsStorageBackend,
     MemoryBackend, SandboxedFsBackend, StateBackend, StorageBackend,
 };
+pub use conversation::{summarize, turns_from_messages, ConversationSummary, ConversationTurn};
 pub use eval::{
     Contains, EvalCase, EvalReport, EvalRow, EvalRunner, Evaluator, ExactMatch, LlmJudge,
 };

--- a/crates/cognis/src/multi_agent.rs
+++ b/crates/cognis/src/multi_agent.rs
@@ -29,9 +29,27 @@ use cognis_core::{CognisError, Message, Result};
 
 use crate::agent::{Agent, AgentResponse};
 
+/// Per-message priority. Higher priorities sort first when an inbox is
+/// drained or a subscriber processes a backlog. The default is `Normal`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum Priority {
+    /// Background work; processed last.
+    Low,
+    /// Standard priority. Default.
+    #[default]
+    Normal,
+    /// Time-sensitive but not critical.
+    High,
+    /// Drop everything else and handle this first.
+    Critical,
+}
+
 /// Envelope for inter-agent messages.
 #[derive(Debug, Clone)]
 pub struct AgentMessage {
+    /// Stable id assigned at construction. Used by `reply_to` to
+    /// correlate request/reply pairs.
+    pub id: uuid::Uuid,
     /// Source agent id (or `"user"` / `"system"` for non-agent senders).
     pub from: String,
     /// Destination agent id.
@@ -40,6 +58,77 @@ pub struct AgentMessage {
     pub content: Message,
     /// Free-form metadata bag for custom routing decisions.
     pub metadata: serde_json::Value,
+    /// If this message replies to a prior one, the prior message's `id`.
+    /// Lets receivers correlate request/reply over a broadcast bus.
+    pub reply_to: Option<uuid::Uuid>,
+    /// Priority — used by ordering helpers. Default `Normal`.
+    pub priority: Priority,
+}
+
+impl Default for AgentMessage {
+    fn default() -> Self {
+        Self {
+            id: uuid::Uuid::new_v4(),
+            from: String::new(),
+            to: String::new(),
+            content: Message::system(""),
+            metadata: serde_json::Value::Null,
+            reply_to: None,
+            priority: Priority::Normal,
+        }
+    }
+}
+
+impl AgentMessage {
+    /// Build a fresh message with a new `id`, `Normal` priority, and no
+    /// reply correlation. Mutate the builder fields directly to set
+    /// `reply_to` / `priority` / `metadata`.
+    pub fn new(from: impl Into<String>, to: impl Into<String>, content: Message) -> Self {
+        Self {
+            id: uuid::Uuid::new_v4(),
+            from: from.into(),
+            to: to.into(),
+            content,
+            metadata: serde_json::Value::Null,
+            reply_to: None,
+            priority: Priority::Normal,
+        }
+    }
+
+    /// Construct a reply to `request`: copies the request's id into
+    /// `reply_to`, swaps from/to, and inherits priority. Caller still
+    /// supplies the new content.
+    pub fn reply(request: &AgentMessage, from: impl Into<String>, content: Message) -> Self {
+        Self {
+            id: uuid::Uuid::new_v4(),
+            from: from.into(),
+            to: request.from.clone(),
+            content,
+            metadata: serde_json::Value::Null,
+            reply_to: Some(request.id),
+            priority: request.priority,
+        }
+    }
+
+    /// Builder: set the priority.
+    pub fn with_priority(mut self, p: Priority) -> Self {
+        self.priority = p;
+        self
+    }
+
+    /// Builder: attach metadata.
+    pub fn with_metadata(mut self, m: serde_json::Value) -> Self {
+        self.metadata = m;
+        self
+    }
+}
+
+/// Sort a slice of messages so higher-priority entries come first; ties
+/// preserve insertion order. Useful when draining a backlog where a
+/// `Critical` reply should jump ahead of any older `Normal` traffic.
+pub fn sort_by_priority(msgs: &mut [AgentMessage]) {
+    // Negate the key (Reverse) so Critical (highest variant) sorts first.
+    msgs.sort_by_key(|m| std::cmp::Reverse(m.priority));
 }
 
 /// Pluggable inter-agent transport. Stock impl: [`InMemoryMessageBus`].
@@ -136,6 +225,7 @@ impl HandoffStrategy for Sequential {
                 to: id.clone(),
                 content: current_input.clone(),
                 metadata: serde_json::Value::Null,
+                ..Default::default()
             })
             .await?;
             current_input = Message::human(resp.content.clone());
@@ -222,6 +312,7 @@ impl HandoffStrategy for Supervisor {
             to: supervisor_id.clone(),
             content: input,
             metadata: serde_json::Value::Null,
+            ..Default::default()
         })
         .await?;
 
@@ -243,6 +334,7 @@ impl HandoffStrategy for Supervisor {
             to: target_id.clone(),
             content: Message::human(instruction.clone()),
             metadata: serde_json::Value::Null,
+            ..Default::default()
         })
         .await?;
 
@@ -360,6 +452,7 @@ impl HandoffStrategy for RoundRobin {
             to: id.clone(),
             content: input.clone(),
             metadata: serde_json::json!({"strategy": "round_robin", "index": idx}),
+            ..Default::default()
         })
         .await?;
         let mut a = agent.lock().await;
@@ -447,6 +540,7 @@ impl HandoffStrategy for Hierarchical {
                 to: current_id.clone(),
                 content: current_input.clone(),
                 metadata: serde_json::json!({"strategy": "hierarchical", "hop": hop}),
+                ..Default::default()
             })
             .await?;
             let response = {
@@ -789,6 +883,7 @@ mod tests {
             to: "alice".into(),
             content: Message::human("hi"),
             metadata: serde_json::Value::Null,
+            ..Default::default()
         })
         .await
         .unwrap();
@@ -797,6 +892,7 @@ mod tests {
             to: "bob".into(),
             content: Message::human("hi"),
             metadata: serde_json::Value::Null,
+            ..Default::default()
         })
         .await
         .unwrap();
@@ -870,5 +966,41 @@ mod tests {
             .add("c", agent_with_response("Y"));
         let resp = orch.run("q").await.unwrap();
         assert_eq!(resp.content, "X");
+    }
+
+    #[test]
+    fn agent_message_new_assigns_unique_ids() {
+        let a = AgentMessage::new("u", "t", Message::human("a"));
+        let b = AgentMessage::new("u", "t", Message::human("a"));
+        assert_ne!(a.id, b.id);
+        assert_eq!(a.priority, Priority::Normal);
+        assert!(a.reply_to.is_none());
+    }
+
+    #[test]
+    fn agent_message_reply_correlates() {
+        let req =
+            AgentMessage::new("user", "writer", Message::human("hi")).with_priority(Priority::High);
+        let resp = AgentMessage::reply(&req, "writer", Message::ai("hello"));
+        assert_eq!(resp.from, "writer");
+        assert_eq!(resp.to, "user");
+        assert_eq!(resp.reply_to, Some(req.id));
+        assert_eq!(resp.priority, Priority::High, "priority inherited");
+    }
+
+    #[test]
+    fn priority_sort_critical_first() {
+        let mut msgs = vec![
+            AgentMessage::new("u", "t", Message::human("low")).with_priority(Priority::Low),
+            AgentMessage::new("u", "t", Message::human("crit")).with_priority(Priority::Critical),
+            AgentMessage::new("u", "t", Message::human("normal")),
+            AgentMessage::new("u", "t", Message::human("high")).with_priority(Priority::High),
+        ];
+        sort_by_priority(&mut msgs);
+        let order: Vec<_> = msgs
+            .iter()
+            .map(|m| m.content.content().to_string())
+            .collect();
+        assert_eq!(order, vec!["crit", "high", "normal", "low"]);
     }
 }

--- a/crates/cognisgraph/src/builder.rs
+++ b/crates/cognisgraph/src/builder.rs
@@ -17,6 +17,9 @@ pub struct Graph<S: GraphState> {
     pub(crate) start: Option<String>,
     /// Optional version tag, stamped on snapshots and checkpoints.
     pub(crate) version: Option<String>,
+    /// Per-node free-form annotations: `node_name → (key → value)`.
+    /// Surface in viz / analysis output for diagnostics or doc gen.
+    pub(crate) annotations: HashMap<String, HashMap<String, serde_json::Value>>,
 }
 
 impl<S: GraphState> Default for Graph<S> {
@@ -33,7 +36,32 @@ impl<S: GraphState> Graph<S> {
             edges: HashMap::new(),
             start: None,
             version: None,
+            annotations: HashMap::new(),
         }
+    }
+
+    /// Attach a key/value annotation to `node_name`. Annotations are
+    /// arbitrary metadata for diagnostics, doc generation, or external
+    /// tooling — they don't affect execution. Multiple annotations per
+    /// node are supported; the same key replaces.
+    ///
+    /// No-op (silently) if `node_name` isn't registered yet — call
+    /// `.node(...)` before `.annotate(...)` to keep things tidy.
+    pub fn annotate(
+        mut self,
+        node_name: impl Into<String>,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        let node = node_name.into();
+        if !self.nodes.contains_key(&node) {
+            return self;
+        }
+        self.annotations
+            .entry(node)
+            .or_default()
+            .insert(key.into(), value.into());
+        self
     }
 
     /// Stamp a version tag. Echoed in snapshots and (when `version_check`

--- a/crates/cognisgraph/src/compiled.rs
+++ b/crates/cognisgraph/src/compiled.rs
@@ -70,6 +70,33 @@ impl<S: GraphState> CompiledGraph<S> {
     pub fn node_names(&self) -> Vec<&str> {
         self.graph.nodes.keys().map(|s| s.as_str()).collect()
     }
+
+    /// Optional graph version tag (set via [`crate::builder::Graph::with_version`]).
+    pub fn version(&self) -> Option<&str> {
+        self.graph.version.as_deref()
+    }
+
+    /// All annotations attached to `node_name`, or an empty map if the
+    /// node has no annotations / isn't registered.
+    pub fn annotations(
+        &self,
+        node_name: &str,
+    ) -> &std::collections::HashMap<String, serde_json::Value> {
+        static EMPTY: std::sync::OnceLock<std::collections::HashMap<String, serde_json::Value>> =
+            std::sync::OnceLock::new();
+        self.graph
+            .annotations
+            .get(node_name)
+            .unwrap_or_else(|| EMPTY.get_or_init(std::collections::HashMap::new))
+    }
+
+    /// Look up a single annotation value by `(node_name, key)`.
+    pub fn annotation(&self, node_name: &str, key: &str) -> Option<&serde_json::Value> {
+        self.graph
+            .annotations
+            .get(node_name)
+            .and_then(|m| m.get(key))
+    }
 }
 
 impl<S: GraphState + Clone + Send + 'static> CompiledGraph<S> {

--- a/crates/cognisgraph/src/lib.rs
+++ b/crates/cognisgraph/src/lib.rs
@@ -43,7 +43,10 @@ pub use command::Command;
 pub use compiled::CompiledGraph;
 pub use durability::{Durability, DurabilityDecision, DurabilityHook};
 pub use goto::Goto;
-pub use metrics::{GraphMetrics, MetricsObserver, NodeTiming, ProfilingObserver};
+pub use metrics::{
+    GraphMetrics, MetricsObserver, NodeTiming, ProfilingObserver, ThresholdCallback,
+    ThresholdProfiler,
+};
 pub use node::{node_fn, Node, NodeCtx, NodeFn, NodeOut, NodeRetryPolicy};
 pub use reducer::{Add, Append, Custom, LastValue, Merge, Reducer};
 pub use snapshot::GraphSnapshot;

--- a/crates/cognisgraph/src/metrics.rs
+++ b/crates/cognisgraph/src/metrics.rs
@@ -207,3 +207,214 @@ mod tests {
         assert!(t.total_ns > 0);
     }
 }
+
+// ────────────────────────────────────────────────────────────────────────
+// ThresholdProfiler — same timing logic as ProfilingObserver, plus
+// per-node duration thresholds that trigger a callback when breached.
+// Use to wire SLO-style alerts ("if any 'embed' invocation runs longer
+// than 5s, log/page/notify").
+// ────────────────────────────────────────────────────────────────────────
+
+/// Callback fired when a node's invocation exceeds its configured
+/// threshold. Receives the node name and the actual elapsed nanoseconds.
+pub type ThresholdCallback = std::sync::Arc<dyn Fn(&str, u128) + Send + Sync>;
+
+/// ProfilingObserver variant that also fires alerts on per-node duration
+/// thresholds. Same timing snapshot via `snapshot()`; thresholds are
+/// configured per node via `with_threshold(node, max_ns)`. On an
+/// `OnNodeEnd` whose elapsed > the configured cap, every registered
+/// callback runs (synchronously, on the observer's thread).
+///
+/// Callbacks should be cheap and non-blocking — they run inline on the
+/// graph engine's thread.
+pub struct ThresholdProfiler {
+    pending: Mutex<HashMap<(Uuid, u64, String), Instant>>,
+    totals: Mutex<HashMap<String, NodeTiming>>,
+    thresholds: Mutex<HashMap<String, u128>>,
+    callbacks: Mutex<Vec<ThresholdCallback>>,
+}
+
+impl Default for ThresholdProfiler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ThresholdProfiler {
+    /// Empty profiler with no thresholds and no callbacks.
+    pub fn new() -> Self {
+        Self {
+            pending: Mutex::new(HashMap::new()),
+            totals: Mutex::new(HashMap::new()),
+            thresholds: Mutex::new(HashMap::new()),
+            callbacks: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Snapshot of per-node timings (same shape as `ProfilingObserver`).
+    pub fn snapshot(&self) -> HashMap<String, NodeTiming> {
+        self.totals.lock().map(|m| m.clone()).unwrap_or_default()
+    }
+
+    /// Register a duration cap (in nanoseconds) for `node`. Subsequent
+    /// invocations that exceed `max_ns` will fire every registered
+    /// callback. Replaces any prior threshold for the node.
+    pub fn with_threshold(self, node: impl Into<String>, max_ns: u128) -> Self {
+        if let Ok(mut t) = self.thresholds.lock() {
+            t.insert(node.into(), max_ns);
+        }
+        self
+    }
+
+    /// Add an alert callback. Multiple callbacks are supported and all
+    /// fire (in registration order) on each breach. Builder-style.
+    pub fn on_threshold_breached<F>(self, cb: F) -> Self
+    where
+        F: Fn(&str, u128) + Send + Sync + 'static,
+    {
+        if let Ok(mut c) = self.callbacks.lock() {
+            c.push(std::sync::Arc::new(cb));
+        }
+        self
+    }
+}
+
+impl Observer for ThresholdProfiler {
+    fn on_event(&self, event: &Event) {
+        match event {
+            Event::OnNodeStart { node, step, run_id } => {
+                if let Ok(mut p) = self.pending.lock() {
+                    p.insert((*run_id, *step, node.clone()), Instant::now());
+                }
+            }
+            Event::OnNodeEnd {
+                node, step, run_id, ..
+            } => {
+                let mut p = match self.pending.lock() {
+                    Ok(p) => p,
+                    Err(_) => return,
+                };
+                let key = (*run_id, *step, node.clone());
+                let started = match p.remove(&key) {
+                    Some(t) => t,
+                    None => return,
+                };
+                let elapsed_ns = started.elapsed().as_nanos();
+                drop(p);
+                if let Ok(mut t) = self.totals.lock() {
+                    let e = t.entry(node.clone()).or_insert_with(|| NodeTiming {
+                        min_ns: u128::MAX,
+                        ..Default::default()
+                    });
+                    e.count += 1;
+                    e.total_ns += elapsed_ns;
+                    e.max_ns = e.max_ns.max(elapsed_ns);
+                    e.min_ns = e.min_ns.min(elapsed_ns);
+                }
+                let breached = self
+                    .thresholds
+                    .lock()
+                    .ok()
+                    .and_then(|m| m.get(node).copied())
+                    .map(|cap| elapsed_ns > cap)
+                    .unwrap_or(false);
+                if breached {
+                    if let Ok(cbs) = self.callbacks.lock() {
+                        for cb in cbs.iter() {
+                            cb(node, elapsed_ns);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod threshold_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    fn end(node: &str, run: Uuid) -> Event {
+        Event::OnNodeEnd {
+            node: node.into(),
+            step: 0,
+            run_id: run,
+            output: serde_json::Value::Null,
+        }
+    }
+    fn start(node: &str, run: Uuid) -> Event {
+        Event::OnNodeStart {
+            node: node.into(),
+            step: 0,
+            run_id: run,
+        }
+    }
+
+    #[test]
+    fn fires_callback_on_breach() {
+        let breaches = Arc::new(AtomicUsize::new(0));
+        let b2 = breaches.clone();
+        // 1ns threshold so any real elapsed time breaches.
+        let p = ThresholdProfiler::new()
+            .with_threshold("slow", 1)
+            .on_threshold_breached(move |_node, _elapsed| {
+                b2.fetch_add(1, Ordering::Relaxed);
+            });
+        let run = Uuid::nil();
+        p.on_event(&start("slow", run));
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        p.on_event(&end("slow", run));
+        assert_eq!(breaches.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn does_not_fire_below_threshold() {
+        let breaches = Arc::new(AtomicUsize::new(0));
+        let b2 = breaches.clone();
+        // Huge threshold — no real invocation will breach.
+        let p = ThresholdProfiler::new()
+            .with_threshold("fast", u128::MAX)
+            .on_threshold_breached(move |_, _| {
+                b2.fetch_add(1, Ordering::Relaxed);
+            });
+        let run = Uuid::nil();
+        p.on_event(&start("fast", run));
+        p.on_event(&end("fast", run));
+        assert_eq!(breaches.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn snapshot_shape_matches_profiling_observer() {
+        let p = ThresholdProfiler::new();
+        let run = Uuid::nil();
+        p.on_event(&start("n", run));
+        p.on_event(&end("n", run));
+        let snap = p.snapshot();
+        let t = snap.get("n").unwrap();
+        assert_eq!(t.count, 1);
+    }
+
+    #[test]
+    fn multiple_callbacks_all_fire() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let c1 = count.clone();
+        let c2 = count.clone();
+        let p = ThresholdProfiler::new()
+            .with_threshold("n", 1)
+            .on_threshold_breached(move |_, _| {
+                c1.fetch_add(1, Ordering::Relaxed);
+            })
+            .on_threshold_breached(move |_, _| {
+                c2.fetch_add(10, Ordering::Relaxed);
+            });
+        let run = Uuid::nil();
+        p.on_event(&start("n", run));
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        p.on_event(&end("n", run));
+        assert_eq!(count.load(Ordering::Relaxed), 11);
+    }
+}

--- a/crates/cognisgraph/src/viz/ascii.rs
+++ b/crates/cognisgraph/src/viz/ascii.rs
@@ -21,9 +21,11 @@ impl<S: GraphState> CompiledGraph<S> {
     /// ```
     pub fn to_ascii(&self) -> String {
         let mut out = String::new();
-        match &self.graph.start {
-            Some(s) => out.push_str(&format!("Graph (start: {s})\n")),
-            None => out.push_str("Graph (start: <unset>)\n"),
+        match (&self.graph.start, self.version()) {
+            (Some(s), Some(v)) => out.push_str(&format!("Graph (start: {s}, version: {v})\n")),
+            (Some(s), None) => out.push_str(&format!("Graph (start: {s})\n")),
+            (None, Some(v)) => out.push_str(&format!("Graph (start: <unset>, version: {v})\n")),
+            (None, None) => out.push_str("Graph (start: <unset>)\n"),
         }
 
         let mut names: Vec<&String> = self.graph.nodes.keys().collect();

--- a/crates/cognisgraph/src/viz/dot.rs
+++ b/crates/cognisgraph/src/viz/dot.rs
@@ -21,21 +21,30 @@ impl<S: GraphState> CompiledGraph<S> {
     /// node) is **not** captured — only what the builder declared statically.
     pub fn to_dot(&self) -> String {
         let mut out = String::from("digraph G {\n");
+        if let Some(v) = self.version() {
+            out.push_str(&format!("    label=\"version: {}\";\n", escape(v)));
+            out.push_str("    labelloc=t;\n");
+        }
         out.push_str("    rankdir=TB;\n");
         out.push_str("    node [shape=box, style=rounded];\n");
 
         let mut names: Vec<&String> = self.graph.nodes.keys().collect();
         names.sort();
 
-        // Node declarations.
+        // Node declarations. Annotations surface as a `tooltip` attribute,
+        // which dot-rendered SVG shows on hover.
         for name in &names {
             let id = node_id(name);
             let label = escape(name);
+            let tooltip = render_annotations(self.annotations(name));
+            let mut attrs = format!("label=\"{label}\"");
             if Some(*name) == self.graph.start.as_ref() {
-                out.push_str(&format!("    {id} [label=\"{label}\", penwidth=2.0];\n"));
-            } else {
-                out.push_str(&format!("    {id} [label=\"{label}\"];\n"));
+                attrs.push_str(", penwidth=2.0");
             }
+            if !tooltip.is_empty() {
+                attrs.push_str(&format!(", tooltip=\"{}\"", escape(&tooltip)));
+            }
+            out.push_str(&format!("    {id} [{attrs}];\n"));
         }
         out.push_str(
             "    __END__ [label=\"END\", shape=oval, style=filled, fillcolor=\"#eeeeee\"];\n",
@@ -53,6 +62,18 @@ impl<S: GraphState> CompiledGraph<S> {
         out.push_str("}\n");
         out
     }
+}
+
+fn render_annotations(map: &std::collections::HashMap<String, serde_json::Value>) -> String {
+    if map.is_empty() {
+        return String::new();
+    }
+    let mut keys: Vec<&String> = map.keys().collect();
+    keys.sort();
+    keys.into_iter()
+        .map(|k| format!("{k}: {}", map[k]))
+        .collect::<Vec<_>>()
+        .join(" | ")
 }
 
 fn node_id(name: &str) -> String {
@@ -149,5 +170,71 @@ mod tests {
         let d = g.to_dot();
         // ID is sanitized, label is preserved.
         assert!(d.contains("node_with_hyphen [label=\"node-with-hyphen\""));
+    }
+
+    #[test]
+    fn version_renders_as_label_when_set() {
+        let g = Graph::<S>::new()
+            .node(
+                "a",
+                node_fn::<S, _, _>("a", |_, _| async move {
+                    Ok(NodeOut {
+                        update: SU,
+                        goto: Goto::end(),
+                    })
+                }),
+            )
+            .start_at("a")
+            .with_version("v1.2.3")
+            .compile()
+            .unwrap();
+        let d = g.to_dot();
+        assert!(d.contains("label=\"version: v1.2.3\""), "got:\n{d}");
+        assert!(d.contains("labelloc=t"));
+    }
+
+    #[test]
+    fn annotation_renders_as_tooltip() {
+        let g = Graph::<S>::new()
+            .node(
+                "embed",
+                node_fn::<S, _, _>("embed", |_, _| async move {
+                    Ok(NodeOut {
+                        update: SU,
+                        goto: Goto::end(),
+                    })
+                }),
+            )
+            .annotate("embed", "owner", "rag-team")
+            .annotate("embed", "slo_ms", 5000)
+            .start_at("embed")
+            .compile()
+            .unwrap();
+        let d = g.to_dot();
+        // Tooltip combines both annotations alphabetically by key.
+        assert!(
+            d.contains("tooltip=\"owner: \\\"rag-team\\\" | slo_ms: 5000\""),
+            "got:\n{d}"
+        );
+    }
+
+    #[test]
+    fn annotate_unknown_node_is_silent_noop() {
+        let g = Graph::<S>::new()
+            .node(
+                "a",
+                node_fn::<S, _, _>("a", |_, _| async move {
+                    Ok(NodeOut {
+                        update: SU,
+                        goto: Goto::end(),
+                    })
+                }),
+            )
+            .annotate("ghost", "x", "y")
+            .start_at("a")
+            .compile()
+            .unwrap();
+        let d = g.to_dot();
+        assert!(!d.contains("tooltip"));
     }
 }

--- a/crates/cognisgraph/src/viz/mermaid.rs
+++ b/crates/cognisgraph/src/viz/mermaid.rs
@@ -18,6 +18,9 @@ impl<S: GraphState> CompiledGraph<S> {
     ///   inferred from the static graph).
     pub fn to_mermaid(&self) -> String {
         let mut out = String::from("flowchart TD\n");
+        if let Some(v) = self.version() {
+            out.push_str(&format!("    %% version: {v}\n"));
+        }
 
         let mut names: Vec<&String> = self.graph.nodes.keys().collect();
         names.sort();

--- a/examples/agents/agent_bus_pubsub.rs
+++ b/examples/agents/agent_bus_pubsub.rs
@@ -47,5 +47,6 @@ fn msg(from: &str, body: &str) -> AgentMessage {
         to: "broadcast".into(),
         content: Message::human(body),
         metadata: serde_json::Value::Null,
+        ..Default::default()
     }
 }

--- a/examples/agents/agent_communication.rs
+++ b/examples/agents/agent_communication.rs
@@ -40,6 +40,7 @@ async fn main() -> Result<()> {
             to: "researcher".into(),
             content: Message::human("kickoff"),
             metadata: serde_json::Value::Null,
+            ..Default::default()
         })
         .await;
 


### PR DESCRIPTION
Closes the **last 6 V1-parity items** flagged in the third refresh report (#27 closed the architectural ones; this round handles the richer-shape gaps).

After this lands, the only remaining V1 surface is the deferred \`Configurable\` ConfigKey collision (architectural redesign, very few users hit it).

## What's in here

### AgentMessage gains id + reply_to + Priority (\`b41668f\`)
- New fields: \`id: Uuid\`, \`reply_to: Option<Uuid>\`, \`priority: Priority\`.
- \`Priority\`: Low / Normal / High / Critical, default Normal.
- Constructors: \`AgentMessage::new(from, to, content)\` and \`AgentMessage::reply(&request, from, content)\` for request/reply correlation.
- \`with_priority\` / \`with_metadata\` builder methods.
- \`Default\` impl so existing struct literals work via \`..Default::default()\`.
- \`sort_by_priority()\` helper for backlog draining (Critical first).

### ToolRegistry permissions + counters + enable/disable (\`b05a15c\`)
- \`enable()\` / \`disable()\` toggle without unregistering. Disabled tools are hidden from \`get\` / \`tool_names\` / \`definitions\` / \`execute\`.
- \`set_permission(name, |agent_id| -> bool)\` attaches an \`agent_id → allowed\` predicate. \`is_allowed()\` checks; \`execute_for(agent_id, ...)\` enforces.
- \`call_count(name)\` cumulative dispatch counter (AtomicUsize, success or fail).
- Internal: \`HashMap<String, ToolEntry>\` instead of bare \`HashMap<String, Arc<dyn Tool>>\`.

### EvalReport summary + markdown + best/worst/pass_rate (\`fbf7310\`)
- \`pass_rate(threshold)\` and \`best()\` / \`worst()\` accessors.
- \`summary(pass_threshold)\` plain-text per-case table + footer.
- \`markdown(pass_threshold)\` GitHub-flavored markdown table for PR comments.

### ConversationTurn + ConversationSummary value types (\`d66cb99\`)
- \`ConversationTurn\` pairs each user input with the next assistant reply; tool messages between are captured. \`is_complete()\` distinguishes finished vs trailing-incomplete turns.
- \`ConversationSummary\` aggregates per-role counts, turn counts, total chars, plus first/last preview snippets (truncated at 200 chars).
- \`turns_from_messages(&messages)\` and \`summarize(&messages)\` are pure functions over \`Vec<Message>\`.

### ThresholdProfiler — duration alerts on node executions (\`6fc0ada\`)
- Sibling of \`ProfilingObserver\` (same timing snapshot shape).
- \`with_threshold(node, max_ns)\` registers a per-node duration cap.
- \`on_threshold_breached(|node, elapsed_ns| { ... })\` registers a callback. Multiple callbacks supported; all fire in registration order.
- Callbacks run synchronously on the engine thread, so they should be cheap.

### Graph node annotations + version surfacing in viz (\`7d4685a\`)
- \`Graph::annotate(node, key, value)\` attaches arbitrary JSON metadata. Unknown nodes silently skipped.
- \`CompiledGraph::{version, annotation, annotations}\` getters.
- DOT: graph version → top label; node annotations → \`tooltip=\"k: v | k: v\"\` (alphabetized).
- Mermaid: graph version → \`%% version: ...\` comment.
- ASCII: graph version → \`Graph (start: a, version: v1)\` header.

## Test plan

- [x] \`cargo test --workspace --lib\` — 32 cognis-trace tests + new ones pass.
- [x] \`cargo clippy --workspace --features all-providers --tests -- -D warnings\` — clean.
- [x] \`cargo fmt --all -- --check\` — clean.
- New tests added per feature:
  - multi_agent: \`agent_message_new_assigns_unique_ids\`, \`agent_message_reply_correlates\`, \`priority_sort_critical_first\`
  - cognis-llm tools: \`disable_hides_*\`, \`enable_restores\`, \`call_count_increments_on_execute\`, \`permission_predicate_blocks_*\`, \`clear_permission_*\`
  - eval: \`pass_rate_and_passing\`, \`best_and_worst\`, \`empty_report_extremes\`, \`summary_renders_*\`, \`markdown_renders_table\`
  - conversation: 6 (empty / pairing / trailing-incomplete / system-not-counted / aggregates / truncate-long)
  - graph metrics: \`fires_callback_on_breach\`, \`does_not_fire_below_threshold\`, \`snapshot_shape_matches_*\`, \`multiple_callbacks_all_fire\`
  - graph viz: \`version_renders_as_label_when_set\`, \`annotation_renders_as_tooltip\`, \`annotate_unknown_node_is_silent_noop\`

## Re-exports added at the cognis umbrella

- \`Priority\`, \`sort_by_priority\` (multi_agent)
- \`ConversationTurn\`, \`ConversationSummary\`, \`turns_from_messages\`, \`summarize\` (conversation)
- \`ThresholdProfiler\`, \`ThresholdCallback\` (cognis-graph)

## Net diff
6 commits, ~1.4k lines added. All in narrow surface areas with no churn outside the new methods/types.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finishes V1 parity by adding message correlation/priority, tool permissions, richer eval reports, conversation views, duration threshold alerts, and graph annotations/version in viz. Improves routing, control, and observability with no breaking changes.

- New Features
  - `cognis` (multi-agent): `AgentMessage` now has `id`, `reply_to`, and `Priority` (Low/Normal/High/Critical). New `new`/`reply` constructors, `with_priority`/`with_metadata`, and `sort_by_priority`.
  - `cognis-llm` (tools): `ToolRegistry` adds `enable`/`disable`, per-tool permission predicate (`set_permission`/`clear_permission`, `is_allowed`, `execute_for`), and `call_count`.
  - `cognis` (eval): `EvalReport` adds `pass_rate`, `best`/`worst`, and human-friendly `summary(threshold)` plus `markdown(threshold)` output.
  - `cognis` (conversation): New `ConversationTurn` and `ConversationSummary` with `turns_from_messages` and `summarize` helpers.
  - `cognisgraph` (metrics): `ThresholdProfiler` with `with_threshold(node, max_ns)` and `on_threshold_breached` callbacks for SLO-style alerts.
  - `cognisgraph` (viz): `Graph::annotate(node, key, value)` with `CompiledGraph::annotation(s)` getters. Version surfaces in DOT (top label), Mermaid (comment), ASCII (header). DOT tooltips show node annotations.
  - Re-exports in `cognis`: `Priority`, `sort_by_priority`, `ConversationTurn`, `ConversationSummary`, `turns_from_messages`, `summarize`, `ThresholdProfiler`, `ThresholdCallback`.

<sup>Written for commit 7d4685a34f5976dda2c34bf1b3d4c75ded649ecb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

