### PR TITLE
chore(release): 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "cognis"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "cognis-core",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "cognis-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "futures",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "cognis-graph"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "cognis-llm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "cognis-core",
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "cognis-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "cognis-rag"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "cognis-core",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "cognis-trace"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT"
 authors = ["Vasanth <itsparser@gmail.com>"]
@@ -35,10 +35,10 @@ schemars = "0.8"
 
 
 dashmap = "6"
-cognis = { path = "crates/cognis", version = "0.3.0" }
-cognis-core = { path = "crates/cognis-core", version = "0.3.0" }
-cognis-graph = { path = "crates/cognisgraph", version = "0.3.0" }
-cognis-llm = { path = "crates/cognis-llm", version = "0.3.0" }
-cognis-rag = { path = "crates/cognis-rag", version = "0.3.0" }
-cognis-macros = { path = "crates/cognis-macros", version = "0.3.0" }
-cognis-trace = { path = "crates/cognis-trace", version = "0.3.0" }
+cognis = { path = "crates/cognis", version = "0.3.1" }
+cognis-core = { path = "crates/cognis-core", version = "0.3.1" }
+cognis-graph = { path = "crates/cognisgraph", version = "0.3.1" }
+cognis-llm = { path = "crates/cognis-llm", version = "0.3.1" }
+cognis-rag = { path = "crates/cognis-rag", version = "0.3.1" }
+cognis-macros = { path = "crates/cognis-macros", version = "0.3.1" }
+cognis-trace = { path = "crates/cognis-trace", version = "0.3.1" }


### PR DESCRIPTION
Patch release rolling up two PRs landed since 0.3.0:

- **#29** \`fix:\` cubic review followups — NaN-safe eval extremes + accurate \`execute_for\` error precedence
- **#30** \`chore(ci):\` tag-driven release workflow with idempotent crates.io publish

This will be the first release driven by the new \`release.yml\` workflow. After merging, the next step is:

\`\`\`
git tag -s v0.3.1 -m "Cognis 0.3.1"
git push origin v0.3.1
\`\`\`

— which will trigger the workflow's verify → publish → release pipeline.

## Diff
- Cargo.toml: \`0.3.0 → 0.3.1\` (workspace.package.version + 7 cognis-* workspace.dependencies pins).
- Cargo.lock regenerated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 0.3.1. Ships NaN-safe eval extremes and correct execute_for error precedence, and switches releases to the tag-driven workflow.

- Bug Fixes
  - Eval extremes: filter NaNs; use total_cmp for ties.
  - execute_for: error precedence set to not_registered → disabled → not_allowed → dispatch.

- Dependencies
  - Bump workspace and all `cognis-*` crates to 0.3.1; regenerate `Cargo.lock`.

<sup>Written for commit 15f662895d193a3673d1e58b423a930637d96b35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

