### PR TITLE
fix: cubic review followups — NaN-safe eval extremes + accurate execute_for errors

### DIFF
--- a/crates/cognis-llm/src/tools/mod.rs
+++ b/crates/cognis-llm/src/tools/mod.rs
@@ -307,15 +307,35 @@ impl ToolRegistry {
     }
 
     /// Like [`ToolRegistry::execute`] but also enforces the permission
-    /// predicate against `agent_id`. Errors with a permission error if
-    /// the predicate returns false.
+    /// predicate against `agent_id`.
+    ///
+    /// Error precedence (so the message is honest about the real reason):
+    /// 1. tool not registered  → `"not registered"`
+    /// 2. tool disabled        → `"disabled"`
+    /// 3. agent not allowed    → `"not allowed for agent ..."`
+    /// 4. dispatch errors from the tool itself
     pub async fn execute_for(
         &self,
         name: &str,
         agent_id: &str,
         input: ToolInput,
     ) -> Result<ToolOutput> {
-        if !self.is_allowed(name, agent_id) {
+        let entry = self.entries.get(name).ok_or_else(|| CognisError::Tool {
+            name: name.to_string(),
+            reason: "not registered".into(),
+        })?;
+        if !entry.enabled {
+            return Err(CognisError::Tool {
+                name: name.to_string(),
+                reason: "disabled".into(),
+            });
+        }
+        let allowed = entry
+            .permission
+            .as_ref()
+            .map(|p| p(agent_id))
+            .unwrap_or(true);
+        if !allowed {
             return Err(CognisError::Tool {
                 name: name.to_string(),
                 reason: format!("not allowed for agent `{agent_id}`"),
@@ -451,6 +471,33 @@ mod tests {
             .await
             .unwrap_err();
         assert!(denied.to_string().contains("not allowed"), "got: {denied}");
+    }
+
+    #[tokio::test]
+    async fn execute_for_reports_not_registered_before_permission() {
+        let reg = ToolRegistry::new();
+        let err = reg
+            .execute_for("ghost", "writer", ToolInput::Text("x".into()))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("not registered"),
+            "wrong error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_for_reports_disabled_before_permission() {
+        let mut reg = ToolRegistry::new();
+        reg.register(Arc::new(Echo));
+        reg.disable("echo");
+        // Permission set to deny — but the disabled state should win.
+        reg.set_permission("echo", |_| false);
+        let err = reg
+            .execute_for("echo", "writer", ToolInput::Text("x".into()))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("disabled"), "wrong error: {err}");
     }
 
     #[tokio::test]

--- a/crates/cognis-macros/Cargo.toml
+++ b/crates/cognis-macros/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 description = "Procedural macros for Cognis: #[tool] attribute for tool definitions and #[derive(GraphState)] for graph state with per-field reducers."
+repository = "https://github.com/0xvasanth/cognis"
 
 [lib]
 proc-macro = true

--- a/crates/cognis-trace/Cargo.toml
+++ b/crates/cognis-trace/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 description = "Pluggable observability for Cognis: bridges CallbackHandler events to Langfuse, LangSmith, and OpenTelemetry."
+repository = "https://github.com/0xvasanth/cognis"
 
 [dependencies]
 cognis-core.workspace = true

--- a/crates/cognis/src/eval/mod.rs
+++ b/crates/cognis/src/eval/mod.rs
@@ -99,22 +99,24 @@ impl<O> EvalReport<O> {
         self.passing(threshold) as f32 / self.rows.len() as f32
     }
 
-    /// Lowest scoring case (or `None` for empty).
+    /// Lowest scoring case (or `None` for empty / all-NaN). Rows with
+    /// NaN scores are excluded from the comparison — they're not "low"
+    /// or "high", just unscored. Ties on real values use `total_cmp`
+    /// for a deterministic result.
     pub fn worst(&self) -> Option<&EvalRow<O>> {
-        self.rows.iter().min_by(|a, b| {
-            a.score
-                .partial_cmp(&b.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        })
+        self.rows
+            .iter()
+            .filter(|r| !r.score.is_nan())
+            .min_by(|a, b| a.score.total_cmp(&b.score))
     }
 
-    /// Highest scoring case (or `None` for empty).
+    /// Highest scoring case (or `None` for empty / all-NaN). Same NaN
+    /// handling as [`EvalReport::worst`].
     pub fn best(&self) -> Option<&EvalRow<O>> {
-        self.rows.iter().max_by(|a, b| {
-            a.score
-                .partial_cmp(&b.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        })
+        self.rows
+            .iter()
+            .filter(|r| !r.score.is_nan())
+            .max_by(|a, b| a.score.total_cmp(&b.score))
     }
 
     /// Total case count.
@@ -312,6 +314,25 @@ mod tests {
         let r = report_with(vec![(Some("a"), 0.3), (Some("b"), 0.9), (Some("c"), 0.5)]);
         assert_eq!(r.best().unwrap().name.as_deref(), Some("b"));
         assert_eq!(r.worst().unwrap().name.as_deref(), Some("a"));
+    }
+
+    #[test]
+    fn nan_score_is_excluded_from_extremes() {
+        let r = report_with(vec![
+            (Some("a"), 0.5),
+            (Some("nan"), f32::NAN),
+            (Some("b"), 0.9),
+        ]);
+        // NaN rows don't compete for best/worst.
+        assert_eq!(r.best().unwrap().name.as_deref(), Some("b"));
+        assert_eq!(r.worst().unwrap().name.as_deref(), Some("a"));
+    }
+
+    #[test]
+    fn all_nan_scores_yield_no_extremes() {
+        let r = report_with(vec![(Some("x"), f32::NAN), (Some("y"), f32::NAN)]);
+        assert!(r.best().is_none());
+        assert!(r.worst().is_none());
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #28 (already merged). cubic posted two review comments on PR #28 between approval and merge; these address them.

## Issue 1 — eval/mod.rs:106 (P2)

\`EvalReport::best()\` and \`worst()\` used \`partial_cmp(...).unwrap_or(Equal)\`. Two problems:

- A NaN score ends up unordered, which silently leaves the extremes wherever they happened to be in the iteration — non-deterministic and wrong.
- Even a deterministic \`total_cmp\` would let positive NaN sort *above* every real value, so a NaN score could be reported as \"best.\"

**Fix**: filter NaN rows out of best/worst entirely. They're unscored, not extremal. Real-value rows are compared with \`total_cmp\` for deterministic tie-breaking. Empty / all-NaN inputs return \`None\`.

## Issue 2 — cognis-llm/src/tools/mod.rs:312 (P2)

\`ToolRegistry::execute_for\` checked permission before existence/enabled. Result: \"not allowed for agent\" was reported even when the real reason was a missing or disabled tool.

**Fix**: explicit error precedence in \`execute_for\`:
1. tool not registered  → \`\"not registered\"\`
2. tool disabled        → \`\"disabled\"\`
3. agent not allowed    → \`\"not allowed for agent ...\"\`
4. dispatch errors from the tool

Two new tests pin the precedence (\`execute_for_reports_not_registered_before_permission\`, \`execute_for_reports_disabled_before_permission\`).

## Test plan

- [x] \`cargo test --workspace --lib\` — green (cognis-llm 25 / cognis 10 eval tests including new NaN cases).
- [x] \`cargo clippy --workspace --features all-providers --tests -- -D warnings\` — clean.
- [x] \`cargo fmt --all -- --check\` — clean.
- New tests:
  - eval: \`nan_score_is_excluded_from_extremes\`, \`all_nan_scores_yield_no_extremes\`
  - tools: \`execute_for_reports_not_registered_before_permission\`, \`execute_for_reports_disabled_before_permission\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make eval extremes NaN-safe and fix `execute_for` to report the real error reason. This removes nondeterminism in eval reports, clarifies tool failures, and adds missing crate metadata for publishing.

- **Bug Fixes**
  - Eval (`cognis`): `best()`/`worst()` now ignore NaN, use `total_cmp` for ties, and return `None` for empty/all-NaN.
  - Tools (`cognis-llm`): `ToolRegistry::execute_for` error order is now not registered → disabled → not allowed → dispatch error.

- **Metadata**
  - Added `repository` to `cognis-macros` and `cognis-trace` manifests.

<sup>Written for commit 07b8f6e025bb348e4ddf0ec0b11688da975bd506. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

