### PR TITLE
chore(ci): tag-driven release workflow with idempotent crates.io publish

### DIFF
--- a/.github/scripts/publish-if-new.sh
+++ b/.github/scripts/publish-if-new.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Idempotent crate publisher used by the Release workflow.
+#
+# Usage: publish-if-new.sh <crate-name> <expected-version>
+#
+# - Refuses to run if the local Cargo.toml's resolved version doesn't
+#   match the expected one (catches stale checkouts / bad inputs).
+# - Queries crates.io for the latest version of the crate.
+# - If the expected version is already published, the script logs and
+#   exits 0 (idempotent — re-runs of a partial release don't fail).
+# - Otherwise runs `cargo publish -p <crate>` with the configured
+#   CARGO_REGISTRY_TOKEN, then waits for the index to confirm the
+#   upload before returning.
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: publish-if-new.sh <crate> <version>" >&2
+  exit 64
+fi
+
+CRATE="$1"
+VERSION="$2"
+
+# Validate the inputs (the workflow already does this for VERSION, but
+# double-checking keeps this script safe to run by hand).
+if ! [[ "$CRATE" =~ ^[a-z][a-z0-9_-]*$ ]]; then
+  echo "::error::invalid crate name: $CRATE" >&2
+  exit 65
+fi
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+  echo "::error::invalid version: $VERSION" >&2
+  exit 65
+fi
+
+echo "::group::checking $CRATE@$VERSION"
+
+# 1. Confirm the manifest version actually matches what we're trying to ship.
+LOCAL_VERSION=$(cargo pkgid -p "$CRATE" 2>/dev/null | sed -E 's/.*[#@]([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?)$/\1/')
+if [ "$LOCAL_VERSION" != "$VERSION" ]; then
+  echo "::error::$CRATE manifest version is $LOCAL_VERSION, expected $VERSION"
+  echo "::endgroup::"
+  exit 1
+fi
+
+# 2. Ask crates.io whether this version is already up.
+PUBLISHED=$(curl --silent --fail --max-time 30 \
+  "https://crates.io/api/v1/crates/$CRATE/$VERSION" \
+  | python3 -c 'import json,sys; sys.stdout.write(json.load(sys.stdin).get("version", {}).get("num", ""))' 2>/dev/null \
+  || true)
+
+if [ "$PUBLISHED" = "$VERSION" ]; then
+  echo "$CRATE@$VERSION is already on crates.io — skipping (idempotent re-run)"
+  echo "::endgroup::"
+  exit 0
+fi
+
+echo "::endgroup::"
+echo "::group::publishing $CRATE@$VERSION"
+
+# 3. Publish. cargo publish blocks until the new version is queryable on
+#    the index, so the next dependent step in the workflow can resolve
+#    it without manual sleep.
+cargo publish -p "$CRATE"
+
+echo "::endgroup::"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,37 +7,141 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
 
 jobs:
