### PR TITLE
docs: address cubic review on PR #31

### DIFF
--- a/docs/mintlify/building-agents/hitl.mdx
+++ b/docs/mintlify/building-agents/hitl.mdx
@@ -122,10 +122,11 @@ let hitl = HumanInTheLoop::new(|ctx| async move {
 
 let pipelined = MiddlewarePipeline::new().push(hitl).build(primary);
 
-let agent = AgentBuilder::new()
-    .with_llm(pipelined.into_client())
-    .build()?;
+// Use the pipelined client directly:
+let resp = pipelined.invoke(messages, tool_defs, opts).await?;
 ```
+
+To run middleware inside an `AgentBuilder`-built agent (where the loop drives the LLM), wrap a `PipelinedClient` in a custom `LLMProvider` and feed that into `Client::new(...)`. See [Middleware → Wiring middleware into an agent](/building-agents/middleware#wiring-middleware-into-an-agent).
 
 Built-in `HumanResponder` impls under `cognis::middleware`: `AlwaysSkip` (no-op for testing). Closures that return `HumanDecision` work too via a blanket impl.
 

--- a/docs/mintlify/building-agents/hitl.mdx
+++ b/docs/mintlify/building-agents/hitl.mdx
@@ -6,57 +6,72 @@ sidebarTitle: "Human-in-the-loop"
 
 Some actions are too important to leave to the model alone — sending an email, executing a transaction, modifying production data. Human-in-the-loop (HITL) lets you mark those actions and require human approval before they run. Cognis offers two paths to HITL, depending on whether you're inside an agent loop or driving a graph directly.
 
-## Two paths
+## Two layers
 
-| You're using… | Use |
-|---|---|
-| `AgentBuilder` | An `Approver` plus the `HumanInTheLoop` middleware. |
-| `Graph<S>` | Interrupts (`with_interrupt_before` / `with_interrupt_after`) plus `resume`. |
+Cognis ships two distinct HITL surfaces — they pause at different points and answer different questions.
 
-The patterns are similar in spirit; the surface differs because graphs have richer state introspection.
+| Layer | Purpose | API |
+|---|---|---|
+| **Tool approval** | Gate a tool call before dispatch. The most common HITL pattern. | `Approver` trait + `AgentBuilder::with_approver(...)` |
+| **Transcript-level pause** | Pause every (or some) LLM call to consult a human — inject context, override the reply, or skip. | `HumanInTheLoop` middleware + `HumanResponder` trait |
+| **Graph interrupts** | Pause a `Graph<S>` before/after named nodes; pull saved state, edit, resume. Useful for staged approvals at workflow boundaries. | `with_interrupt_before` / `with_interrupt_after` + `resume` |
 
-## Quick example — agent approver
+For "ask before running tool X" — almost always the right answer — use **tool approval**. For "let a reviewer steer the model on every reply" — rare — use the middleware. For workflow checkpoints, use graph interrupts.
+
+## Quick example — tool approval
+
+`AgentBuilder::with_approver` wraps every registered tool in an `ApprovalGatedTool`. The approver decides per call.
 
 ```rust
 use std::sync::Arc;
 use cognis::prelude::*;
 use cognis::AgentBuilder;
-use cognis::middleware::{HumanInTheLoop, ApprovalGate};
 
-let approver = Arc::new(MyApprover);                // your impl Approver
+let approver = Arc::new(MyApprover);   // your impl Approver
 
 let agent = AgentBuilder::new()
     .with_llm(client)
-    .with_tools(tools)
-    .with_approver(approver.clone())
-    .middleware(HumanInTheLoop::new(approver))
+    .with_tools(tools)         // register tools first
+    .with_approver(approver)   // then wrap with the approver — order matters
     .build()?;
 ```
 
-Inside the loop, every tool call passes through the approver. Yours decides what gets gated:
+<Note>
+Tools registered *after* `.with_approver(...)` are NOT auto-wrapped. Call `with_approver` last.
+</Note>
+
+The trait:
 
 ```rust
-use cognis::tools::{Approver, ApprovalDecision};
+use async_trait::async_trait;
+use cognis::tools::{Approver, Decision};
+use cognis::Result;
 
 struct MyApprover;
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Approver for MyApprover {
-    async fn approve(&self, tool: &str, args: &serde_json::Value)
-        -> cognis::Result<ApprovalDecision>
+    async fn approve(&self, tool_name: &str, args: &serde_json::Value)
+        -> Result<Decision>
     {
-        if tool == "send_email" {
+        if tool_name == "send_email" {
             // Surface to your UI; await the human's reply.
-            let decision = my_ui::ask_human(tool, args).await?;
+            let decision = my_ui::ask_human(tool_name, args).await?;
             Ok(decision)
         } else {
-            Ok(ApprovalDecision::Approve)
+            Ok(Decision::Approve)
         }
     }
 }
 ```
 
-`ApprovalDecision` covers the common shapes — `Approve`, `Reject(reason)`, `Edit(new_args)` — so a human can either let it run, refuse, or modify the call before dispatch.
+`Decision` covers the common shapes:
+
+- `Decision::Approve` — let the call run as-is.
+- `Decision::Reject { reason }` — refuse; the model sees `reason` as the tool's output and can apologize or try something else. Use `Decision::reject("nope")` as a shortcut.
+- `Decision::Edit { args }` — approve, but rewrite the args (e.g., cap a transfer amount).
+
+Built-in approvers under `cognis::tools`: `AutoApprove`, `RejectAll`, `AllowList` — handy for tests or as a base to compose your own.
 
 ## Quick example — graph interrupts
 
@@ -87,18 +102,32 @@ match graph.invoke(state, cfg.clone()).await {
 
 Source: [`examples/graphs/graph_interrupts_demo.rs`](https://github.com/0xvasanth/cognis/blob/main/examples/graphs/graph_interrupts_demo.rs).
 
-## Approval policies
+## Transcript-level pause
 
-Built-in policies you can compose with `HumanInTheLoop`:
+For the rarer case where you want a human to potentially intervene on *every* model call (or a subset gated by a predicate), wrap the LLM client with the `HumanInTheLoop` middleware. It pauses before each call, asks a `HumanResponder`, and acts on a `HumanDecision`.
 
-| Policy | Behavior |
-|---|---|
-| `AutoApproveAll` | Skip the human; always approve. Useful in dev. |
-| `AutoRejectAll` | Skip the human; always reject. Useful in tests. |
-| `AlwaysSkip` | Bypass the gate entirely (no approval, no rejection). |
-| `ApprovalGate` | Pluggable policy: the bouncer is your closure. |
+```rust
+use std::sync::Arc;
+use cognis::middleware::{HumanInTheLoop, HumanDecision, MiddlewarePipeline};
+use cognis_llm::Client;
 
-Wrap any of these into the agent the same way as a custom `Approver`.
+let primary = Client::from_env()?;
+
+let hitl = HumanInTheLoop::new(|ctx| async move {
+    // Inspect ctx.messages, ctx.opts; return HumanDecision::Skip,
+    // ::InjectSystem(text), or ::Override(text).
+    Ok(HumanDecision::Skip)
+})
+.with_gate(|ctx| ctx.messages.last().map_or(false, |m| m.content().contains("CONFIRM")));
+
+let pipelined = MiddlewarePipeline::new().push(hitl).build(primary);
+
+let agent = AgentBuilder::new()
+    .with_llm(pipelined.into_client())
+    .build()?;
+```
+
+Built-in `HumanResponder` impls under `cognis::middleware`: `AlwaysSkip` (no-op for testing). Closures that return `HumanDecision` work too via a blanket impl.
 
 ## How it works
 

--- a/docs/mintlify/building-agents/memory.mdx
+++ b/docs/mintlify/building-agents/memory.mdx
@@ -93,7 +93,8 @@ Override `seed()` if your memory wants to project differently than it stores —
 ## How it works
 
 - **Memory lives on the agent**, not on the graph state. That's why `stateful()` matters: it keeps the agent's `Memory` field alive across `run` calls.
-- **Memory is read once at the start of `run` and written incrementally as the loop produces messages.** The order matches the transcript.
+- **Memory is read at the start of each `run`** (when stateful) to seed the conversation; the agent appends the run's transcript to memory **after `run` completes**, in one batch. Memory is not updated during the loop.
+- **In stateless mode, memory is not written** — every `run` is independent.
 - **Pinned system messages are *always* prepended** — even if the rest of the memory has been summarized away.
 - **Summarization runs as an LLM call** through the `client` you handed the memory. It costs tokens; budget for it.
 
@@ -102,7 +103,7 @@ Override `seed()` if your memory wants to project differently than it stores —
 Memory state is in-process by default. For persistence across processes:
 
 - Use the agent's `Backend` (`with_filesystem`) to write a markdown / JSON memory file the agent reads back.
-- Use `cognis-graph` checkpointers to persist the graph state itself, including the memory snapshot — see [Graph workflows → Checkpointing](/graph-workflows/checkpointing).
+- Use `cognis-graph` checkpointers to persist the agent's *graph state* across processes — see [Graph workflows → Checkpointing](/graph-workflows/checkpointing). Note that checkpointers persist what's in the graph state struct, not the agent's `Memory` backend internals; if your `Memory` keeps state outside the graph (e.g. in a `SummaryBufferMemory`'s running summary), persist that separately or hydrate it from a store of your choice on startup.
 
 ## See also
 

--- a/docs/mintlify/building-agents/middleware.mdx
+++ b/docs/mintlify/building-agents/middleware.mdx
@@ -1,159 +1,208 @@
 ---
 title: "Middleware"
-description: "Cross-cutting policies that wrap every model call. Retry, fallback, rate limits, redaction, prompt caching, summarization, planning, HITL — all composable."
+description: "Cross-cutting policies that wrap LLM calls. Retry, fallback, redaction, prompt caching, summarization, planning — composable, and agent-friendly via a custom provider."
 sidebarTitle: "Middleware"
 ---
 
-Middleware is how Cognis adds production discipline without rewriting your agent loop. A middleware sits between the agent and the model, sees every call, and can mutate the request, retry, redact, gate, log, or replace the response. They compose: add three, and they stack in declared order.
+Middleware is how Cognis adds production discipline around `Client` calls — retry, fallback, rate limits, redaction, prompt caching, planning, summarization. Each middleware wraps a `Client` and runs on every chat call. Multiple middlewares compose into a `MiddlewarePipeline`.
 
 ## How it works
 
-Each middleware implements `Middleware`, a trait with one method that wraps a `Next` (the rest of the chain ending at the LLM). The agent's `MiddlewarePipeline` runs them in order on every model call inside the loop.
+A middleware implements `cognis::middleware::Middleware`, a trait with one async method (`call`) that receives a `MiddlewareCtx` and an `Arc<dyn Next>`. The pipeline runs them in **reverse-push order** — the most-recently-pushed layer is the *outermost* wrapper.
 
 ```rust
-use cognis::middleware::{ModelRetry, RateLimit, PromptCaching};
+use std::sync::Arc;
+use cognis::middleware::{ModelRetry, RegexRedactor, MiddlewarePipeline};
+use cognis_llm::Client;
 
-let agent = AgentBuilder::new()
-    .with_llm(client)
-    .middleware(RateLimit::token_bucket(rate, burst))
-    .middleware(ModelRetry::exponential(3))
-    .middleware(PromptCaching::default())
-    .build()?;
+let primary = Client::from_env()?;
+
+let pipelined = MiddlewarePipeline::new()
+    .push(ModelRetry::new(3))         // innermost (closest to the client)
+    .push(RegexRedactor::new())       // outermost (sees the request first)
+    .build(primary);
+
+// Use directly:
+let resp = pipelined.invoke(messages, tool_defs, opts).await?;
 ```
 
-The order matters: the first one declared is the outermost. So `RateLimit` enforces *before* a retry burns through your tokens; `PromptCaching` shapes what the provider sees regardless of retries.
+The chain executes outside-in: `RegexRedactor::call` runs first, then `ModelRetry::call`, then the raw client. Push order is "innermost first."
+
+<Note>
+Middleware is **not** auto-wired into `AgentBuilder` in v0.3. To run middleware inside an agent loop, wrap your client into a `PipelinedClient` and serve it through a custom `LLMProvider` — see [Wiring middleware into an agent](#wiring-middleware-into-an-agent) below.
+</Note>
 
 ## What's in the box
 
-The full catalog lives under `cognis::middleware::*`. Reach for these by job:
+The full catalog under `cognis::middleware::*`. Reach for these by job:
 
 ### Resilience
 
-| Middleware | Effect |
+| Middleware | Constructor |
 |---|---|
-| `ModelRetry` | Retry on transient errors and rate limits with backoff. |
-| `ModelFallback` | Fall back to another model on failure. |
-| `Recovery` / `FixedRecovery` / `FnRecovery` | Custom recovery strategies on errors. |
-| `ToolRetry` / `ToolRetryClassifier` | Retry tool calls that the model emitted but that failed. |
+| `ModelRetry` | `ModelRetry::new(max_attempts)` — exponential backoff (100ms initial, 2x, 30s cap) by default |
+| `ModelFallback` | `ModelFallback::new(fallback_client: Client)` |
+| `Recovery` (`FixedRecovery`, `FnRecovery`) | Custom recovery on errors |
+| `ToolRetry` (`ToolRetryClassifier`) | `ToolRetry::new(max_attempts)` for retrying tool calls the model emitted that failed |
 
 ### Rate and cost
 
-| Middleware | Effect |
+| Middleware | Constructor |
 |---|---|
-| `RateLimit` (with `TokenBucket`) | Token-bucket rate limiting per model or globally. |
-| `ModelCallLimit`, `ToolCallLimit` | Hard caps per run. |
+| `RateLimit` | `RateLimit::new(Arc::new(TokenBucket::new(rate_per_sec, burst)))` — also accepts `SlidingWindow`, `Composite`, `CostBased` |
+| `ModelCallLimit` | `ModelCallLimit::new(cap)` — hard cap on calls per pipeline run |
+| `ToolCallLimit` | `ToolCallLimit::new(cap)` |
 
 ### Privacy
 
-| Middleware | Effect |
+| Middleware | Constructor |
 |---|---|
-| `PiiRedactor` | Mask known PII patterns before the request leaves your process. |
-| `RegexRedactor` | Bring-your-own-pattern redaction. |
+| `PiiRedactor` | `PiiRedactor::new()` — masks common PII patterns (emails, phones, etc.) |
+| `RegexRedactor` | `RegexRedactor::new()` — bring your own patterns |
 
 ### Prompt and context
 
-| Middleware | Effect |
+| Middleware | Constructor |
 |---|---|
-| `PromptCaching` | Mark messages as cacheable for providers that support it (Anthropic). |
-| `ContextEditing` | Mutate messages before they go to the model. |
-| `ContextInjection` (`FnContextProvider`) | Inject context derived from your app state. |
-| `Summarization` | Compress old turns when the transcript grows. |
-| `CapMessageLength` | Truncate over-long messages. |
-| `DropMatching` | Filter messages by predicate. |
+| `PromptCaching` | `PromptCaching::new()` (or `::default()`) — Anthropic prompt-cache markers |
+| `ContextEditing` | `ContextEditing::new(policy)` — mutate messages before they go to the model |
+| `ContextInjection` | `ContextInjection::new(provider)` — inject context derived from your app state |
+| `Summarization` | `Summarization::new(keep_last)` — compress old turns when the transcript grows |
+
+### Planning and todos
+
+| Middleware | Constructor |
+|---|---|
+| `Planning` | `Planning::new()` |
+| `TodoMiddleware` | Maintain an internal task list the agent can read and update |
 
 ### Tools
 
 | Middleware | Effect |
 |---|---|
-| `ToolAllowList` / `ToolDenyList` / `ToolFilter` | Restrict which tools the model may call. |
-| `LimitTools` | Cap the number of tool definitions sent to the model. |
-| `ToolEmulator` (`MapEmulator`, `EmulatorSource`) | Replay tool calls deterministically — great for tests. |
-| `ToolSelection` | Steer the model toward a subset of tools per turn. |
-| `PatchToolCalls` (`FnToolCallPatcher`) | Fix or rewrite the model's tool calls before dispatch. |
+| `ToolEmulator` (`MapEmulator`, `EmulatorSource`) | Replay tool calls deterministically — great for tests |
+| `ToolSelection` | Steer the model toward a subset of tools per turn |
+| `PatchToolCalls` (`FnToolCallPatcher`) | Fix or rewrite the model's tool calls before dispatch |
 
-### Planning and todos
-
-| Middleware | Effect |
-|---|---|
-| `Planning` | Inject a planning step before tool selection. |
-| `TodoMiddleware` | Maintain an internal task list the agent can read and update. |
-
-### Human-in-the-loop
-
-| Middleware | Effect |
-|---|---|
-| `HumanInTheLoop` (`HumanResponder`, `HumanDecision`, `ChatApproval`, `ChatApprover`) | Pause for human approval or input on configured tools. |
-| `ApprovalGate` / `AlwaysSkip` / `AutoApproveAll` / `AutoRejectAll` | Approval policies. |
+For tool-call **gating** (require human approval before specific tools run), use `Approver` + `AgentBuilder::with_approver`, not middleware. See [Human-in-the-loop](/building-agents/hitl).
 
 ### Workspace and subagents
 
 | Middleware | Effect |
 |---|---|
-| `FilesystemMiddleware`, `WorkspaceLister` | Expose a virtual workspace to the model. |
-| `EditPolicy` | Gate which files the agent may edit. |
-| `SubagentMiddleware`, `SubagentRouter` | Spawn subagents from inside the loop for context isolation. |
-
-### Pipelines
-
-| Type | Effect |
-|---|---|
-| `MiddlewarePipeline` | Compose multiple middlewares programmatically. |
-| `PipelinedClient` | A `Client` wrapper that runs the pipeline on every call. |
+| `FilesystemMiddleware` | Expose a virtual workspace to the model |
+| `SubagentMiddleware` (`SubagentRouter`) | Spawn subagents from inside the pipeline for context isolation |
 
 ## Quick example — production stack
 
-A reasonable defaults stack for a customer-facing agent:
+A reasonable defaults stack for a customer-facing client:
 
 ```rust
 use std::sync::Arc;
-use cognis::prelude::*;
-use cognis::AgentBuilder;
 use cognis::middleware::{
     ModelRetry, ModelFallback, RateLimit, TokenBucket,
-    PromptCaching, PiiRedactor, Summarization,
+    PromptCaching, PiiRedactor, Summarization, MiddlewarePipeline,
 };
+use cognis_llm::Client;
 
 let primary = Client::from_env()?;
-let backup = /* a cheaper Client::builder() */;
+let backup  = Client::builder().model("gpt-4o-mini").build()?;
 
-let agent = AgentBuilder::new()
-    .with_llm(primary)
-    .middleware(RateLimit::new(TokenBucket::per_minute(60_000)))
-    .middleware(PiiRedactor::default())
-    .middleware(PromptCaching::default())
-    .middleware(Summarization::token_budget(8_000))
-    .middleware(ModelRetry::exponential(3))
-    .middleware(ModelFallback::to(backup))
-    .with_system_prompt("…")
-    .with_tools(my_tools)
+// Innermost first, outermost last (reverse-push semantics).
+let pipelined = MiddlewarePipeline::new()
+    .push(ModelFallback::new(backup))                          // last-resort fallback
+    .push(ModelRetry::new(3))                                  // retry transients
+    .push(Summarization::new(8))                               // keep last 8 turns
+    .push(PromptCaching::new())                                // mark cacheable
+    .push(PiiRedactor::new())                                  // redact before send
+    .push(RateLimit::new(Arc::new(TokenBucket::new(1000.0, 60_000)))) // outermost
+    .build(primary);
+```
+
+Read top-to-bottom (push order): retry happens *inside* redaction, redaction happens *inside* the rate limiter — so the rate limiter sees every retry attempt, and the model never sees raw PII.
+
+## Wiring middleware into an agent
+
+`AgentBuilder` accepts a raw `Client`; it doesn't take a `PipelinedClient` directly. Two ways to bridge:
+
+**Option 1 — `PipelinedClient` standalone**, for code that calls the model directly without the agent harness:
+
+```rust
+let resp = pipelined.invoke(messages, tool_defs, opts).await?;
+```
+
+**Option 2 — Custom `LLMProvider`** that delegates to the pipeline. Wrap that provider into a `Client`, then hand it to `AgentBuilder`:
+
+```rust
+use std::sync::Arc;
+use async_trait::async_trait;
+use cognis_llm::{Client, provider::{LLMProvider, Provider}};
+use cognis_llm::chat::{ChatOptions, ChatResponse, HealthStatus, StreamChunk};
+use cognis::middleware::PipelinedClient;
+use cognis_core::{Message, Result, RunnableStream};
+
+struct PipelinedProvider(Arc<PipelinedClient>);
+
+#[async_trait]
+impl LLMProvider for PipelinedProvider {
+    fn name(&self) -> &str { "pipelined" }
+    fn provider_type(&self) -> Provider { self.0.client().provider().provider_type() }
+    async fn chat_completion(&self, messages: Vec<Message>, opts: ChatOptions) -> Result<ChatResponse> {
+        self.0.invoke(messages, vec![], opts).await
+    }
+    async fn chat_completion_with_tools(&self, messages: Vec<Message>, tools: Vec<cognis_llm::tools::ToolDefinition>, opts: ChatOptions) -> Result<ChatResponse> {
+        self.0.invoke(messages, tools, opts).await
+    }
+    async fn chat_completion_stream(&self, m: Vec<Message>, o: ChatOptions) -> Result<RunnableStream<StreamChunk>> {
+        self.0.client().provider().chat_completion_stream(m, o).await
+    }
+    async fn health_check(&self) -> Result<HealthStatus> {
+        self.0.client().provider().health_check().await
+    }
+}
+
+let agent = cognis::AgentBuilder::new()
+    .with_llm(Client::new(Arc::new(PipelinedProvider(Arc::new(pipelined)))))
     .build()?;
 ```
 
-Read top-to-bottom: rate-limit first (don't waste retries on a 429), redact PII before it ever reaches a wire, mark cacheable for Anthropic, summarize old turns when context grows, retry transients, fall back to a cheaper model if everything else fails.
+This is a power-user pattern; reach for it when you need every agent-driven LLM call to go through the same middleware chain.
 
 ## Writing your own middleware
 
 The trait is small:
 
 ```rust
+use std::sync::Arc;
 use async_trait::async_trait;
 use cognis::middleware::{Middleware, MiddlewareCtx, Next};
+use cognis_llm::chat::ChatResponse;
+use cognis_core::Result;
 
 struct LogTokens;
 
 #[async_trait]
 impl Middleware for LogTokens {
-    async fn handle(&self, ctx: MiddlewareCtx<'_>, next: Next<'_>) -> cognis::Result<ChatResponse> {
-        let resp = next.run(ctx).await?;
+    async fn call(&self, ctx: MiddlewareCtx, next: Arc<dyn Next>) -> Result<ChatResponse> {
+        let resp = next.invoke(ctx).await?;
         if let Some(usage) = &resp.usage {
             tracing::info!(input = usage.input_tokens, output = usage.output_tokens, "llm call");
         }
         Ok(resp)
     }
+
+    fn name(&self) -> &str { "LogTokens" }
 }
 ```
 
-Plug it in with `.middleware(LogTokens)` like any other. Order in the chain is your call.
+Push it onto the pipeline like any other:
+
+```rust
+let pipelined = MiddlewarePipeline::new()
+    .push(LogTokens)
+    .push(ModelRetry::new(3))
+    .build(client);
+```
 
 ## See also
 
@@ -165,7 +214,7 @@ Plug it in with `.middleware(LogTokens)` like any other. Order in the chain is y
     PII redaction, deny-lists, SSRF protection.
   </Card>
   <Card title="Human-in-the-loop" icon="user-check" href="/building-agents/hitl">
-    Approval-gated tools.
+    Approval-gated tools — different from middleware.
   </Card>
   <Card title="Reference → cognis" icon="book" href="/reference/api/cognis">
     Full middleware re-export list.

--- a/docs/mintlify/building-agents/middleware.mdx
+++ b/docs/mintlify/building-agents/middleware.mdx
@@ -13,7 +13,7 @@ A middleware implements `cognis::middleware::Middleware`, a trait with one async
 ```rust
 use std::sync::Arc;
 use cognis::middleware::{ModelRetry, RegexRedactor, MiddlewarePipeline};
-use cognis_llm::Client;
+use cognis_llm::{Client, provider::Provider};
 
 let primary = Client::from_env()?;
 
@@ -103,10 +103,14 @@ use cognis::middleware::{
     ModelRetry, ModelFallback, RateLimit, TokenBucket,
     PromptCaching, PiiRedactor, Summarization, MiddlewarePipeline,
 };
-use cognis_llm::Client;
+use cognis_llm::{Client, provider::Provider};
 
 let primary = Client::from_env()?;
-let backup  = Client::builder().model("gpt-4o-mini").build()?;
+let backup  = Client::builder()
+    .provider(Provider::OpenAI)
+    .api_key(std::env::var("OPENAI_API_KEY")?)
+    .model("gpt-4o-mini")
+    .build()?;
 
 // Innermost first, outermost last (reverse-push semantics).
 let pipelined = MiddlewarePipeline::new()

--- a/docs/mintlify/building-agents/multi-agent.mdx
+++ b/docs/mintlify/building-agents/multi-agent.mdx
@@ -43,12 +43,12 @@ let resp: AgentResponse = orch.run(input).await?;
     Source: [`examples/v2/08_ollama_multi_agent.rs`](https://github.com/0xvasanth/cognis/blob/main/examples/v2/08_ollama_multi_agent.rs).
   </Tab>
   <Tab title="Supervisor">
-    The first agent acts as a router: its reply names the next worker and the prompt to send. The orchestrator keeps cycling until a worker terminates without naming another.
+    The first agent acts as a router: it sees the input, replies, and its reply is parsed for the next worker's name + the prompt to send. The chosen worker runs once; its reply is the final answer. Single hop — to chain further hops, run another `orch.run(...)` with the previous output.
 
     ```rust
     use cognis::{MultiAgentOrchestrator, Supervisor};
 
-    let orch = MultiAgentOrchestrator::new(Supervisor::default())
+    let orch = MultiAgentOrchestrator::new(Supervisor::new())
         .add("supervisor", supervisor_agent)   // first agent is the router
         .add("researcher", researcher_agent)
         .add("writer", writer_agent);
@@ -57,63 +57,81 @@ let resp: AgentResponse = orch.run(input).await?;
     Customize how the supervisor's reply is parsed:
 
     ```rust
+    use std::sync::Arc;
+
     let orch = MultiAgentOrchestrator::new(
-        Supervisor::new().with_parser(|reply: &str| {
+        Supervisor::new().with_parser(Arc::new(|reply: &str| {
             // return Some((agent_id, prompt_for_that_agent))
-            // or None to terminate.
-            todo!()
-        })
+            // or None to keep the supervisor's reply as the final answer.
+            None
+        }))
     );
     ```
   </Tab>
   <Tab title="ParallelVote">
-    All agents run on the same input concurrently. Outputs are aggregated by majority vote — the modal answer wins. The constructor takes a quorum (0.0–1.0); if no answer crosses it, the orchestrator returns the most-voted answer with a low-confidence flag.
+    All agents run on the same input concurrently. Outputs are tallied by content equality — the most-frequent reply wins; ties break by registration order.
 
     ```rust
     use cognis::{MultiAgentOrchestrator, ParallelVote};
 
-    let orch = MultiAgentOrchestrator::new(ParallelVote::new(0.5))
+    let orch = MultiAgentOrchestrator::new(ParallelVote)
         .add("a", a)
         .add("b", b)
         .add("c", c);
     ```
-    Useful for high-stakes classifications, fact-check ensembles, or running the same prompt across multiple models.
+    Useful for high-stakes classifications, fact-check ensembles, or running the same prompt across multiple models. For quorum-based voting (require a minimum agreement before accepting), use the `Consensus` strategy instead — `Consensus::new(0.5)` requires 50% agreement.
   </Tab>
   <Tab title="RoundRobin">
-    Turn-taking. Each agent goes in order, gets the running transcript, replies, and the next agent gets the updated transcript. Loops for N rounds.
+    Round-robin load-balancing across agents that share the same role (e.g. an "answerer" pool). Each `run()` call routes to the next agent in registration order, cycling. The picked agent handles the request alone; the others are not invoked for this call.
 
     ```rust
     use cognis::{MultiAgentOrchestrator, RoundRobin};
 
-    let orch = MultiAgentOrchestrator::new(RoundRobin::default())
-        .add("proposer", proposer)
-        .add("critic", critic);
+    let orch = MultiAgentOrchestrator::new(RoundRobin::new())
+        .add("worker_a", worker_a)
+        .add("worker_b", worker_b)
+        .add("worker_c", worker_c);
     ```
-    Useful for debate loops, propose-then-critique-then-revise patterns, multi-perspective brainstorming.
+    Useful when you want to spread requests across replicas. For iterative debate / propose-then-critique loops, drive the back-and-forth from your application code by calling `orch.run(...)` (or specific agents) in sequence.
   </Tab>
 </Tabs>
 
 ## How it works
 
-- **Each strategy is a struct that implements `HandoffStrategy`.** That trait is two methods: pick the next step, and decide when to terminate.
+- **Each strategy is a struct that implements `HandoffStrategy`.** That trait has one required async method: `run(&self, agents, input, bus) -> Result<AgentResponse>`. The strategy decides everything that happens between the user's input and the final response.
 - **Agents inside the orchestrator are still `Agent`s.** Each runs its own loop with its own memory, tools, and middleware. The orchestrator only decides who runs next.
 - **Errors propagate.** If an agent inside the orchestrator returns `Err`, the orchestrator returns `Err`. Wrap a sub-agent's client with `with_fallback` if you want graceful degradation.
 - **The orchestrator returns an `AgentResponse`.** Same shape as a single agent — drop-in callers don't change.
+- **Other strategies in the box.** Beyond the four covered above, `cognis::multi_agent` also ships `Hierarchical` (manager → workers tree) and `Consensus` (quorum-based voting).
 
 ## Custom handoff
 
 Implement `HandoffStrategy` for full control:
 
 ```rust
-use cognis::multi_agent::{HandoffStrategy, /* … */};
+use std::sync::Arc;
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+use cognis::multi_agent::{HandoffStrategy, MessageBus};
+use cognis::{Agent, AgentResponse, Message, Result};
 
 struct EscalateOnUnsure;
 
+#[async_trait]
 impl HandoffStrategy for EscalateOnUnsure {
+    async fn run(
+        &self,
+        agents: &[(String, Arc<Mutex<Agent>>)],
+        input: Message,
+        bus: Arc<dyn MessageBus>,
+    ) -> Result<AgentResponse> {
+        // 1. Run a primary agent.
+        // 2. If its reply is unsure, route to a senior agent.
+        // 3. Return the chosen reply.
+        todo!()
+    }
+
     fn name(&self) -> &str { "EscalateOnUnsure" }
-    // Two required methods: select next step + termination check.
-    // Full signature in the cognis::multi_agent module.
-    // …
 }
 ```
 

--- a/docs/mintlify/building-rag/embeddings.mdx
+++ b/docs/mintlify/building-rag/embeddings.mdx
@@ -105,11 +105,11 @@ All implement `VectorStore`:
 
 ```rust
 pub trait VectorStore: Send + Sync {
-    async fn add_texts(&mut self, texts: Vec<String>, ids: Option<Vec<String>>) -> Result<Vec<String>>;
-    async fn add_vectors(&mut self, vectors: Vec<(String, Vec<f32>, HashMap<String, Value>)>) -> Result<()>;
+    async fn add_texts(&mut self, texts: Vec<String>, metadata: Option<Vec<HashMap<String, Value>>>) -> Result<Vec<String>>;
+    async fn add_vectors(&mut self, vectors: Vec<Vec<f32>>, texts: Vec<String>, metadata: Option<Vec<HashMap<String, Value>>>) -> Result<Vec<String>>;
     async fn similarity_search(&self, query: &str, k: usize) -> Result<Vec<SearchResult>>;
-    async fn similarity_search_by_vector(&self, vector: &[f32], k: usize) -> Result<Vec<SearchResult>>;
-    async fn similarity_search_with_filter(&self, query: &str, k: usize, filter: Filter) -> Result<Vec<SearchResult>>;
+    async fn similarity_search_by_vector(&self, query_vector: Vec<f32>, k: usize) -> Result<Vec<SearchResult>>;
+    async fn similarity_search_with_filter(&self, query: &str, k: usize, filter: &Filter) -> Result<Vec<SearchResult>>;
     async fn delete(&mut self, ids: Vec<String>) -> Result<()>;
 }
 ```
@@ -152,7 +152,7 @@ Vector stores support metadata filters when their backend does:
 use cognis_rag::Filter;
 
 let filter = Filter::eq("section", "intro");
-let hits = store.similarity_search_with_filter("…", 5, filter).await?;
+let hits = store.similarity_search_with_filter("…", 5, &filter).await?;
 ```
 
 `Filter` is a small DSL — `eq`, `ne`, `in`, `not_in`, plus `and`/`or` combinators. The store translates it to its native query language.

--- a/docs/mintlify/contribute/adding-a-provider.mdx
+++ b/docs/mintlify/contribute/adding-a-provider.mdx
@@ -95,7 +95,7 @@ all-providers = ["openai", "ollama", "anthropic", "google", "azure", "voyage", "
 ```rust
 // crates/cognis-llm/src/provider/mod.rs
 pub enum Provider {
-    OpenAi,
+    OpenAI,
     Anthropic,
     Google,
     Ollama,

--- a/docs/mintlify/contribute/adding-a-vector-store.mdx
+++ b/docs/mintlify/contribute/adding-a-vector-store.mdx
@@ -18,20 +18,41 @@ Cognis ships six vector stores (in-memory, FAISS, Chroma, Qdrant, Pinecone, Weav
 ## The trait
 
 ```rust
+use std::collections::HashMap;
+use serde_json::Value;
+
 #[async_trait]
 pub trait VectorStore: Send + Sync {
-    async fn add_texts(&mut self, texts: Vec<String>, ids: Option<Vec<String>>) -> Result<Vec<String>>;
-    async fn add_vectors(&mut self, vectors: Vec<(String, Vec<f32>, HashMap<String, Value>)>) -> Result<()>;
+    async fn add_texts(
+        &mut self,
+        texts: Vec<String>,
+        metadata: Option<Vec<HashMap<String, Value>>>,
+    ) -> Result<Vec<String>>;
+
+    async fn add_vectors(
+        &mut self,
+        vectors: Vec<Vec<f32>>,
+        texts: Vec<String>,
+        metadata: Option<Vec<HashMap<String, Value>>>,
+    ) -> Result<Vec<String>>;
+
     async fn similarity_search(&self, query: &str, k: usize) -> Result<Vec<SearchResult>>;
-    async fn similarity_search_by_vector(&self, vector: &[f32], k: usize) -> Result<Vec<SearchResult>>;
-    async fn similarity_search_with_filter(&self, query: &str, k: usize, filter: Filter) -> Result<Vec<SearchResult>>;
+    async fn similarity_search_by_vector(&self, query_vector: Vec<f32>, k: usize) -> Result<Vec<SearchResult>>;
+
+    /// Default fallback: searches top `k * 4`, then filters in-process. Override
+    /// when your backend supports native metadata filters (Qdrant, Pinecone, …).
+    async fn similarity_search_with_filter(&self, query: &str, k: usize, filter: &Filter) -> Result<Vec<SearchResult>>;
+
     async fn delete(&mut self, ids: Vec<String>) -> Result<()>;
+
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool { self.len() == 0 }
 }
 ```
 
-`SearchResult` is `{ id, text, score, metadata }`.
+`SearchResult` is `{ id, text, score, metadata }`. `add_texts` returns the IDs the store assigned; `add_vectors` is the lower-level entry when the caller has already paid the embedding cost.
 
-For backends that don't natively support a method (e.g. some don't take a metadata filter), provide a sensible fallback — fetch top K, then filter in-process — and document the difference.
+For backends that don't natively support a method, provide a sensible fallback (`similarity_search_with_filter` has one already) and document the difference.
 
 ## Step 1 — Build the struct
 
@@ -95,7 +116,7 @@ In `crates/cognis-rag/src/lib.rs`:
 pub use vectorstore::myvector::{MyVectorStore, MyVectorStoreBuilder};
 ```
 
-The umbrella picks it up automatically through `pub use cognis_rag::*`.
+The `cognis` umbrella **does not** auto-glob from `cognis_rag` — it explicitly lists the types it re-exports at the top level. Add your types to the relevant `pub use cognis_rag::{...}` block in `crates/cognis/src/lib.rs` so users get `cognis::MyVectorStore` without an extra import. Existing entries there (e.g. `InMemoryVectorStore`, `Filter`) are the template.
 
 ## Step 3 — Tests
 

--- a/docs/mintlify/contribute/ways-to-contribute.mdx
+++ b/docs/mintlify/contribute/ways-to-contribute.mdx
@@ -33,7 +33,7 @@ Documentation contributions are first-class. Three flavors:
 
 - **Fix typos and rough edges** — open a PR directly.
 - **Sharpen explanations** — if a page felt confusing, rewrite the part you got stuck on. You're closer to that experience than the maintainers.
-- **Add missing pages** — propose a topic in an issue first; the docs site has a structure ([Learn / Reference / Contribute](/contribute/architecture)) that we try to keep coherent.
+- **Add missing pages** — propose a topic in an issue first; the docs site has a structure (Learn / Reference / Examples / Contribute) that we try to keep coherent.
 
 The docs source lives at [`docs/mintlify/`](https://github.com/0xvasanth/cognis/tree/main/docs/mintlify). It's [Mintlify](https://mintlify.com) — write Markdown / MDX with Cognis-flavored conventions.
 

--- a/docs/mintlify/examples/observability.mdx
+++ b/docs/mintlify/examples/observability.mdx
@@ -12,8 +12,8 @@ Observability examples show what's running and how it's doing — events, callba
 | `obs_callback_manager` | `CallbackManager` for stacked handlers | [src](https://github.com/0xvasanth/cognis/blob/main/examples/observability/callback_manager.rs) |
 | `obs_tracing` | Stdout `TracingObserver` | [src](https://github.com/0xvasanth/cognis/blob/main/examples/observability/tracing_demo.rs) |
 | `obs_health_monitoring` | Provider health checks | [src](https://github.com/0xvasanth/cognis/blob/main/examples/observability/health_monitoring.rs) |
-| `obs_evaluation_framework` | `EvaluationFramework` over a dataset | [src](https://github.com/0xvasanth/cognis/blob/main/examples/observability/evaluation_framework.rs) |
-| `obs_evaluation_pipeline` | `EvaluationPipeline` with multiple datasets | [src](https://github.com/0xvasanth/cognis/blob/main/examples/observability/evaluation_pipeline.rs) |
+| `obs_evaluation_framework` | `EvalRunner` over a dataset of `EvalCase`s | [src](https://github.com/0xvasanth/cognis/blob/main/examples/observability/evaluation_framework.rs) |
+| `obs_evaluation_pipeline` | Multi-dataset eval flow with custom evaluators | [src](https://github.com/0xvasanth/cognis/blob/main/examples/observability/evaluation_pipeline.rs) |
 
 ## How to run
 
@@ -28,7 +28,7 @@ cargo run -p cognis-examples --example obs_evaluation_framework
 ## Pick a starting point
 
 - **Just want to see what's happening?** `obs_tracing` prints events to stdout.
-- **Building eval into CI?** `obs_evaluation_framework` is the smallest working harness.
+- **Building eval into CI?** `obs_evaluation_framework` is the smallest working harness — `EvalRunner` over a `Vec<EvalCase>`.
 - **Stacking observers?** `obs_callback_manager` shows how to multiplex.
 
 ## See also

--- a/docs/mintlify/get-started/quickstart.mdx
+++ b/docs/mintlify/get-started/quickstart.mdx
@@ -4,7 +4,7 @@ description: "Build a tool-calling agent in five minutes."
 sidebarTitle: "Quickstart"
 ---
 
-This guide walks you through building your first Cognis agent — a small assistant that can do arithmetic by calling a `Calculator` tool. By the end you'll have a binary that runs against any of seven LLM providers, switching with a single environment variable.
+This guide walks you through building your first Cognis agent — a small assistant that can do arithmetic by calling a `Calculator` tool. By the end you'll have a binary that runs against any of six LLM providers (OpenAI, Anthropic, Google, Ollama, Azure, OpenRouter), switching with a single environment variable.
 
 ## Prerequisites
 
@@ -19,7 +19,7 @@ cognis = { version = "0.3", features = ["openai", "ollama"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
-The `openai` and `ollama` features come on by default. Enable other providers with `anthropic`, `google`, `azure`, `openrouter`, or take everything with `all-providers`.
+The `openai` and `ollama` features come on by default. Enable others with `anthropic`, `google`, `azure`, or take everything with `all-providers`. OpenRouter uses the OpenAI wire format, so the `openai` feature already covers it — no separate flag.
 
 ## Step 2 — Set credentials
 
@@ -82,8 +82,7 @@ Cognis never reads `.env` files. Use your shell, `direnv`, or `envchain` — see
 ```rust src/main.rs
 use std::sync::Arc;
 use cognis::prelude::*;
-use cognis::{AgentBuilder, Calculator};
-use cognis_llm::Client;
+use cognis::{AgentBuilder, Calculator, Client};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/docs/mintlify/observability/evaluation.mdx
+++ b/docs/mintlify/observability/evaluation.mdx
@@ -1,119 +1,111 @@
 ---
 title: "Evaluation"
-description: "Run datasets through your agent, score the outputs, ship results to Langfuse."
+description: "Run datasets through any Runnable, score the outputs, ship results to your trace backend."
 sidebarTitle: "Evaluation"
 ---
 
-Evaluation closes the loop: you ran traces, you tracked cost, now you need to know *how good* the answers are. Cognis ships an evaluation framework under `cognis::eval` for offline runs over a dataset — pair it with [scores](/observability/prompts-scores) to push results into Langfuse.
+Evaluation closes the loop: you ran traces, you tracked cost, now you need to know *how good* the answers are. Cognis ships a small evaluation harness under `cognis::eval` for offline runs over a dataset — pair it with [scores](/observability/prompts-scores) to push results into Langfuse.
 
 ## Mental model
 
-An eval has four parts:
+Three moving parts:
 
-- **A dataset** — a list of `(input, expected)` pairs.
-- **A target** — the thing under test, usually an `Agent` or a `Runnable`.
-- **Scorers** — one or more functions that compare actual vs expected and return a `ScoreValue`.
-- **A reporter** — what you do with the results (print, write JSON, push to Langfuse).
+- **Cases** — `(input, expected)` pairs of type `EvalCase<I, O>`.
+- **A runnable under test** — anything `Runnable<I, O>`. An agent, a chain, or a custom impl.
+- **An evaluator** — `Evaluator<O>` produces a score in `[0.0, 1.0]` for an actual `O` against a reference `O`.
+
+`EvalRunner` invokes every case through the runnable, scores each output, and produces an `EvalReport`.
 
 ## Quick example
 
 ```rust
+use std::sync::Arc;
+use cognis::eval::{EvalCase, EvalRunner, ExactMatch};
 use cognis::prelude::*;
-use cognis::eval::{EvalCase, EvaluationFramework, /* … */};
 
 let cases = vec![
-    EvalCase::new("greeting", "Hi there", "Hello! How can I help?"),
-    EvalCase::new("math", "What is 2 + 2?", "4"),
-    // …
+    EvalCase::new("greeting".to_string(), "hello".to_string()).with_name("greet"),
+    EvalCase::new("math".to_string(), "4".to_string()).with_name("two-plus-two"),
 ];
 
-let mut framework = EvaluationFramework::new()
-    .with_target(my_agent)              // anything Runnable<Message, AgentResponse>
-    .with_scorer(/* exact-match scorer */)
-    .with_scorer(/* llm-as-judge scorer */);
+let runner = EvalRunner::new(
+    Arc::new(my_runnable),       // anything Runnable<String, String>
+    Arc::new(ExactMatch),        // built-in evaluator
+    cases,
+)
+.with_concurrency(8);
 
-let report = framework.run(cases).await?;
-println!("{:#?}", report);
+let report = runner.run().await?;
+println!("mean score: {:.2}", report.mean());
+println!("pass rate (>= 0.8): {:.2}", report.pass_rate(0.8));
 ```
 
-The `EvaluationFramework` runs each case (concurrent up to `max_concurrency`), collects results, and produces a report you can serialize, print, or feed to a CI gate.
+`EvalReport<O>` exposes `mean()`, `pass_rate(threshold)`, `passing(threshold)`, `best()`, `worst()`, plus the raw `rows: Vec<EvalRow<O>>`.
 
 Source: [`examples/observability/evaluation_framework.rs`](https://github.com/0xvasanth/cognis/blob/main/examples/observability/evaluation_framework.rs).
 
-## Pipelines
+## Built-in evaluators
 
-For larger eval workloads — multiple datasets, sliced reporting, regressions vs a baseline — use `EvaluationPipeline`. It composes scorers, datasets, and outputs into a reproducible flow.
+| Evaluator | Score |
+|---|---|
+| `ExactMatch` | `1.0` iff `actual == expected`, else `0.0` |
+| `Contains` | `1.0` iff the actual string contains the expected substring |
+| `LlmJudge` | Asks a `Client` to score the actual against the expected — useful when "exact match" isn't appropriate |
 
-```rust
-use cognis::eval::EvaluationPipeline;
+`LlmJudge` takes a `Client` plus a rubric prompt; see [`crates/cognis/src/eval/evaluators.rs`](https://github.com/0xvasanth/cognis/blob/main/crates/cognis/src/eval/evaluators.rs).
 
-let pipeline = EvaluationPipeline::new()
-    .with_target(my_agent)
-    .add_dataset("greeting", greeting_cases)
-    .add_dataset("math", math_cases)
-    .with_scorer(scorer_a)
-    .with_scorer(scorer_b)
-    .with_baseline(prior_report)        // optional: fail the run if regressions
-    .build();
+## Custom evaluators
 
-let summary = pipeline.run().await?;
-```
-
-Source: [`examples/observability/evaluation_pipeline.rs`](https://github.com/0xvasanth/cognis/blob/main/examples/observability/evaluation_pipeline.rs).
-
-## Scorers
-
-A scorer is a function (or struct with state) that returns a `ScoreValue`:
+The trait is one async method:
 
 ```rust
-use cognis::eval::{Scorer, ScoreContext};
-use cognis_trace::ScoreValue;
+use async_trait::async_trait;
+use cognis::eval::Evaluator;
+use cognis::Result;
 
-struct ExactMatch;
+struct LengthSimilar;
 
-#[async_trait::async_trait]
-impl Scorer for ExactMatch {
-    fn name(&self) -> &str { "exact_match" }
-    async fn score(&self, ctx: &ScoreContext<'_>) -> cognis::Result<ScoreValue> {
-        let ok = ctx.actual.trim() == ctx.expected.trim();
-        Ok(ScoreValue::Boolean(ok))
+#[async_trait]
+impl Evaluator<String> for LengthSimilar {
+    async fn score(&self, actual: &String, expected: &String) -> Result<f32> {
+        let diff = (actual.len() as f32 - expected.len() as f32).abs();
+        let scale = expected.len().max(1) as f32;
+        Ok((1.0 - diff / scale).max(0.0))
     }
 }
 ```
 
-Stack scorers — most evals run a fast deterministic scorer (exact match, length check) plus an LLM-as-judge scorer for nuanced quality.
+Stack evaluators by running multiple `EvalRunner`s over the same cases — most evals run a fast deterministic evaluator (exact match, length check) plus an `LlmJudge` for nuanced quality.
 
 ## Pushing scores to Langfuse
 
-Combine the eval framework with `LangfuseScorer` (see [Prompts and scores](/observability/prompts-scores)) to push every `ScoreRecord` produced by an eval into Langfuse, tied to the trace of that case.
+Combine the eval report with `LangfuseScorer` (see [Prompts and scores](/observability/prompts-scores)) to push every score record into Langfuse, tied to the trace of each case.
 
 ```rust
-let report = framework.run(cases).await?;
-for record in report.score_records() {
-    langfuse_scorer.submit(record).await?;
+use cognis_trace::{ScoreRecord, ScoreValue};
+use cognis_trace::exporters::langfuse::{LangfuseConfig, LangfuseScorer};
+
+let scorer = LangfuseScorer::new(LangfuseConfig::from_env()?)?;
+for row in &report.rows {
+    scorer.submit(ScoreRecord {
+        run_id: /* trace run_id from when the case was invoked */,
+        trace_id: None,
+        session_id: None,
+        name: "exact_match".into(),
+        value: ScoreValue::Numeric(row.score as f64),
+        comment: row.name.clone(),
+    }).await?;
 }
 ```
 
-Now Langfuse dashboards reflect eval outcomes alongside production runs.
-
-## Datasets
-
-`EvalCase` is the smallest unit — `(input, expected)` plus optional metadata. Build datasets in code, load from JSON, or pull from your own data store.
-
-```rust
-EvalCase::new("id", "input text", "expected output")
-    .with_metadata("category", "math")
-    .with_tag("regression-set");
-```
-
-Filter cases at run time with `framework.filter(|c| c.has_tag("regression-set"))`.
+Run cases under a tracing observer to get the `run_id` per case; see [Trace with Langfuse](/observability/langfuse) for the wiring.
 
 ## How it works
 
-- **Each case is its own run.** `run_id` per case correlates traces, metrics, and scores.
-- **Scoring runs after the target.** A failing target produces a record with the error in `actual`, which a scorer can flag.
-- **Concurrency follows `RunnableConfig::max_concurrency`.** For LLM-as-judge scorers, this is also where you bound the eval's own model calls.
-- **Reports are serializable.** Snapshot them, diff against baselines, gate CI on regressions.
+- **Two passes per run:** the runner invokes every case under a concurrency cap, then scores actuals against expecteds.
+- **Concurrency follows `with_concurrency(n)`** — defaults to 4. Tune for your provider's quota when the runnable is a `Client`-backed chain.
+- **Errors per case** propagate from `runner.run().await?`. Wrap your runnable with `with_max_retries` if you want transient errors absorbed.
+- **Reports are serializable** with `Serialize` impls; snapshot them in tests, diff against baselines, gate CI on regressions.
 
 ## See also
 

--- a/docs/mintlify/observability/evaluation.mdx
+++ b/docs/mintlify/observability/evaluation.mdx
@@ -86,10 +86,13 @@ use cognis_trace::{ScoreRecord, ScoreValue};
 use cognis_trace::exporters::langfuse::{LangfuseConfig, LangfuseScorer};
 
 let scorer = LangfuseScorer::new(LangfuseConfig::from_env()?)?;
-for row in &report.rows {
+for (row, run_id) in report.rows.iter().zip(case_run_ids) {
     scorer.submit(ScoreRecord {
-        run_id: /* trace run_id from when the case was invoked */,
-        trace_id: None,
+        run_id,
+        // Set at least one of `trace_id` or `session_id` — `LangfuseScorer`
+        // skips submission when both are None (a score with nothing to link
+        // to is dropped).
+        trace_id: Some(run_id),       // attach to the case's trace
         session_id: None,
         name: "exact_match".into(),
         value: ScoreValue::Numeric(row.score as f64),
@@ -98,14 +101,14 @@ for row in &report.rows {
 }
 ```
 
-Run cases under a tracing observer to get the `run_id` per case; see [Trace with Langfuse](/observability/langfuse) for the wiring.
+Run cases under a tracing observer to get the `run_id` per case (`case_run_ids` above); see [Trace with Langfuse](/observability/langfuse) for the wiring.
 
 ## How it works
 
 - **Two passes per run:** the runner invokes every case under a concurrency cap, then scores actuals against expecteds.
 - **Concurrency follows `with_concurrency(n)`** — defaults to 4. Tune for your provider's quota when the runnable is a `Client`-backed chain.
 - **Errors per case** propagate from `runner.run().await?`. Wrap your runnable with `with_max_retries` if you want transient errors absorbed.
-- **Reports are serializable** with `Serialize` impls; snapshot them in tests, diff against baselines, gate CI on regressions.
+- **Reports are read-only summaries.** `EvalReport` and `EvalRow` aren't `Serialize` today — for snapshotting against baselines, build your own thin record from `(name, score, actual)` and serialize that.
 
 ## See also
 

--- a/docs/mintlify/observability/prompts-scores.mdx
+++ b/docs/mintlify/observability/prompts-scores.mdx
@@ -76,7 +76,7 @@ Every run gets a `run_id`. Score it any time — during the run (in-band) or lat
 
 | `ScoreValue` | Use for |
 |---|---|
-| `Numeric(f32)` | quality, novelty, helpfulness — anything on a continuous scale |
+| `Numeric(f64)` | quality, novelty, helpfulness — anything on a continuous scale |
 | `Categorical(String)` | "good" / "bad" / "skip", custom labels |
 | `Boolean(bool)` | binary thumbs up/down |
 

--- a/docs/mintlify/patterns/hitl-approval.mdx
+++ b/docs/mintlify/patterns/hitl-approval.mdx
@@ -95,10 +95,10 @@ async fn main() -> Result<()> {
 
 ## How it works
 
-- **The approver runs *before* dispatch.** A reject means the tool never executes — the loop sees "rejected by operator" as the tool result.
+- **The approver runs *before* dispatch.** `with_approver(...)` wraps every registered tool in an `ApprovalGatedTool`. When the agent's dispatcher tries to run the tool, the wrapper consults the approver first.
+- **A `Reject` decision short-circuits the tool**, returning the rejection reason as the tool's output — the agent sees "rejected by operator" and can apologize, retry, or take a different path.
 - **`Edit` lets the human fix the model's args** without rejecting. Useful when the model picked the right tool but the wrong amount or recipient.
-- **The approver is `Arc<dyn Approver>`** because the same instance is used in two places — the builder's gate and the middleware. Sharing avoids state divergence.
-- **`HumanInTheLoop` is the middleware**, not the approver. The middleware enforces the gate inside the model-call wrapping; the approver is the policy.
+- **`Arc<dyn Approver>` is the shape passed in** — the builder takes ownership and uses the same instance for every gated tool, so the approver can hold state (a counter, a queue handle, an audit log) without divergence.
 
 ## Production approver
 

--- a/docs/mintlify/patterns/hitl-approval.mdx
+++ b/docs/mintlify/patterns/hitl-approval.mdx
@@ -19,9 +19,9 @@ An agent with two tools — one safe (`get_balance`), one sensitive (`transfer_f
 ## The approver
 
 ```rust
-use std::sync::Arc;
 use async_trait::async_trait;
-use cognis::tools::{Approver, ApprovalDecision};
+use cognis::tools::{Approver, Decision};
+use cognis::Result;
 use serde_json::Value;
 
 struct CliApprover {
@@ -30,13 +30,13 @@ struct CliApprover {
 
 #[async_trait]
 impl Approver for CliApprover {
-    async fn approve(&self, tool: &str, args: &Value) -> cognis::Result<ApprovalDecision> {
-        if !self.sensitive.contains(&tool) {
-            return Ok(ApprovalDecision::Approve);
+    async fn approve(&self, tool_name: &str, args: &Value) -> Result<Decision> {
+        if !self.sensitive.contains(&tool_name) {
+            return Ok(Decision::Approve);
         }
 
         println!("\n[approval needed]");
-        println!("  tool: {tool}");
+        println!("  tool: {tool_name}");
         println!("  args: {}", serde_json::to_string_pretty(args)?);
         print!("  approve? (y / n / e=edit): ");
         std::io::Write::flush(&mut std::io::stdout())?;
@@ -44,16 +44,16 @@ impl Approver for CliApprover {
         let mut line = String::new();
         std::io::stdin().read_line(&mut line)?;
         match line.trim() {
-            "y" | "yes" => Ok(ApprovalDecision::Approve),
+            "y" | "yes" => Ok(Decision::Approve),
             "e" | "edit" => {
                 print!("  new JSON args: ");
                 std::io::Write::flush(&mut std::io::stdout())?;
                 let mut edit = String::new();
                 std::io::stdin().read_line(&mut edit)?;
                 let new_args: Value = serde_json::from_str(edit.trim())?;
-                Ok(ApprovalDecision::Edit(new_args))
+                Ok(Decision::Edit { args: new_args })
             }
-            _ => Ok(ApprovalDecision::Reject("rejected by operator".into())),
+            _ => Ok(Decision::reject("rejected by operator")),
         }
     }
 }
@@ -65,8 +65,7 @@ impl Approver for CliApprover {
 use std::sync::Arc;
 use cognis::prelude::*;
 use cognis::AgentBuilder;
-use cognis::middleware::HumanInTheLoop;
-use cognis_llm::Client;
+use cognis::Client;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -78,8 +77,7 @@ async fn main() -> Result<()> {
         .with_llm(Client::from_env()?)
         .with_tool(Arc::new(GetBalanceTool))     // (your impls)
         .with_tool(Arc::new(TransferFundsTool))
-        .with_approver(approver.clone())
-        .middleware(HumanInTheLoop::new(approver))
+        .with_approver(approver)                 // wraps every registered tool
         .with_system_prompt(
             "You are a banking assistant. Use tools to inspect accounts and \
              move money. Confirm intent in plain English before any transfer.",
@@ -123,7 +121,7 @@ For long-running approvals (the human is asleep), persist the agent's state and 
 
 <CardGroup cols={2}>
   <Card title="Human-in-the-loop" icon="user-check" href="/building-agents/hitl">
-    Approver, ApprovalDecision, graph interrupts.
+    Approver, Decision, graph interrupts.
   </Card>
   <Card title="Tools" icon="screwdriver-wrench" href="/building-agents/tools">
     Define the tools being gated.

--- a/docs/mintlify/patterns/long-context.mdx
+++ b/docs/mintlify/patterns/long-context.mdx
@@ -98,7 +98,7 @@ Pair this with retrieval: rank summaries by relevance to a question, reorder, th
 | Concern | Add |
 |---|---|
 | Retries on transient errors | Wrap the client with `with_max_retries(3)`. |
-| Cost cap | `RateLimit::token_bucket(...)` middleware; or precompute token counts and refuse oversized inputs. |
+| Cost cap | `RateLimit::new(Arc::new(TokenBucket::new(rate, burst)))` in a `MiddlewarePipeline`; or precompute token counts and refuse oversized inputs. |
 | Caching | Hash chunks; skip the map call when the chunk has been seen. |
 | Monitoring | Wire `cognis-trace` so each map call is its own generation span — see [Trace with Langfuse](/observability/langfuse). |
 | Determinism | Set `temperature=0` (via `Client::builder().temperature(...)` or `ChatOptions`) for reproducible summaries in tests. |

--- a/docs/mintlify/patterns/research-assistant.mdx
+++ b/docs/mintlify/patterns/research-assistant.mdx
@@ -137,10 +137,10 @@ When you're ready to ship, layer on:
 | Concern | What to add |
 |---|---|
 | Real search | A Tavily / Brave / SerpAPI tool — see [Tools](/building-agents/tools). |
-| Cost control | `RateLimit::token_bucket(rate, burst)` and `ModelCallLimit` middleware on each agent. |
+| Cost control | `RateLimit::new(Arc::new(TokenBucket::new(rate, burst)))` and `ModelCallLimit::new(n)` in a `MiddlewarePipeline` around your `Client`. |
 | Tracing | Wire `cognis-trace` so each agent appears as a nested span in Langfuse. |
 | Caching | Cache search results with a `CachedRetriever`-style wrapper around the tool. |
-| Eval | Build an `EvaluationFramework` over a small set of known good questions, score with an LLM-as-judge. |
+| Eval | Build an `EvalRunner` over a small set of known good questions and an `LlmJudge` evaluator. |
 | Streaming UI | `orch.stream_events(...)` and forward `OnLlmToken` to your frontend — see [Patterns → Streaming UI](/patterns/streaming-ui). |
 
 ## Variations

--- a/docs/mintlify/patterns/streaming-ui.mdx
+++ b/docs/mintlify/patterns/streaming-ui.mdx
@@ -88,6 +88,7 @@ Add `axum`, `tokio`, `serde`, and `serde_json` to your `Cargo.toml`.
 ```js
 const res = await fetch("/chat", {
   method: "POST",
+  headers: { "Content-Type": "application/json" },   // Axum's Json extractor checks this
   body: JSON.stringify({ message: input.value }),
 });
 
@@ -100,13 +101,18 @@ while (true) {
   const { value, done } = await reader.read();
   if (done) break;
   buf += decoder.decode(value, { stream: true });
-  // Parse `event: …\ndata: …\n\n` frames.
+  // Parse `event: …\ndata: …\n\n` frames. SSE allows multiple data: lines per
+  // frame; concatenate them with \n.
   const frames = buf.split("\n\n");
   buf = frames.pop();
   for (const frame of frames) {
-    const [eventLine, dataLine] = frame.split("\n");
-    const eventType = eventLine.replace("event: ", "");
-    const data = dataLine.replace("data: ", "");
+    let eventType = "message";
+    const dataLines = [];
+    for (const line of frame.split("\n")) {
+      if (line.startsWith("event: ")) eventType = line.slice(7);
+      else if (line.startsWith("data: ")) dataLines.push(line.slice(6));
+    }
+    const data = dataLines.join("\n");
     if (eventType === "token") output.append(data);
     else if (eventType === "tool_start") sidebar.add(JSON.parse(data));
     // …

--- a/docs/mintlify/production/caching.mdx
+++ b/docs/mintlify/production/caching.mdx
@@ -52,16 +52,14 @@ The cache survives restarts and is shared across processes that point at the sam
 Anthropic and some others support marking the *start* of a prompt as cacheable on the provider side. You pay full price the first time, a fraction on subsequent calls. Use the `PromptCaching` middleware:
 
 ```rust
-use cognis::middleware::PromptCaching;
+use cognis::middleware::{PromptCaching, MiddlewarePipeline};
 
-let agent = AgentBuilder::new()
-    .with_llm(client)
-    .middleware(PromptCaching::default())
-    // …
-    .build()?;
+let pipelined = MiddlewarePipeline::new()
+    .push(PromptCaching::new())
+    .build(client);
 ```
 
-The middleware adds the right markers; the provider does the deduplication. Particularly powerful for agents with long, stable system prompts and tool definitions — those rarely change between turns.
+The middleware adds the right markers; the provider does the deduplication. Particularly powerful for agents with long, stable system prompts and tool definitions — those rarely change between turns. To wire this inside an `AgentBuilder` agent, see [Middleware → Wiring middleware into an agent](/building-agents/middleware#wiring-middleware-into-an-agent).
 
 ## How it composes
 
@@ -70,21 +68,21 @@ A typical stack:
 ```rust
 use std::time::Duration;
 use cognis::prelude::*;
-use cognis::middleware::{PromptCaching, ModelRetry};
+use cognis::middleware::{PromptCaching, ModelRetry, MiddlewarePipeline};
+use cognis_llm::Client;
 
-let resilient = Client::from_env()?
+let client = Client::from_env()?
     .with_memory_cache(|m: &Vec<Message>| /* key */ "todo".to_string())
     .with_max_retries(3)
     .with_timeout(Duration::from_secs(30));
 
-let agent = AgentBuilder::new()
-    .with_llm(resilient)
-    .middleware(PromptCaching::default())
-    .middleware(ModelRetry::exponential(3))   // outer retry — handles cache failures too
-    .build()?;
+let pipelined = MiddlewarePipeline::new()
+    .push(ModelRetry::new(3))                 // innermost: retry transient errors
+    .push(PromptCaching::new())               // outermost: mark cacheable
+    .build(client);
 ```
 
-Read top-to-bottom: serve from in-memory cache when possible, retry on failure, time out on hangs. Inside the agent, mark cacheable prompts and retry on transient errors.
+Read inside-out: serve from the in-memory cache when possible, mark cacheable prompts for the provider, retry on transient errors, time out on hangs.
 
 ## Embedder cache
 

--- a/docs/mintlify/production/caching.mdx
+++ b/docs/mintlify/production/caching.mdx
@@ -66,15 +66,19 @@ The middleware adds the right markers; the provider does the deduplication. Part
 A typical stack:
 
 ```rust
-use std::time::Duration;
 use cognis::prelude::*;
 use cognis::middleware::{PromptCaching, ModelRetry, MiddlewarePipeline};
 use cognis_llm::Client;
 
-let client = Client::from_env()?
-    .with_memory_cache(|m: &Vec<Message>| /* key */ "todo".to_string())
-    .with_max_retries(3)
-    .with_timeout(Duration::from_secs(30));
+// Two layers do similar jobs at different levels:
+//   - in-memory dedup of repeat calls -> Runnable wrapper on the Client
+//   - prompt-cache markers for the provider + retries -> middleware pipeline
+//
+// `MiddlewarePipeline::build` requires a raw `Client`, so wrap that *first*,
+// then layer the Runnable wrappers around the pipelined client when you
+// invoke it (or via `with_max_retries` on the Client surface for code that
+// uses Client directly without the pipeline).
+let client = Client::from_env()?;
 
 let pipelined = MiddlewarePipeline::new()
     .push(ModelRetry::new(3))                 // innermost: retry transient errors
@@ -82,7 +86,7 @@ let pipelined = MiddlewarePipeline::new()
     .build(client);
 ```
 
-Read inside-out: serve from the in-memory cache when possible, mark cacheable prompts for the provider, retry on transient errors, time out on hangs.
+Mark cacheable prompts for the provider, retry on transient errors. For an in-memory dedup cache on top, use `client.with_memory_cache(key_fn)` directly when calling the `Client` outside the pipeline, or layer your own caching middleware in the pipeline.
 
 ## Embedder cache
 

--- a/docs/mintlify/production/going-to-production.mdx
+++ b/docs/mintlify/production/going-to-production.mdx
@@ -11,7 +11,7 @@ This page is a checklist. Each section links to the deeper guide.
 ## Resilience
 
 - ✅ **Wrap the LLM client** with `with_max_retries(3)` and `with_timeout(Duration::from_secs(30))`.
-- ✅ **Add a fallback model** via `with_fallback(...)` or `ModelFallback::to(...)` middleware. A cheaper backup beats a 5xx.
+- ✅ **Add a fallback model** via `Client::with_fallback(...)` or `ModelFallback::new(backup_client)` middleware. A cheaper backup beats a 5xx.
 - ✅ **Retry on rate limits.** `RetryPolicy::new(n)` with backoff handles 429s correctly.
 - ✅ **Cap retry attempts.** Infinite retry is a bug. 3–5 attempts with exponential backoff.
 - ✅ **Cap loop iterations.** Always set `with_max_iterations(n)` on agents.
@@ -20,7 +20,7 @@ See [Resilience](/production/resilience) for the patterns.
 
 ## Rate and cost
 
-- ✅ **Rate-limit upstream.** `RateLimit::new(TokenBucket::per_minute(n))` with bucket sized to your provider tier.
+- ✅ **Rate-limit upstream.** `RateLimit::new(Arc::new(TokenBucket::new(rate_per_sec, burst)))` with bucket sized to your provider tier.
 - ✅ **Track cost.** Wire `cognis-trace` with `with_default_pricing()` so every call has a USD attached.
 - ✅ **Cap cost per run.** `ModelCallLimit` and `ToolCallLimit` middleware bound how much one user request can spend.
 - ✅ **Cache obvious repeats.** `CachedEmbeddings` for indexing; `with_memory_cache` for LLM calls; `PromptCaching` middleware for Anthropic-style prefix caching.
@@ -75,7 +75,7 @@ See [Streaming](/building-agents/streaming).
 ## Evals and CI
 
 - ✅ **Build a small golden set.** 30–100 cases of "I know what the answer should be."
-- ✅ **Run evals on every change.** `EvaluationFramework` over the golden set; gate CI on regressions.
+- ✅ **Run evals on every change.** `EvalRunner` over the golden set; gate CI on regressions.
 - ✅ **Push scores to Langfuse.** Tie eval scores to traces so you can drill from "this regressed" to "the trace that broke it."
 
 See [Evaluation](/observability/evaluation).
@@ -84,7 +84,7 @@ See [Evaluation](/observability/evaluation).
 
 - ✅ **Build with the right features.** `cargo build --release --features all-providers,langfuse,vectorstore-faiss` (adapt to your stack).
 - ✅ **Pin secrets in your runner's secret store.** Same env-var names as local dev.
-- ✅ **Health checks.** Wire a tiny `Client::builder().health_check()` endpoint so your platform's load balancer can detect bad pods.
+- ✅ **Health checks.** Wire a tiny endpoint that calls `client.provider().health_check().await` so your platform's load balancer can detect bad pods.
 - ✅ **Graceful shutdown.** Drain the trace handler, cancel in-flight requests, then exit.
 
 ## Cost containers
@@ -103,10 +103,9 @@ use std::time::Duration;
 use cognis::prelude::*;
 use cognis::AgentBuilder;
 use cognis::middleware::{
-    ModelRetry, ModelFallback, RateLimit, TokenBucket,
+    MiddlewarePipeline, ModelRetry, ModelFallback, RateLimit, TokenBucket,
     PromptCaching, PiiRedactor, Summarization, ModelCallLimit,
 };
-use cognis::observers::TracingObserver;          // or a Langfuse-bridged HandlerObserver
 use cognis_llm::Client;
 use cognis_graph::SqliteCheckpointer;
 
@@ -115,19 +114,32 @@ let primary = Client::from_env()?
     .with_timeout(Duration::from_secs(30));
 let backup = Client::builder().model("gpt-4o-mini").build()?;
 
+// 1. Wrap the LLM client with middleware. Innermost first, outermost last.
+let pipelined = MiddlewarePipeline::new()
+    .push(ModelFallback::new(backup))
+    .push(ModelRetry::new(3))
+    .push(Summarization::new(8))
+    .push(PromptCaching::new())
+    .push(PiiRedactor::new())
+    .push(ModelCallLimit::new(20))
+    .push(RateLimit::new(Arc::new(TokenBucket::new(1000.0, 60_000))))
+    .build(primary.clone());
+
+// 2. Persist agent graph state across processes via the checkpointer.
 let cp = Arc::new(SqliteCheckpointer::open("./state.db").await?);
+let custom_graph = cognis::default_react_graph()
+    .compile()?
+    .with_checkpointer(cp);
+
 let memory = SummaryBufferMemory::new(primary.clone(), 2000)
     .with_system("You are a careful assistant.");
 
 let agent = AgentBuilder::new()
+    // For middleware to wrap every model call inside the agent, see
+    // /building-agents/middleware#wiring-middleware-into-an-agent
+    // (build a custom LLMProvider that delegates to `pipelined`).
     .with_llm(primary)
-    .middleware(RateLimit::new(TokenBucket::per_minute(60_000)))
-    .middleware(ModelCallLimit::new(20))
-    .middleware(PiiRedactor::default())
-    .middleware(PromptCaching::default())
-    .middleware(Summarization::token_budget(8_000))
-    .middleware(ModelRetry::exponential(3))
-    .middleware(ModelFallback::to(backup))
+    .with_graph(custom_graph)
     .with_tools(my_tools)
     .with_memory(memory)
     .with_max_iterations(8)

--- a/docs/mintlify/production/going-to-production.mdx
+++ b/docs/mintlify/production/going-to-production.mdx
@@ -106,13 +106,17 @@ use cognis::middleware::{
     MiddlewarePipeline, ModelRetry, ModelFallback, RateLimit, TokenBucket,
     PromptCaching, PiiRedactor, Summarization, ModelCallLimit,
 };
-use cognis_llm::Client;
+use cognis_llm::{Client, provider::Provider};
 use cognis_graph::SqliteCheckpointer;
 
 let primary = Client::from_env()?
     .with_max_retries(3)
     .with_timeout(Duration::from_secs(30));
-let backup = Client::builder().model("gpt-4o-mini").build()?;
+let backup = Client::builder()
+    .provider(Provider::OpenAI)
+    .api_key(std::env::var("OPENAI_API_KEY")?)
+    .model("gpt-4o-mini")
+    .build()?;
 
 // 1. Wrap the LLM client with middleware. Innermost first, outermost last.
 let pipelined = MiddlewarePipeline::new()

--- a/docs/mintlify/production/resilience.mdx
+++ b/docs/mintlify/production/resilience.mdx
@@ -21,9 +21,13 @@ A production-grade Client:
 ```rust
 use std::time::Duration;
 use cognis::prelude::*;
-use cognis_llm::Client;
+use cognis_llm::{Client, provider::Provider};
 
-let backup = Client::builder().model("gpt-4o-mini").build()?;
+let backup = Client::builder()
+    .provider(Provider::OpenAI)
+    .api_key(std::env::var("OPENAI_API_KEY")?)
+    .model("gpt-4o-mini")
+    .build()?;
 
 let client = Client::from_env()?
     .with_max_retries(3)
@@ -52,10 +56,14 @@ For policies that apply on every model call regardless of caller, use the middle
 ```rust
 use std::sync::Arc;
 use cognis::middleware::{ModelRetry, ModelFallback, RateLimit, TokenBucket, MiddlewarePipeline};
-use cognis_llm::Client;
+use cognis_llm::{Client, provider::Provider};
 
 let primary = Client::from_env()?;
-let backup  = Client::builder().model("gpt-4o-mini").build()?;
+let backup  = Client::builder()
+    .provider(Provider::OpenAI)
+    .api_key(std::env::var("OPENAI_API_KEY")?)
+    .model("gpt-4o-mini")
+    .build()?;
 
 // Push order: innermost first, outermost last.
 let pipelined = MiddlewarePipeline::new()

--- a/docs/mintlify/production/resilience.mdx
+++ b/docs/mintlify/production/resilience.mdx
@@ -23,15 +23,15 @@ use std::time::Duration;
 use cognis::prelude::*;
 use cognis_llm::Client;
 
-let primary = Client::from_env()?
-    .with_max_retries(3)
-    .with_timeout(Duration::from_secs(30));
+let backup = Client::builder().model("gpt-4o-mini").build()?;
 
-let backup_client = Client::builder().model("gpt-4o-mini").build()?;
-let client = primary.with_fallback(backup_client);
+let client = Client::from_env()?
+    .with_max_retries(3)
+    .with_timeout(Duration::from_secs(30))
+    .with_fallback(backup);
 ```
 
-The chain reads top-to-bottom: try the primary three times with a 30s timeout; if all retries fail, try the backup once.
+The chain reads top-to-bottom: try the primary three times with a 30s timeout; if all retries fail, fall back to a cheaper backup.
 
 ## Wrappers reference
 
@@ -47,18 +47,22 @@ For more, see [Runnables → Wrappers](/core-ideas/runnables#wrappers).
 
 ## Middleware reference
 
-Inside an agent loop, prefer middleware so policy applies everywhere uniformly:
+For policies that apply on every model call regardless of caller, use the middleware pipeline. Build a `PipelinedClient` and either use it directly or feed it through a custom provider when you need it inside an `AgentBuilder` agent — see [Middleware → Wiring middleware into an agent](/building-agents/middleware#wiring-middleware-into-an-agent).
 
 ```rust
-use cognis::middleware::{ModelRetry, ModelFallback, RateLimit, TokenBucket};
+use std::sync::Arc;
+use cognis::middleware::{ModelRetry, ModelFallback, RateLimit, TokenBucket, MiddlewarePipeline};
+use cognis_llm::Client;
 
-let agent = AgentBuilder::new()
-    .with_llm(primary)
-    .middleware(RateLimit::new(TokenBucket::per_minute(60_000)))
-    .middleware(ModelRetry::exponential(3))
-    .middleware(ModelFallback::to(backup))
-    // …
-    .build()?;
+let primary = Client::from_env()?;
+let backup  = Client::builder().model("gpt-4o-mini").build()?;
+
+// Push order: innermost first, outermost last.
+let pipelined = MiddlewarePipeline::new()
+    .push(ModelFallback::new(backup))
+    .push(ModelRetry::new(3))
+    .push(RateLimit::new(Arc::new(TokenBucket::new(1000.0, 60_000))))
+    .build(primary);
 ```
 
 | Middleware | Effect |
@@ -66,11 +70,11 @@ let agent = AgentBuilder::new()
 | `ModelRetry` | Retry transient errors and 429s with backoff. |
 | `ModelFallback` | Fall through to a backup model. |
 | `Recovery` (`FixedRecovery`, `FnRecovery`) | Custom recovery on errors. |
-| `RateLimit` (`TokenBucket`) | Rate-limit per minute / per second. |
-| `ModelCallLimit`, `ToolCallLimit` | Hard caps per run. |
+| `RateLimit` (`TokenBucket`, `SlidingWindow`, `CostBased`, `Composite`) | Rate-limit per minute / per second / by cost. |
+| `ModelCallLimit`, `ToolCallLimit` | Hard caps per pipeline run. |
 | `ToolRetry` (`ToolRetryClassifier`) | Retry tool calls the model emitted that failed. |
 
-The order is the chain order. `RateLimit` first means retries don't bypass it. See [Middleware](/building-agents/middleware) for the full catalog.
+The pipeline runs **outside-in**: the *most-recently-pushed* layer is the outermost wrapper. So `RateLimit` pushed last means the limiter sees every retry attempt. See [Middleware](/building-agents/middleware) for the full catalog.
 
 ## Retry policies
 
@@ -96,8 +100,7 @@ Exponential backoff with jitter is the right default for rate-limited APIs — y
 
 | Limiter | Behavior |
 |---|---|
-| `TokenBucket::per_minute(n)` | Refill at `n` tokens/min, with a configurable burst. Best general-purpose. |
-| `TokenBucket::per_second(n)` | Tighter window when latency budget matters. |
+| `TokenBucket::new(rate_per_sec, burst)` | Refill at `rate_per_sec` tokens/sec with a configurable burst. Best general-purpose. |
 | Sliding-window | Stricter over a fixed window — useful for compliance bounds. |
 | Cost-based | Charges *cost*, not call count. Lets cheap calls flow but throttles expensive ones. |
 | Composite | Combine multiple limiters (per-second AND per-minute AND per-day). |
@@ -109,7 +112,7 @@ For provider-specific quotas (e.g., OpenAI's per-org TPM), match the bucket size
 Some failures aren't transient. The model emitted bad JSON. The tool returned a 4xx your code can fix. Use **recovery middleware** for these:
 
 ```rust
-use cognis::middleware::{Recovery, FnRecovery};
+use cognis::middleware::{Recovery, FnRecovery, MiddlewarePipeline};
 
 let recovery = FnRecovery::new(|err, ctx| async move {
     // Decide based on the error.
@@ -117,18 +120,17 @@ let recovery = FnRecovery::new(|err, ctx| async move {
     todo!()
 });
 
-let agent = AgentBuilder::new()
-    .with_llm(client)
-    .middleware(Recovery::new(recovery))
-    .build()?;
+let pipelined = MiddlewarePipeline::new()
+    .push(Recovery::new(recovery))
+    .build(client);
 ```
 
-Recovery sees the error and the call context. It can synthesize a response, re-prompt with a fix, or escalate.
+Recovery sees the error and the call context. It can synthesize a response, re-prompt with a fix, or escalate. To use it inside an `AgentBuilder` agent, see the bridging pattern in [Middleware → Wiring middleware into an agent](/building-agents/middleware#wiring-middleware-into-an-agent).
 
 ## How it works
 
 - **Wrappers compose by re-wrapping.** `client.with_max_retries(3).with_timeout(d)` builds nested Runnables — types are explicit at every layer.
-- **Middleware runs in declaration order, outermost first.** `RateLimit → ModelRetry → ModelFallback` means the limiter sees the original call (not retries), the retry tries fallbacks each attempt, the fallback only kicks in after retries are exhausted.
+- **Middleware runs outside-in: most-recently-pushed is outermost.** `pipeline.push(ModelFallback).push(ModelRetry).push(RateLimit)` means the rate limiter sees the original call, then retry runs (each retry hits the limiter again), then fallback fires only when retries are exhausted.
 - **Errors carry structure.** `CognisError::RateLimited { retry_after_ms }` lets retry policy honor the provider's hint. `CognisError::ProviderError { provider, message, .. }` distinguishes between provider classes.
 - **Cancellation is cooperative.** All wrappers honor `RunnableConfig::cancel_token` and `deadline`.
 

--- a/docs/mintlify/production/security.mdx
+++ b/docs/mintlify/production/security.mdx
@@ -24,58 +24,52 @@ The framework provides hooks; *what* counts as PII or *which* tools are allowed 
 `PiiRedactor` masks known PII patterns (emails, phone numbers, credit-card-like sequences, common identifiers) before any prompt leaves Cognis:
 
 ```rust
-use cognis::middleware::PiiRedactor;
+use cognis::middleware::{PiiRedactor, MiddlewarePipeline};
 
-let agent = AgentBuilder::new()
-    .with_llm(client)
-    .middleware(PiiRedactor::default())
-    // …
-    .build()?;
+let pipelined = MiddlewarePipeline::new()
+    .push(PiiRedactor::new())
+    .build(client);
 ```
 
 For domain-specific patterns, `RegexRedactor` accepts your own patterns:
 
 ```rust
-use cognis::middleware::RegexRedactor;
+use cognis::middleware::{RegexRedactor, MiddlewarePipeline};
 
 let redactor = RegexRedactor::new()
     .add_pattern(r"\bACCT-\d{10}\b", "<ACCOUNT>")
     .add_pattern(r"\bSSN-\d{3}-\d{2}-\d{4}\b", "<SSN>");
 
-let agent = AgentBuilder::new()
-    .with_llm(client)
-    .middleware(redactor)
-    // …
-    .build()?;
+let pipelined = MiddlewarePipeline::new()
+    .push(redactor)
+    .build(client);
 ```
 
-Combine — `PiiRedactor` for the obvious, `RegexRedactor` for your own patterns. Order doesn't matter much; both run before the request hits the wire.
+Combine — `PiiRedactor` for the obvious, `RegexRedactor` for your own patterns. To wire either into an `AgentBuilder` agent, see [Middleware → Wiring middleware into an agent](/building-agents/middleware#wiring-middleware-into-an-agent).
 
 ## Tool deny-lists and allow-lists
 
-Restrict which tools the agent may call at runtime:
+Restrict which tools the model is offered at request time, via the middleware pipeline:
 
 ```rust
-use cognis::middleware::{ToolAllowList, ToolDenyList};
+use cognis::middleware::{ToolAllowList, ToolDenyList, MiddlewarePipeline};
 
 // Belt:
-let agent = AgentBuilder::new()
-    .with_llm(client)
-    .with_tools(my_tools)
-    .middleware(ToolAllowList::new(vec!["search", "calculator"]))
-    .build()?;
+let pipelined_allow = MiddlewarePipeline::new()
+    .push(ToolAllowList::new(vec!["search".into(), "calculator".into()]))
+    .build(client.clone());
 
 // Suspenders:
-let agent = AgentBuilder::new()
-    .with_llm(client)
-    .with_tools(my_tools)
-    .middleware(ToolDenyList::new(vec!["execute_shell", "delete_account"]))
-    .build()?;
+let pipelined_deny = MiddlewarePipeline::new()
+    .push(ToolDenyList::new(vec!["execute_shell".into(), "delete_account".into()]))
+    .build(client);
 ```
 
 Why two? Defense in depth. Allow-lists are enumerable from the registered tools (model can't call what's not registered), but deny-lists guard against accidental future registrations.
 
-`LimitTools::new(n)` caps how many tool definitions are sent in any single model call — useful when you have a large tool registry and want the model to focus.
+`LimitTools(n)` caps how many tool definitions are sent in any single model call — useful when you have a large tool registry and want the model to focus.
+
+For tool-call **approval gating** (require human sign-off before specific tools run, regardless of allow-list), use `Approver` + `AgentBuilder::with_approver` — see [Human-in-the-loop](/building-agents/hitl).
 
 ## Human-in-the-loop for the riskiest tools
 

--- a/docs/mintlify/reference/api/cognis-rag.mdx
+++ b/docs/mintlify/reference/api/cognis-rag.mdx
@@ -79,12 +79,14 @@ All implement `VectorStore`:
 
 ```rust
 pub trait VectorStore: Send + Sync {
-    async fn add_texts(&mut self, texts: Vec<String>, ids: Option<Vec<String>>) -> Result<Vec<String>>;
-    async fn add_vectors(&mut self, vectors: Vec<(String, Vec<f32>, Metadata)>) -> Result<()>;
+    async fn add_texts(&mut self, texts: Vec<String>, metadata: Option<Vec<HashMap<String, Value>>>) -> Result<Vec<String>>;
+    async fn add_vectors(&mut self, vectors: Vec<Vec<f32>>, texts: Vec<String>, metadata: Option<Vec<HashMap<String, Value>>>) -> Result<Vec<String>>;
     async fn similarity_search(&self, query: &str, k: usize) -> Result<Vec<SearchResult>>;
-    async fn similarity_search_by_vector(&self, vector: &[f32], k: usize) -> Result<Vec<SearchResult>>;
-    async fn similarity_search_with_filter(&self, query: &str, k: usize, filter: Filter) -> Result<Vec<SearchResult>>;
+    async fn similarity_search_by_vector(&self, query_vector: Vec<f32>, k: usize) -> Result<Vec<SearchResult>>;
+    async fn similarity_search_with_filter(&self, query: &str, k: usize, filter: &Filter) -> Result<Vec<SearchResult>>;
     async fn delete(&mut self, ids: Vec<String>) -> Result<()>;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool { self.len() == 0 }
 }
 ```
 

--- a/docs/mintlify/reference/api/cognis-trace.mdx
+++ b/docs/mintlify/reference/api/cognis-trace.mdx
@@ -134,14 +134,14 @@ impl LangfusePromptClient {
 
 ```rust
 pub enum ScoreValue {
-    Numeric(f32),
+    Numeric(f64),
     Categorical(String),
     Boolean(bool),
 }
 
 pub struct ScoreRecord {
     pub run_id: Uuid,
-    pub trace_id: Option<String>,
+    pub trace_id: Option<Uuid>,
     pub session_id: Option<String>,
     pub name: String,
     pub value: ScoreValue,

--- a/docs/mintlify/reference/api/cognis.mdx
+++ b/docs/mintlify/reference/api/cognis.mdx
@@ -32,7 +32,7 @@ The umbrella crate. Most apps depend on this and write `use cognis::prelude::*;`
 | `agent_bus` | `AgentBus`, `Subscription`, `SubscribeError`. |
 | `agent_events` | `AgentEvent`, `AgentEventBus`, `EventSubscription`, `DEFAULT_EVENTS_TOPIC`. |
 | `backend` | `Backend`, `InMemoryStorageBackend`, `LocalFsStorageBackend`, `SandboxedFsBackend`, `MemoryBackend`. |
-| `eval` | `EvaluationFramework`, `EvaluationPipeline`, `EvalCase`, `Scorer`, `ScoreContext`. |
+| `eval` | `EvalRunner`, `EvalCase`, `EvalRow`, `EvalReport`, `Evaluator` trait, plus built-in `ExactMatch`, `Contains`, `LlmJudge`. |
 | `history` | Conversation persistence helpers. |
 | `middleware` | The full middleware catalog (see [Middleware](/building-agents/middleware)). |
 | `multi_agent` | `MultiAgentOrchestrator`, `Sequential`, `Supervisor`, `ParallelVote`, `RoundRobin`, `HandoffStrategy`. |
@@ -42,7 +42,7 @@ The umbrella crate. Most apps depend on this and write `use cognis::prelude::*;`
 | `session` | `Session`, `SessionStore`, `InMemorySessionStore`. |
 | `skills` | Reusable agent skills. |
 | `telemetry` | Lightweight metrics. |
-| `tools` | Built-in tools — `Calculator`, `FilesystemTool`, `HttpRequest`, `JsonQuery`, `OpenApiTool`, `PythonRepl`, `HumanTool`. Plus `ToolOrchestrator`, `ExecutionPlan`, `ToolStep`. |
+| `tools` | Built-in tools — `Calculator`, file tools (`FileReadTool`/`FileWriteTool`/`FileEditTool`/`FileListTool`/`FileGlobTool`/`FileGrepTool`/`FileExistsTool`), `JsonQueryTool`, `PythonReplTool`, `HumanTool`, `ShellTool`, `SubAgentTool`, `RetrieverTool`, `WikipediaTool`. Plus `ToolOrchestrator`, `ExecutionPlan`, `ToolStep`, and the approval primitives (`Approver`, `Decision`, `AllowList`, `AutoApprove`, `RejectAll`, `ApprovalGatedTool`). HTTP / OpenAPI / web-search tools (`HttpRequest`, `OpenApiToolset`, `WebSearchTool`, `TavilyProvider*`) are gated behind the `tools-http` feature. |
 
 ## prelude
 

--- a/docs/mintlify/reference/api/cognis.mdx
+++ b/docs/mintlify/reference/api/cognis.mdx
@@ -42,7 +42,7 @@ The umbrella crate. Most apps depend on this and write `use cognis::prelude::*;`
 | `session` | `Session`, `SessionStore`, `InMemorySessionStore`. |
 | `skills` | Reusable agent skills. |
 | `telemetry` | Lightweight metrics. |
-| `tools` | Built-in tools — `Calculator`, file tools (`FileReadTool`/`FileWriteTool`/`FileEditTool`/`FileListTool`/`FileGlobTool`/`FileGrepTool`/`FileExistsTool`), `JsonQueryTool`, `PythonReplTool`, `HumanTool`, `ShellTool`, `SubAgentTool`, `RetrieverTool`, `WikipediaTool`. Plus `ToolOrchestrator`, `ExecutionPlan`, `ToolStep`, and the approval primitives (`Approver`, `Decision`, `AllowList`, `AutoApprove`, `RejectAll`, `ApprovalGatedTool`). HTTP / OpenAPI / web-search tools (`HttpRequest`, `OpenApiToolset`, `WebSearchTool`, `TavilyProvider*`) are gated behind the `tools-http` feature. |
+| `tools` | Built-in tools — `Calculator`, file tools (`FileReadTool`/`FileWriteTool`/`FileEditTool`/`FileListTool`/`FileGlobTool`/`FileGrepTool`/`FileExistsTool`), `JsonQueryTool`, `PythonReplTool`, `HumanTool`, `ShellTool`, `SubAgentTool`, `RetrieverTool`. Plus `ToolOrchestrator`, `ExecutionPlan`, `ToolStep`, and the approval primitives (`Approver`, `Decision`, `AllowList`, `AutoApprove`, `RejectAll`, `ApprovalGatedTool`). HTTP / OpenAPI / web-search / Wikipedia tools (`HttpRequest`, `OpenApiToolset`, `WebSearchTool`, `TavilyProvider*`, `WikipediaTool`) are gated behind the `tools-http` feature. |
 
 ## prelude
 


### PR DESCRIPTION
## Summary

Follow-up to #31 addressing the 27 review findings cubic posted. Verified each one against the v0.3 source before fixing — all 27 were correct or partially correct, none rejected. Touches 23 docs pages.

## Highlights

**Compile-breaking corrections (P1):**

- `middleware.mdx` — `AgentBuilder` has no `.middleware()` method in v0.3. Rewrote to show `MiddlewarePipeline::new().push(...).build(client)`, with a dedicated section on bridging into `AgentBuilder` via a custom `LLMProvider`. Fixed `Middleware` trait signature (`call`, `Arc<dyn Next>`, `next.invoke`). Corrected ordering: most-recently-pushed is outermost.
- `multi-agent.mdx` — Supervisor is single-hop (not cycling). `ParallelVote` has no quorum parameter (`Consensus` does). `RoundRobin` is load-balancing across replicas, not iterative debate. `HandoffStrategy` has one required method (`run`), not two.
- `hitl.mdx`, `hitl-approval.mdx` — `HumanInTheLoop` takes a `HumanResponder` (not `Approver`). Tool approval is `with_approver` + `Decision` enum (not `ApprovalDecision`).
- `evaluation.mdx`, `cognis.mdx`, `examples/observability.mdx` — Rewrote around the real exports: `EvalRunner`, `Evaluator`, `EvalCase`, `EvalReport`. Dropped non-existent `EvaluationFramework` / `EvaluationPipeline` / `ScoreContext`.

**Type/sig fixes (P2):**

- `cognis-trace.mdx`, `prompts-scores.mdx` — `ScoreValue::Numeric(f64)`, `ScoreRecord.trace_id: Option<Uuid>`.
- `cognis-rag.mdx`, `embeddings.mdx`, `adding-a-vector-store.mdx` — Real `VectorStore` signatures: `add_texts` takes metadata (not ids); `add_vectors` takes three `Vec<...>` args; `similarity_search_with_filter` takes `&Filter`.
- `adding-a-provider.mdx` — `Provider::OpenAi` → `Provider::OpenAI`.
- `quickstart.mdx` — "seven providers" → six. `use cognis::Client;` (no explicit `cognis-llm` dep needed). Clarified that openrouter shares the openai feature flag.
- `streaming-ui.mdx` — Added `Content-Type: application/json` on the fetch. Fixed SSE parsing to walk every line (handles multi-line `data:`).
- `going-to-production.mdx` — `health_check()` is on `client.provider()`, not `Client::builder()`. The reference production stack now actually attaches the SQLite checkpointer to the agent's compiled graph.
- `resilience.mdx`, `caching.mdx`, `security.mdx`, plus three patterns pages — Replaced every non-existent constructor (`RateLimit::token_bucket`, `TokenBucket::per_minute`, `ModelRetry::exponential`, `ModelFallback::to`, etc.) with the real one.

**Misc (P3):**

- `ways-to-contribute.mdx` — Structure listing now mentions all four tabs (Learn / Reference / Examples / Contribute).
- `memory.mdx` — Clarified memory is written *after* run completes (not incrementally), and that graph checkpointers persist graph state, not arbitrary `Memory` backend internals.
- `cognis.mdx` (tools row) — Listed real tool exports and noted that HTTP / OpenAPI / web-search tools are gated behind `tools-http`.

## Test plan

- [x] `grep` confirms zero references to non-existent APIs (`ApprovalDecision`, `ModelRetry::exponential`, `ModelFallback::to`, `TokenBucket::per_minute`, `RateLimit::token_bucket`, `EvaluationFramework`, `EvaluationPipeline`, `ScoreContext`, `Numeric(f32)`, `Provider::OpenAi`, `.middleware(`).
- [x] All 60+ internal cross-links still resolve.
- [ ] Mintlify preview (auto-deploys) renders new pages without parse errors.
- [ ] Reviewer to spot-check the rewritten middleware page — the bridging-into-AgentBuilder pattern is a power-user shape and the example code is non-trivial.

## Notes

- Verifier subagent inverted verdicts on a couple of items (cognis-trace types, vector-store sigs, quickstart imports). Direct source check confirmed cubic was right; fixed.
- No code changes — only `docs/mintlify/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns 23 Mintlify docs pages with v0.3 APIs and fixes 27 review findings plus 7 follow‑up issues. Removes references to non-existent APIs and shows the correct patterns for middleware, HITL, multi-agent, evals, vector stores, and production usage.

- **Bug Fixes**
  - Middleware: `AgentBuilder` has no `.middleware()`. Shows `MiddlewarePipeline::new().push(...).build(client)` and how to bridge into an agent via a custom `LLMProvider`. Fixed `Middleware::call` signature (`Arc<dyn Next>`, `next.invoke`) and clarified push order (most-recently-pushed is outermost). Dropped nonexistent `pipelined.into_client()`; examples compile by setting `.provider(...)` and `.api_key(...)` on backup clients.
  - HITL: Tool approval is `AgentBuilder::with_approver` using `Decision` (`Approve`, `Reject`, `Edit`). `HumanInTheLoop` uses a `HumanResponder` for transcript-level pauses. Removed the outdated note implying middleware enforces tool approval.
  - Multi-agent: Supervisor is single-hop. `ParallelVote` has no quorum (use `Consensus` for that). `RoundRobin` load-balances across replicas. `HandoffStrategy` requires `run(...)` (single method).
  - Evaluation: Rewrote around `EvalRunner`, `Evaluator`, `EvalCase`, `EvalReport`. Removed `EvaluationFramework`/`EvaluationPipeline`/`ScoreContext`. Langfuse example now sets `trace_id`; notes that `EvalReport`/`EvalRow` aren’t `Serialize` today.
  - Vector stores: Real `VectorStore` signatures (`add_texts` takes metadata; `add_vectors` takes vectors + texts + metadata; `similarity_search_by_vector(Vec<f32>)`; `similarity_search_with_filter(&Filter)`). Added `len()`/`is_empty()` where relevant.
  - Production and misc: Replaced fake constructors with real ones (`RateLimit::new(Arc::new(TokenBucket::new(...)))`, `ModelRetry::new(n)`, `ModelFallback::new(client)`). `ScoreValue::Numeric(f64)`, `ScoreRecord.trace_id: Option<Uuid>`. `Provider::OpenAI`. Quickstart notes six providers and uses `use cognis::Client`. SSE demo adds `Content-Type` and handles multi-line `data:`. Health checks call `client.provider().health_check()`. Checkpointer attached to the compiled graph. Memory is appended after `run` completes. `WikipediaTool` is gated behind the `tools-http` feature. Caching page clarifies pipeline layering and uses a raw `Client` with `MiddlewarePipeline`.

- **Migration**
  - Use a `MiddlewarePipeline` around your `Client`; to apply inside `AgentBuilder`, create a custom `LLMProvider` that delegates to the pipelined client.
  - Gate tools with `with_approver` and return `Decision` values; keep `HumanInTheLoop` for transcript-level pauses only.
  - Update any code/docs depending on old multi-agent assumptions: no supervisor cycling; `Consensus` for quorums; `RoundRobin` is for load-balancing.
  - Replace eval usages of `EvaluationFramework`/`Pipeline` with `EvalRunner` and an `Evaluator` (e.g., `ExactMatch`, `LlmJudge`). When exporting to Langfuse, set at least one of `trace_id` or `session_id`.
  - Update tracing types: use `ScoreValue::Numeric(f64)` and `ScoreRecord.trace_id: Option<Uuid>`.
  - Switch rate limit and fallback constructors to the real ones; move health checks to `client.provider().health_check()`. Ensure backup `Client::builder()` examples set `.provider(...)` and `.api_key(...)`. Use `tools-http` to access HTTP/OpenAPI/web-search/Wikipedia tools.

<sup>Written for commit 2de2ee002eda8de81326662d96675815842ffca0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