-  test:
-    name: Full test suite
+  # ────────────────────────────────────────────────────────────────────
+  # 1. Verify the tag matches workspace.package.version, then run the
+  #    full test suite + clippy + fmt against the tagged commit.
+  # ────────────────────────────────────────────────────────────────────
+  verify:
+    name: Verify tag and test
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.parse.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse tag
+        id: parse
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          TAG="${REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          # Allow only the digits-and-dots-and-pre-release-suffix shape
+          # we actually use. Refuses tag names that could be smuggled
+          # into a shell command later.
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+            echo "::error::tag '$TAG' is not a valid semver release tag"
+            exit 1
+          fi
+          {
+            echo "tag=$TAG"
+            echo "version=$VERSION"
+          } >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG version=$VERSION"
+
+      - name: Check workspace.package.version matches the tag
+        env:
+          EXPECTED: ${{ steps.parse.outputs.version }}
+        run: |
+          WORKSPACE_VERSION=$(awk '/^\[workspace\.package\]/{f=1} f && /^version/ {print $3; exit}' Cargo.toml | tr -d '"')
+          if [ "$WORKSPACE_VERSION" != "$EXPECTED" ]; then
+            echo "::error::tag v$EXPECTED != workspace.package.version $WORKSPACE_VERSION"
+            exit 1
+          fi
+          echo "tag matches workspace.package.version: $WORKSPACE_VERSION"
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo fmt
+        run: cargo fmt --all -- --check
+
+      - name: cargo clippy
+        run: cargo clippy --workspace --features all-providers --tests -- -D warnings
+
+      - name: cargo test
+        run: cargo test --workspace --features all-providers
+
+  # ────────────────────────────────────────────────────────────────────
+  # 2. Publish all crates to crates.io in strict dependency order.
+  #    Each step is idempotent: if a crate at the tagged version
+  #    already exists on crates.io (e.g. from a prior partial run),
+  #    the helper detects that and skips rather than failing.
+  # ────────────────────────────────────────────────────────────────────
+  publish:
+    name: Publish to crates.io
+    needs: verify
+    runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      VERSION: ${{ needs.verify.outputs.version }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --workspace --features all-providers
 
-  # publish:
-  #   name: Publish to crates.io
-  #   needs: test
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: dtolnay/rust-toolchain@stable
-  #     - name: Publish rustchain-core
-  #       run: cargo publish -p rustchain-core
-  #       env:
-  #         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-  #     - name: Publish rustchain
-  #       run: cargo publish -p rustchain
-  #       env:
-  #         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-  #     - name: Publish langgraph
-  #       run: cargo publish -p langgraph
-  #       env:
-  #         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-  #     - name: Publish deepagents
-  #       run: cargo publish -p deepagents
-  #       env:
-  #         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Sanity-check CARGO_REGISTRY_TOKEN
+        run: |
+          if [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
+            echo "::error::CARGO_REGISTRY_TOKEN secret is not set on this repo"
+            exit 1
+          fi
+
+      # Strict dep order. cognis-macros and cognis-core have no internal
+      # deps and could be parallelized, but sequential is simpler and
+      # the publish wait dominates anyway.
+      - name: Publish cognis-macros
+        run: .github/scripts/publish-if-new.sh cognis-macros "$VERSION"
+
+      - name: Publish cognis-core
+        run: .github/scripts/publish-if-new.sh cognis-core "$VERSION"
+
+      - name: Publish cognis-llm
+        run: .github/scripts/publish-if-new.sh cognis-llm "$VERSION"
+
+      - name: Publish cognis-rag
+        run: .github/scripts/publish-if-new.sh cognis-rag "$VERSION"
+
+      - name: Publish cognis-graph
+        run: .github/scripts/publish-if-new.sh cognis-graph "$VERSION"
+
+      - name: Publish cognis-trace
+        run: .github/scripts/publish-if-new.sh cognis-trace "$VERSION"
+
+      - name: Publish cognis (umbrella)
+        run: .github/scripts/publish-if-new.sh cognis "$VERSION"
+
+  # ────────────────────────────────────────────────────────────────────
+  # 3. Create a GitHub Release with auto-generated notes.
+  #    Runs only after publish succeeds so a failed publish doesn't
+  #    leave a dangling release.
+  # ────────────────────────────────────────────────────────────────────
+  release:
+    name: GitHub Release
+    needs: [verify, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.verify.outputs.version }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create release
+        run: |
+          TAG="v$VERSION"
+          # Idempotent: skip if a release for this tag already exists.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release $TAG already exists; skipping"
+            exit 0
+          fi
+          gh release create "$TAG" \
+            --title "Cognis $TAG" \
+            --generate-notes \
+            --verify-tag


### PR DESCRIPTION
Wires up automated releases to crates.io.

## Trigger

Push a tag matching `v*` (e.g. `git tag -s v0.3.1 -m 'Cognis 0.3.1' && git push origin v0.3.1`). The workflow runs from there — no manual `cargo publish` needed.

## Jobs

### `verify`
- Parses the tag and validates it's a strict semver shape (rejects `v1.2.3"; rm -rf /` style malicious names).
- Confirms `workspace.package.version` in `Cargo.toml` matches the tag.
- Runs `cargo fmt --check`, `cargo clippy --workspace --features all-providers --tests -- -D warnings`, `cargo test --workspace --features all-providers`.

### `publish`
- Uploads the 7 crates in strict dependency order:
  1. `cognis-macros`, `cognis-core` (no internal deps)
  2. `cognis-llm`, `cognis-rag`, `cognis-graph`, `cognis-trace` (depend on core ± macros)
  3. `cognis` (umbrella, depends on all four siblings)
- Uses a helper script `.github/scripts/publish-if-new.sh` that:
  - re-validates the local manifest version,
  - queries crates.io for the version,
  - **skips publishing if it's already there** — so a partial run can be safely retried.
- `cargo publish` itself blocks on index propagation, so dependent crates resolve without manual sleeps.

### `release`
- Creates a GitHub Release with auto-generated notes (`gh release create --generate-notes --verify-tag`).
- Idempotent: skips if a release for the tag already exists.

## Security review

- All interpolated values flow through `env:` blocks rather than direct `${{ ... }}` expansion inside shell commands. (Per [GitHub's workflow-injection guidance](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/).)
- The tag-parsing step refuses anything that's not `^v?[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$` so a hostile tag name can't smuggle shell into a later step.
- The helper script validates both crate name and version with regex before invoking cargo.

## Setup before merging

Add a `CARGO_REGISTRY_TOKEN` repo secret. Grab a token from https://crates.io/settings/tokens with:
- scope: `publish-update` + `publish-new`
- crate scope: restricted to crates starting with `cognis` (avoids the secret being able to publish anything else if leaked)

## Manual verification

Helper script smoke-tested locally:
- `cognis-core@0.3.0` (already published) → skips with "is already on crates.io"
- `cognis-core@9.9.9` (mismatch) → errors with "manifest version is 0.3.0, expected 9.9.9"
- `'evil; rm' 0.3.0` (bad input) → errors with "invalid crate name"

After merge, the next release is just:
\`\`\`
git tag -s v0.3.1 -m "Cognis 0.3.1"
git push origin v0.3.1
\`\`\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates tag-driven releases to `crates.io` with an idempotent publish flow for all Cognis crates, and auto-creates a GitHub Release. Push a `v*` tag and the workflow verifies, publishes, and ships without manual steps.

- **New Features**
  - Tag `v*` trigger: strict semver parsing, checks `workspace.package.version`, runs `cargo fmt`, `cargo clippy`, and `cargo test`.
  - Idempotent publish with `.github/scripts/publish-if-new.sh`: validates manifest, skips if already on `crates.io`, publishes all 7 crates in order (`cognis-macros`, `cognis-core`, `cognis-llm`, `cognis-rag`, `cognis-graph`, `cognis-trace`, `cognis`).
  - GitHub Release: auto-generated notes, skips if the tag’s release exists.
  - Hardening: inputs passed via `env`, tag/crate/version validated with regex.

- **Migration**
  - Add `CARGO_REGISTRY_TOKEN` repo secret (scopes: `publish-update`, `publish-new`; crate scope: `cognis*`).
  - Release flow: `git tag -s vX.Y.Z && git push origin vX.Y.Z`.

<sup>Written for commit 0c91e72c1e59b4a99b211f76a08a64c2c8b9d777. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

