### PR TITLE
feat: DedupVectorStore + LlmExtractor + FactExtractor (#40, #41)

### DIFF
--- a/crates/cognis-rag/src/lib.rs
+++ b/crates/cognis-rag/src/lib.rs
@@ -77,16 +77,16 @@ pub use splitters::{
     TokenAwareSplitter, Tokenizer,
 };
 pub use transformers::{Dedup, Enrichment, LongContextReorder, MetadataTransformer};
+pub use vectorstore::{
+    normalized_fingerprint, DedupVectorStore, Filter, InMemoryVectorStore, SearchResult,
+    VectorStore,
+};
 #[cfg(feature = "vectorstore-chroma")]
 pub use vectorstore::{ChromaBuilder, ChromaProvider};
 #[cfg(feature = "vectorstore-faiss")]
 pub use vectorstore::{
     FaissConfig, FaissIndex, FaissIndexType, FaissMetric, FaissVectorStore, FlatIndex, HNSWIndex,
     IVFFlatIndex,
-};
-pub use vectorstore::{
-    normalized_fingerprint, DedupVectorStore, Filter, InMemoryVectorStore, SearchResult,
-    VectorStore,
 };
 #[cfg(feature = "vectorstore-pinecone")]
 pub use vectorstore::{PineconeBuilder, PineconeProvider};

--- a/crates/cognis-rag/src/lib.rs
+++ b/crates/cognis-rag/src/lib.rs
@@ -84,7 +84,10 @@ pub use vectorstore::{
     FaissConfig, FaissIndex, FaissIndexType, FaissMetric, FaissVectorStore, FlatIndex, HNSWIndex,
     IVFFlatIndex,
 };
-pub use vectorstore::{Filter, InMemoryVectorStore, SearchResult, VectorStore};
+pub use vectorstore::{
+    normalized_fingerprint, DedupVectorStore, Filter, InMemoryVectorStore, SearchResult,
+    VectorStore,
+};
 #[cfg(feature = "vectorstore-pinecone")]
 pub use vectorstore::{PineconeBuilder, PineconeProvider};
 #[cfg(feature = "vectorstore-qdrant")]

--- a/crates/cognis-rag/src/vectorstore/dedup.rs
+++ b/crates/cognis-rag/src/vectorstore/dedup.rs
@@ -1,0 +1,519 @@
+//! Content-deduplicating [`VectorStore`] decorator.
+//!
+//! [`DedupVectorStore`] wraps any [`VectorStore`] and silently drops
+//! documents whose normalised content fingerprint has already been seen.
+//! Use it whenever the same fact may arrive multiple times (agent loops,
+//! repeated indexing runs, multi-source pipelines) and you want the index
+//! to stay clean without extra bookkeeping in application code.
+//!
+//! The default fingerprint normalises text (lowercase + collapsed
+//! whitespace) then applies FNV-1a 128-bit — the same algorithm used by
+//! [`crate::record_manager::fingerprint`]. Supply a custom function via
+//! [`DedupVectorStore::with_fingerprint`] when your dedup key is not
+//! derived from raw text (e.g. a document ID or a composite hash).
+
+use std::collections::HashSet;
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+
+use cognis_core::Result;
+
+use super::{Filter, SearchResult, VectorStore};
+
+// ---------------------------------------------------------------------------
+// Default fingerprint
+// ---------------------------------------------------------------------------
+
+/// Normalise `text` (lowercase + collapse whitespace) then fingerprint with
+/// FNV-1a 128-bit. Two pieces of text that differ only in case or spacing
+/// produce the same fingerprint and are treated as duplicates.
+///
+/// The algorithm is the same as [`crate::record_manager::fingerprint`] but
+/// applied to the normalised form so that case / whitespace variants
+/// collapse. Exposed as a public function so callers can pre-compute
+/// fingerprints when seeding an existing store (see
+/// [`DedupVectorStore::with_seen`]).
+pub fn normalized_fingerprint(text: &str) -> String {
+    // Normalise: lowercase + single-space whitespace runs.
+    let normalised = text
+        .split_whitespace()
+        .map(|w| w.to_lowercase())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    // FNV-1a 128-bit (published constants, public domain).
+    const OFFSET: u128 = 0x6c62272e07bb014262b821756295c58d;
+    const PRIME: u128 = 0x0000000001000000000000000000013b;
+    let mut h: u128 = OFFSET;
+    for b in normalised.as_bytes() {
+        h ^= u128::from(*b);
+        h = h.wrapping_mul(PRIME);
+    }
+    format!("{h:032x}")
+}
+
+// ---------------------------------------------------------------------------
+// DedupVectorStore
+// ---------------------------------------------------------------------------
+
+/// A [`VectorStore`] decorator that silently skips documents whose
+/// normalised content fingerprint is already in the seen-set.
+///
+/// # Type parameters
+///
+/// * `S` — the inner [`VectorStore`] implementation.
+/// * `F` — the fingerprint function `fn(&str) -> String`. Defaults to
+///   [`normalized_fingerprint`] (lowercase + whitespace-collapse + FNV-1a).
+///   Provide a custom function via [`DedupVectorStore::with_fingerprint`]
+///   when you need a different dedup key (e.g. document ID, composite hash).
+///
+/// # Persistence across restarts
+///
+/// The seen-set lives in memory and is cleared on process restart. To
+/// survive restarts, query your storage for existing content fingerprints
+/// on startup and pass them to [`DedupVectorStore::with_seen`]. The
+/// [`normalized_fingerprint`] function is public so you can pre-compute
+/// hashes from stored records.
+///
+/// ```rust,ignore
+/// let hashes = db.query_all("SELECT content_hash FROM facts").await?;
+/// let store = DedupVectorStore::with_seen(inner, hashes);
+/// ```
+pub struct DedupVectorStore<S, F = fn(&str) -> String>
+where
+    S: VectorStore,
+    F: Fn(&str) -> String + Send + Sync,
+{
+    inner: S,
+    fingerprint_fn: F,
+    seen: HashSet<String>,
+}
+
+// --- constructors for the default fingerprint ---
+
+impl<S: VectorStore> DedupVectorStore<S, fn(&str) -> String> {
+    /// Wrap `inner` with an empty seen-set and the default
+    /// [`normalized_fingerprint`] function.
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            fingerprint_fn: normalized_fingerprint,
+            seen: HashSet::new(),
+        }
+    }
+
+    /// Wrap `inner` and pre-populate the seen-set from `seen` fingerprints.
+    ///
+    /// Use this when re-starting a process and you want to restore the
+    /// dedup state from previously persisted fingerprints.
+    pub fn with_seen(inner: S, seen: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            inner,
+            fingerprint_fn: normalized_fingerprint,
+            seen: seen.into_iter().collect(),
+        }
+    }
+}
+
+// --- constructors with a custom fingerprint function ---
+
+impl<S, F> DedupVectorStore<S, F>
+where
+    S: VectorStore,
+    F: Fn(&str) -> String + Send + Sync,
+{
+    /// Wrap `inner` with a custom fingerprint function and an empty seen-set.
+    ///
+    /// The function receives the raw document text and returns a string key.
+    /// Documents whose key is already in the seen-set are skipped.
+    pub fn with_fingerprint(inner: S, f: F) -> Self {
+        Self {
+            inner,
+            fingerprint_fn: f,
+            seen: HashSet::new(),
+        }
+    }
+
+    /// Wrap `inner` with a custom fingerprint function and a pre-populated
+    /// seen-set.
+    pub fn with_fingerprint_and_seen(
+        inner: S,
+        f: F,
+        seen: impl IntoIterator<Item = String>,
+    ) -> Self {
+        Self {
+            inner,
+            fingerprint_fn: f,
+            seen: seen.into_iter().collect(),
+        }
+    }
+
+    // --- inspection ---
+
+    /// Whether `text` is already recorded in the seen-set (using the
+    /// configured fingerprint function).
+    pub fn contains(&self, text: &str) -> bool {
+        self.seen.contains(&(self.fingerprint_fn)(text))
+    }
+
+    /// Read-only access to the inner store.
+    pub fn inner(&self) -> &S {
+        &self.inner
+    }
+
+    /// Mutable access to the inner store — e.g. to call store-specific
+    /// methods not on the [`VectorStore`] trait.
+    pub fn inner_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    /// Iterate over all fingerprints currently held in the seen-set.
+    /// Useful when persisting state to storage before shutdown.
+    pub fn seen_fingerprints(&self) -> impl Iterator<Item = &str> {
+        self.seen.iter().map(|s| s.as_str())
+    }
+
+    /// Number of unique fingerprints recorded (≥ documents in the inner
+    /// store when duplicates were skipped).
+    pub fn seen_count(&self) -> usize {
+        self.seen.len()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// VectorStore impl
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl<S, F> VectorStore for DedupVectorStore<S, F>
+where
+    S: VectorStore + Send + Sync,
+    F: Fn(&str) -> String + Send + Sync,
+{
+    /// Filter out texts whose fingerprint is already seen, then delegate
+    /// the remainder to the inner store.
+    ///
+    /// Skipped documents are represented as `"dedup:skipped:{fingerprint}"`
+    /// in the returned ID list so that callers whose code expects
+    /// `ids.len() == texts.len()` still holds.
+    async fn add_texts(
+        &mut self,
+        texts: Vec<String>,
+        metadata: Option<Vec<HashMap<String, serde_json::Value>>>,
+    ) -> Result<Vec<String>> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut pass_texts: Vec<String> = Vec::new();
+        let mut pass_meta: Vec<HashMap<String, serde_json::Value>> = Vec::new();
+        // Tracks final position: None = sent to inner, Some(id) = skipped.
+        let mut slots: Vec<Option<String>> = Vec::with_capacity(texts.len());
+
+        for (i, text) in texts.iter().enumerate() {
+            let fp = (self.fingerprint_fn)(text);
+            if self.seen.contains(&fp) {
+                slots.push(Some(format!("dedup:skipped:{fp}")));
+            } else {
+                self.seen.insert(fp);
+                pass_texts.push(text.clone());
+                if let Some(m) = &metadata {
+                    pass_meta.push(m[i].clone());
+                }
+                slots.push(None);
+            }
+        }
+
+        let real_meta = if metadata.is_some() && !pass_meta.is_empty() {
+            Some(pass_meta)
+        } else {
+            None
+        };
+
+        let mut inner_ids = if !pass_texts.is_empty() {
+            self.inner.add_texts(pass_texts, real_meta).await?
+        } else {
+            Vec::new()
+        };
+
+        // Reconstruct output in original order.
+        let mut inner_iter = inner_ids.drain(..);
+        let ids = slots
+            .into_iter()
+            .map(|slot| match slot {
+                Some(skipped_id) => skipped_id,
+                None => inner_iter.next().unwrap_or_default(),
+            })
+            .collect();
+        Ok(ids)
+    }
+
+    /// Filter out pre-embedded vectors whose text fingerprint is already
+    /// seen, then delegate the remainder to the inner store.
+    async fn add_vectors(
+        &mut self,
+        vectors: Vec<Vec<f32>>,
+        texts: Vec<String>,
+        metadata: Option<Vec<HashMap<String, serde_json::Value>>>,
+    ) -> Result<Vec<String>> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut pass_vecs: Vec<Vec<f32>> = Vec::new();
+        let mut pass_texts: Vec<String> = Vec::new();
+        let mut pass_meta: Vec<HashMap<String, serde_json::Value>> = Vec::new();
+        let mut slots: Vec<Option<String>> = Vec::with_capacity(texts.len());
+
+        for (i, (text, vec)) in texts.iter().zip(vectors.iter()).enumerate() {
+            let fp = (self.fingerprint_fn)(text);
+            if self.seen.contains(&fp) {
+                slots.push(Some(format!("dedup:skipped:{fp}")));
+            } else {
+                self.seen.insert(fp);
+                pass_texts.push(text.clone());
+                pass_vecs.push(vec.clone());
+                if let Some(m) = &metadata {
+                    pass_meta.push(m[i].clone());
+                }
+                slots.push(None);
+            }
+        }
+
+        let real_meta = if metadata.is_some() && !pass_meta.is_empty() {
+            Some(pass_meta)
+        } else {
+            None
+        };
+
+        let mut inner_ids = if !pass_texts.is_empty() {
+            self.inner.add_vectors(pass_vecs, pass_texts, real_meta).await?
+        } else {
+            Vec::new()
+        };
+
+        let mut inner_iter = inner_ids.drain(..);
+        let ids = slots
+            .into_iter()
+            .map(|slot| match slot {
+                Some(skipped_id) => skipped_id,
+                None => inner_iter.next().unwrap_or_default(),
+            })
+            .collect();
+        Ok(ids)
+    }
+
+    async fn similarity_search(&self, query: &str, k: usize) -> Result<Vec<SearchResult>> {
+        self.inner.similarity_search(query, k).await
+    }
+
+    async fn similarity_search_by_vector(
+        &self,
+        query_vector: Vec<f32>,
+        k: usize,
+    ) -> Result<Vec<SearchResult>> {
+        self.inner.similarity_search_by_vector(query_vector, k).await
+    }
+
+    async fn similarity_search_with_filter(
+        &self,
+        query: &str,
+        k: usize,
+        filter: &Filter,
+    ) -> Result<Vec<SearchResult>> {
+        self.inner.similarity_search_with_filter(query, k, filter).await
+    }
+
+    async fn delete(&mut self, ids: Vec<String>) -> Result<()> {
+        self.inner.delete(ids).await
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::embeddings::FakeEmbeddings;
+    use crate::vectorstore::InMemoryVectorStore;
+    use std::sync::Arc;
+
+    fn inner() -> InMemoryVectorStore {
+        InMemoryVectorStore::new(Arc::new(FakeEmbeddings::new(8)))
+    }
+
+    // --- add_texts ---
+
+    #[tokio::test]
+    async fn skips_duplicate_on_second_add() {
+        let mut store = DedupVectorStore::new(inner());
+        store.add_texts(vec!["the workspace uses Go".into()], None).await.unwrap();
+        store.add_texts(vec!["the workspace uses Go".into()], None).await.unwrap();
+        assert_eq!(store.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn case_and_whitespace_normalisation_deduplicates() {
+        let mut store = DedupVectorStore::new(inner());
+        store.add_texts(vec!["The workspace uses Go.".into()], None).await.unwrap();
+        store.add_texts(vec!["  THE  WORKSPACE   USES  GO.  ".into()], None).await.unwrap();
+        assert_eq!(store.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn distinct_content_both_stored() {
+        let mut store = DedupVectorStore::new(inner());
+        store.add_texts(vec!["Fact A.".into()], None).await.unwrap();
+        store.add_texts(vec!["Fact B.".into()], None).await.unwrap();
+        assert_eq!(store.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn batch_add_with_mixed_duplicates() {
+        let mut store = DedupVectorStore::new(inner());
+        let ids1 = store
+            .add_texts(vec!["unique one".into(), "unique two".into()], None)
+            .await
+            .unwrap();
+        assert_eq!(ids1.len(), 2);
+        assert!(!ids1[0].starts_with("dedup:skipped:"));
+        assert!(!ids1[1].starts_with("dedup:skipped:"));
+
+        let ids2 = store
+            .add_texts(
+                vec!["unique one".into(), "unique three".into(), "unique two".into()],
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(ids2.len(), 3);
+        // First and third are duplicates.
+        assert!(ids2[0].starts_with("dedup:skipped:"));
+        assert!(!ids2[1].starts_with("dedup:skipped:"), "unique three should pass through");
+        assert!(ids2[2].starts_with("dedup:skipped:"));
+        assert_eq!(store.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn with_seen_skips_pre_populated_fingerprints() {
+        let fp = normalized_fingerprint("already known fact");
+        let mut store = DedupVectorStore::with_seen(inner(), [fp]);
+        store
+            .add_texts(vec!["already known fact".into()], None)
+            .await
+            .unwrap();
+        assert_eq!(store.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn read_operations_pass_through() {
+        let mut store = DedupVectorStore::new(inner());
+        store.add_texts(vec!["searchable fact".into()], None).await.unwrap();
+        let results = store.similarity_search("fact", 5).await.unwrap();
+        assert!(!results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_passes_through() {
+        let mut store = DedupVectorStore::new(inner());
+        let ids = store.add_texts(vec!["deletable".into()], None).await.unwrap();
+        assert_eq!(store.len(), 1);
+        store.delete(ids).await.unwrap();
+        assert_eq!(store.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn seen_count_tracks_unique_fingerprints() {
+        let mut store = DedupVectorStore::new(inner());
+        store.add_texts(vec!["a".into(), "b".into()], None).await.unwrap();
+        store.add_texts(vec!["a".into()], None).await.unwrap(); // duplicate
+        assert_eq!(store.seen_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn contains_reflects_seen_set() {
+        let mut store = DedupVectorStore::new(inner());
+        assert!(!store.contains("new fact"));
+        store.add_texts(vec!["new fact".into()], None).await.unwrap();
+        assert!(store.contains("new fact"));
+        // Case variant also matches.
+        assert!(store.contains("NEW FACT"));
+    }
+
+    // --- custom fingerprint ---
+
+    #[tokio::test]
+    async fn custom_fingerprint_uses_provided_function() {
+        // Fingerprint only on the first word — any two texts with the same
+        // first word are considered duplicates.
+        let mut store = DedupVectorStore::with_fingerprint(inner(), |text: &str| {
+            text.split_whitespace()
+                .next()
+                .unwrap_or("")
+                .to_lowercase()
+                .to_string()
+        });
+        store.add_texts(vec!["rust is great".into()], None).await.unwrap();
+        store.add_texts(vec!["rust is also fast".into()], None).await.unwrap();
+        // Both start with "rust" → second is a duplicate.
+        assert_eq!(store.len(), 1);
+    }
+
+    // --- add_vectors ---
+
+    #[tokio::test]
+    async fn add_vectors_deduplicates() {
+        let mut store = DedupVectorStore::new(inner());
+        let vec = vec![0.1_f32; 8];
+        store
+            .add_vectors(vec![vec.clone()], vec!["vec fact".into()], None)
+            .await
+            .unwrap();
+        store
+            .add_vectors(vec![vec.clone()], vec!["vec fact".into()], None)
+            .await
+            .unwrap();
+        assert_eq!(store.len(), 1);
+    }
+
+    // --- normalized_fingerprint properties ---
+
+    #[test]
+    fn fingerprint_is_deterministic() {
+        assert_eq!(
+            normalized_fingerprint("hello world"),
+            normalized_fingerprint("hello world")
+        );
+    }
+
+    #[test]
+    fn fingerprint_is_case_insensitive() {
+        assert_eq!(
+            normalized_fingerprint("Hello World"),
+            normalized_fingerprint("hello world")
+        );
+    }
+
+    #[test]
+    fn fingerprint_collapses_whitespace() {
+        assert_eq!(
+            normalized_fingerprint("hello   world"),
+            normalized_fingerprint("hello world")
+        );
+    }
+
+    #[test]
+    fn fingerprint_distinguishes_different_content() {
+        assert_ne!(
+            normalized_fingerprint("hello world"),
+            normalized_fingerprint("goodbye world")
+        );
+    }
+}

--- a/crates/cognis-rag/src/vectorstore/dedup.rs
+++ b/crates/cognis-rag/src/vectorstore/dedup.rs
@@ -12,8 +12,8 @@
 //! [`DedupVectorStore::with_fingerprint`] when your dedup key is not
 //! derived from raw text (e.g. a document ID or a composite hash).
 
-use std::collections::HashSet;
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 use async_trait::async_trait;
 
@@ -288,7 +288,9 @@ where
         };
 
         let mut inner_ids = if !pass_texts.is_empty() {
-            self.inner.add_vectors(pass_vecs, pass_texts, real_meta).await?
+            self.inner
+                .add_vectors(pass_vecs, pass_texts, real_meta)
+                .await?
         } else {
             Vec::new()
         };
@@ -313,7 +315,9 @@ where
         query_vector: Vec<f32>,
         k: usize,
     ) -> Result<Vec<SearchResult>> {
-        self.inner.similarity_search_by_vector(query_vector, k).await
+        self.inner
+            .similarity_search_by_vector(query_vector, k)
+            .await
     }
 
     async fn similarity_search_with_filter(
@@ -322,7 +326,9 @@ where
         k: usize,
         filter: &Filter,
     ) -> Result<Vec<SearchResult>> {
-        self.inner.similarity_search_with_filter(query, k, filter).await
+        self.inner
+            .similarity_search_with_filter(query, k, filter)
+            .await
     }
 
     async fn delete(&mut self, ids: Vec<String>) -> Result<()> {
@@ -354,16 +360,28 @@ mod tests {
     #[tokio::test]
     async fn skips_duplicate_on_second_add() {
         let mut store = DedupVectorStore::new(inner());
-        store.add_texts(vec!["the workspace uses Go".into()], None).await.unwrap();
-        store.add_texts(vec!["the workspace uses Go".into()], None).await.unwrap();
+        store
+            .add_texts(vec!["the workspace uses Go".into()], None)
+            .await
+            .unwrap();
+        store
+            .add_texts(vec!["the workspace uses Go".into()], None)
+            .await
+            .unwrap();
         assert_eq!(store.len(), 1);
     }
 
     #[tokio::test]
     async fn case_and_whitespace_normalisation_deduplicates() {
         let mut store = DedupVectorStore::new(inner());
-        store.add_texts(vec!["The workspace uses Go.".into()], None).await.unwrap();
-        store.add_texts(vec!["  THE  WORKSPACE   USES  GO.  ".into()], None).await.unwrap();
+        store
+            .add_texts(vec!["The workspace uses Go.".into()], None)
+            .await
+            .unwrap();
+        store
+            .add_texts(vec!["  THE  WORKSPACE   USES  GO.  ".into()], None)
+            .await
+            .unwrap();
         assert_eq!(store.len(), 1);
     }
 
@@ -388,7 +406,11 @@ mod tests {
 
         let ids2 = store
             .add_texts(
-                vec!["unique one".into(), "unique three".into(), "unique two".into()],
+                vec![
+                    "unique one".into(),
+                    "unique three".into(),
+                    "unique two".into(),
+                ],
                 None,
             )
             .await
@@ -396,7 +418,10 @@ mod tests {
         assert_eq!(ids2.len(), 3);
         // First and third are duplicates.
         assert!(ids2[0].starts_with("dedup:skipped:"));
-        assert!(!ids2[1].starts_with("dedup:skipped:"), "unique three should pass through");
+        assert!(
+            !ids2[1].starts_with("dedup:skipped:"),
+            "unique three should pass through"
+        );
         assert!(ids2[2].starts_with("dedup:skipped:"));
         assert_eq!(store.len(), 3);
     }
@@ -415,7 +440,10 @@ mod tests {
     #[tokio::test]
     async fn read_operations_pass_through() {
         let mut store = DedupVectorStore::new(inner());
-        store.add_texts(vec!["searchable fact".into()], None).await.unwrap();
+        store
+            .add_texts(vec!["searchable fact".into()], None)
+            .await
+            .unwrap();
         let results = store.similarity_search("fact", 5).await.unwrap();
         assert!(!results.is_empty());
     }
@@ -423,7 +451,10 @@ mod tests {
     #[tokio::test]
     async fn delete_passes_through() {
         let mut store = DedupVectorStore::new(inner());
-        let ids = store.add_texts(vec!["deletable".into()], None).await.unwrap();
+        let ids = store
+            .add_texts(vec!["deletable".into()], None)
+            .await
+            .unwrap();
         assert_eq!(store.len(), 1);
         store.delete(ids).await.unwrap();
         assert_eq!(store.len(), 0);
@@ -432,7 +463,10 @@ mod tests {
     #[tokio::test]
     async fn seen_count_tracks_unique_fingerprints() {
         let mut store = DedupVectorStore::new(inner());
-        store.add_texts(vec!["a".into(), "b".into()], None).await.unwrap();
+        store
+            .add_texts(vec!["a".into(), "b".into()], None)
+            .await
+            .unwrap();
         store.add_texts(vec!["a".into()], None).await.unwrap(); // duplicate
         assert_eq!(store.seen_count(), 2);
     }
@@ -441,7 +475,10 @@ mod tests {
     async fn contains_reflects_seen_set() {
         let mut store = DedupVectorStore::new(inner());
         assert!(!store.contains("new fact"));
-        store.add_texts(vec!["new fact".into()], None).await.unwrap();
+        store
+            .add_texts(vec!["new fact".into()], None)
+            .await
+            .unwrap();
         assert!(store.contains("new fact"));
         // Case variant also matches.
         assert!(store.contains("NEW FACT"));
@@ -460,8 +497,14 @@ mod tests {
                 .to_lowercase()
                 .to_string()
         });
-        store.add_texts(vec!["rust is great".into()], None).await.unwrap();
-        store.add_texts(vec!["rust is also fast".into()], None).await.unwrap();
+        store
+            .add_texts(vec!["rust is great".into()], None)
+            .await
+            .unwrap();
+        store
+            .add_texts(vec!["rust is also fast".into()], None)
+            .await
+            .unwrap();
         // Both start with "rust" → second is a duplicate.
         assert_eq!(store.len(), 1);
     }

--- a/crates/cognis-rag/src/vectorstore/mod.rs
+++ b/crates/cognis-rag/src/vectorstore/mod.rs
@@ -8,6 +8,9 @@ use serde::{Deserialize, Serialize};
 
 use cognis_core::Result;
 
+pub mod dedup;
+pub use dedup::{normalized_fingerprint, DedupVectorStore};
+
 mod in_memory;
 pub use in_memory::InMemoryVectorStore;
 

--- a/crates/cognis/src/agent/fact_extractor.rs
+++ b/crates/cognis/src/agent/fact_extractor.rs
@@ -136,8 +136,7 @@ where
     /// Send `text` to the model as the human turn. The system prompt
     /// already includes schema-derived format instructions.
     async fn invoke(&self, text: String, _: RunnableConfig) -> Result<O> {
-        let instructions = OutputParser::format_instructions(&self.parser)
-            .unwrap_or_default();
+        let instructions = OutputParser::format_instructions(&self.parser).unwrap_or_default();
         let system = format!("{}\n\n{instructions}", self.system_prompt);
         let messages = vec![Message::system(system), Message::human(text)];
         let resp = self.client.chat(messages, ChatOptions::default()).await?;
@@ -488,11 +487,8 @@ mod tests {
         }
 
         // Not JSON at all.
-        let extractor =
-            LlmExtractor::<Answer>::builder(canned_client("not json")).build();
-        let result = extractor
-            .invoke("input".into(), Default::default())
-            .await;
+        let extractor = LlmExtractor::<Answer>::builder(canned_client("not json")).build();
+        let result = extractor.invoke("input".into(), Default::default()).await;
         assert!(result.is_err());
     }
 
@@ -554,7 +550,10 @@ mod tests {
     async fn fact_extractor_returns_empty_on_model_empty_array() {
         let extractor = FactExtractor::new(canned_client("[]"));
         let facts = extractor
-            .invoke(FactExtractionInput::new("no useful info"), Default::default())
+            .invoke(
+                FactExtractionInput::new("no useful info"),
+                Default::default(),
+            )
             .await
             .unwrap();
         assert!(facts.is_empty());

--- a/crates/cognis/src/agent/fact_extractor.rs
+++ b/crates/cognis/src/agent/fact_extractor.rs
@@ -1,0 +1,591 @@
+//! LLM-driven structured extraction primitives.
+//!
+//! Two public types:
+//!
+//! * [`LlmExtractor<O>`] — the generic building block. Give it a system
+//!   prompt and any `DeserializeOwned + JsonSchema` output type and it
+//!   calls the model, auto-generates format instructions from the schema,
+//!   and parses the response. `Runnable<String, O>`.
+//!
+//! * [`FactExtractor`] — a ready-to-use specialisation of `LlmExtractor`
+//!   for the common "distil agent output into atomic memory facts" case.
+//!   Takes [`FactExtractionInput`] and returns `Vec<`[`Fact`]`>`. Parse
+//!   failures are logged and swallowed (returns `Ok(vec![])`) so the
+//!   memory write path never stalls on a badly-formatted model response.
+//!   `Runnable<FactExtractionInput, Vec<Fact>>`.
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cognis_core::output_parsers::{OutputParser, StructuredOutputConfig, StructuredOutputParser};
+use cognis_core::{Message, Result, Runnable, RunnableConfig};
+use cognis_llm::chat::ChatOptions;
+use cognis_llm::Client;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// LlmExtractor<O>
+// ---------------------------------------------------------------------------
+
+/// Generic structured extractor: renders text input into an LLM prompt,
+/// calls the model, and parses the response as `O`.
+///
+/// The JSON Schema for `O` is derived automatically via [`JsonSchema`] and
+/// appended to the system prompt as format instructions. Models that
+/// respond with leading prose still parse correctly because
+/// [`StructuredOutputParser`] scans for the first balanced JSON
+/// object/array by default.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use cognis::agent::{LlmExtractor, LlmExtractorBuilder};
+/// use cognis_llm::{Client, ClientBuilder, Provider};
+/// use serde::Deserialize;
+/// use schemars::JsonSchema;
+/// use std::sync::Arc;
+///
+/// #[derive(Deserialize, JsonSchema)]
+/// struct Sentiment { label: String, score: f32 }
+///
+/// let client = Arc::new(ClientBuilder::new().provider(Provider::Anthropic).build()?);
+/// let extractor = LlmExtractor::<Sentiment>::builder(client)
+///     .system_prompt("Classify the sentiment of the following text.")
+///     .build();
+///
+/// let result = extractor.invoke("I love this!".into(), Default::default()).await?;
+/// ```
+pub struct LlmExtractor<O> {
+    client: Arc<Client>,
+    system_prompt: String,
+    parser: StructuredOutputParser<O>,
+}
+
+impl<O> Clone for LlmExtractor<O> {
+    fn clone(&self) -> Self {
+        Self {
+            client: Arc::clone(&self.client),
+            system_prompt: self.system_prompt.clone(),
+            parser: self.parser.clone(),
+        }
+    }
+}
+
+impl<O> LlmExtractor<O> {
+    /// Start building a new extractor backed by `client`.
+    pub fn builder(client: Arc<Client>) -> LlmExtractorBuilder<O> {
+        LlmExtractorBuilder {
+            client,
+            system_prompt: None,
+            parser_config: None,
+            _out: PhantomData,
+        }
+    }
+}
+
+/// Builder for [`LlmExtractor`].
+pub struct LlmExtractorBuilder<O> {
+    client: Arc<Client>,
+    system_prompt: Option<String>,
+    parser_config: Option<StructuredOutputConfig>,
+    _out: PhantomData<fn() -> O>,
+}
+
+impl<O> LlmExtractorBuilder<O> {
+    /// Override the system-level instruction. Format instructions derived
+    /// from the output schema are always appended, so you only need to
+    /// describe the *task* here.
+    pub fn system_prompt(mut self, p: impl Into<String>) -> Self {
+        self.system_prompt = Some(p.into());
+        self
+    }
+
+    /// Override the JSON extraction config (e.g. switch to strict mode or
+    /// provide a custom extractor for tag-delimited responses).
+    pub fn parser_config(mut self, c: StructuredOutputConfig) -> Self {
+        self.parser_config = Some(c);
+        self
+    }
+
+    /// Build the extractor.
+    pub fn build(self) -> LlmExtractor<O> {
+        let system_prompt = self.system_prompt.unwrap_or_else(|| {
+            "You are a precise information extraction assistant. \
+             Extract only what is explicitly present in the provided text."
+                .to_string()
+        });
+        let parser = match self.parser_config {
+            Some(cfg) => StructuredOutputParser::with_config(cfg),
+            None => StructuredOutputParser::new(),
+        };
+        LlmExtractor {
+            client: self.client,
+            system_prompt,
+            parser,
+        }
+    }
+}
+
+#[async_trait]
+impl<O> Runnable<String, O> for LlmExtractor<O>
+where
+    O: serde::de::DeserializeOwned + JsonSchema + Send + 'static,
+{
+    /// Send `text` to the model as the human turn. The system prompt
+    /// already includes schema-derived format instructions.
+    async fn invoke(&self, text: String, _: RunnableConfig) -> Result<O> {
+        let instructions = OutputParser::format_instructions(&self.parser)
+            .unwrap_or_default();
+        let system = format!("{}\n\n{instructions}", self.system_prompt);
+        let messages = vec![Message::system(system), Message::human(text)];
+        let resp = self.client.chat(messages, ChatOptions::default()).await?;
+        OutputParser::parse(&self.parser, resp.message.content())
+    }
+
+    fn name(&self) -> &str {
+        "LlmExtractor"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FactKind + Fact + FactExtractionInput
+// ---------------------------------------------------------------------------
+
+/// Semantic category of an extracted fact.
+///
+/// Choosing the right kind helps downstream systems filter or prioritise
+/// facts before writing to a memory store.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FactKind {
+    /// A standing decision that must always be followed.
+    Rule,
+    /// A softer guideline; follow unless there is a reason not to.
+    Preference,
+    /// Situational information that informs decisions without being prescriptive.
+    Context,
+    /// A past choice with its rationale — informative, not prescriptive for the future.
+    Decision,
+    /// An ongoing state worth being aware of.
+    Observation,
+}
+
+/// One atomic, self-contained fact extracted from agent output.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct Fact {
+    /// Self-contained statement that is interpretable without the surrounding
+    /// text it was extracted from.
+    pub content: String,
+    /// Semantic category — used for filtering and routing in memory systems.
+    pub kind: FactKind,
+    /// Relative importance 0.0–1.0. Higher values surface the fact first
+    /// during retrieval ranking.
+    pub importance: f32,
+}
+
+/// Input to [`FactExtractor::invoke`].
+#[derive(Debug, Clone)]
+pub struct FactExtractionInput {
+    /// The raw text to distil — typically the full output of an agent turn.
+    pub text: String,
+    /// Optional hints that frame the extraction context, e.g.
+    /// `"project: billing-v2"` or `"user: alice"`. Rendered as a bulleted
+    /// section above the text so the model can filter for relevance.
+    pub context_hints: Vec<String>,
+    /// Upper bound on the number of facts returned. Defaults to 7.
+    pub max_facts: usize,
+}
+
+impl FactExtractionInput {
+    /// Minimal constructor — no hints, default `max_facts = 7`.
+    pub fn new(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            context_hints: vec![],
+            max_facts: 7,
+        }
+    }
+
+    /// Append a context hint (builder-style, chainable).
+    pub fn with_hint(mut self, hint: impl Into<String>) -> Self {
+        self.context_hints.push(hint.into());
+        self
+    }
+
+    /// Override the maximum number of returned facts (builder-style).
+    pub fn with_max_facts(mut self, n: usize) -> Self {
+        self.max_facts = n;
+        self
+    }
+}
+
+impl Default for FactExtractionInput {
+    fn default() -> Self {
+        Self::new("")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FactExtractor
+// ---------------------------------------------------------------------------
+
+const DEFAULT_SYSTEM_PROMPT: &str = "\
+You are extracting reusable memory facts from an AI agent's completed work.
+
+Extract only atomic, self-contained facts — each must be understandable
+without the surrounding text it came from.
+
+Classify each fact as exactly one of:
+  rule        — a standing decision that must always be followed
+  preference  — a softer guideline; follow unless there is a reason not to
+  context     — situational information that informs decisions
+  decision    — a past choice with its rationale (informative, not prescriptive)
+  observation — an ongoing state worth being aware of
+
+Rate importance 0.0–1.0:
+  1.0 = critical invariant that affects every future action
+  0.5 = moderately useful background
+  0.0 = borderline; included only for completeness
+
+If the output contains no useful facts, return an empty JSON array: []";
+
+/// Distils raw agent output into a ranked list of atomic [`Fact`]s.
+///
+/// Built on [`LlmExtractor<Vec<Fact>>`]. Any parse or model failure is
+/// logged at WARN and swallowed — the caller always receives `Ok(vec![])`
+/// rather than an error. This is intentional: the memory write path must
+/// never block because of a badly-formatted model response.
+///
+/// # Customisation
+///
+/// Override the system prompt or parser config via [`FactExtractor::builder`].
+/// The default prompt is tuned for general-purpose agents; for domain-specific
+/// extraction (e.g. medical, legal, financial), replacing the prompt via
+/// `FactExtractorBuilder::system_prompt` is often sufficient.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use cognis::agent::{FactExtractor, FactExtractionInput};
+/// use cognis_llm::{Client, ClientBuilder, Provider};
+/// use std::sync::Arc;
+///
+/// let client = Arc::new(ClientBuilder::new().provider(Provider::Anthropic).build()?);
+/// let extractor = FactExtractor::new(client);
+///
+/// let facts = extractor.invoke(
+///     FactExtractionInput::new("Chose monolithic architecture for the API service.")
+///         .with_hint("project: billing-v2")
+///         .with_max_facts(5),
+///     Default::default(),
+/// ).await?;
+/// ```
+pub struct FactExtractor {
+    inner: LlmExtractor<Vec<Fact>>,
+}
+
+impl FactExtractor {
+    /// Create with the default extraction prompt.
+    pub fn new(client: Arc<Client>) -> Self {
+        Self::builder(client).build()
+    }
+
+    /// Start building a customised [`FactExtractor`].
+    pub fn builder(client: Arc<Client>) -> FactExtractorBuilder {
+        FactExtractorBuilder {
+            client,
+            system_prompt: None,
+            parser_config: None,
+        }
+    }
+
+    fn render_user_message(input: &FactExtractionInput) -> String {
+        let mut parts: Vec<String> = Vec::new();
+
+        if !input.context_hints.is_empty() {
+            let hints = input
+                .context_hints
+                .iter()
+                .map(|h| format!("- {h}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            parts.push(format!("Context:\n{hints}"));
+        }
+
+        parts.push(format!("Agent output:\n---\n{}\n---", input.text));
+        parts.push(format!(
+            "Extract up to {} atomic facts. Return a JSON array only — no prose.",
+            input.max_facts
+        ));
+
+        parts.join("\n\n")
+    }
+}
+
+/// Builder for [`FactExtractor`].
+pub struct FactExtractorBuilder {
+    client: Arc<Client>,
+    system_prompt: Option<String>,
+    parser_config: Option<StructuredOutputConfig>,
+}
+
+impl FactExtractorBuilder {
+    /// Override the extraction system prompt. The JSON schema hint is
+    /// still appended automatically; you only need to describe the task.
+    pub fn system_prompt(mut self, p: impl Into<String>) -> Self {
+        self.system_prompt = Some(p.into());
+        self
+    }
+
+    /// Override the JSON parser config.
+    pub fn parser_config(mut self, c: StructuredOutputConfig) -> Self {
+        self.parser_config = Some(c);
+        self
+    }
+
+    /// Build the extractor.
+    pub fn build(self) -> FactExtractor {
+        let mut builder = LlmExtractor::<Vec<Fact>>::builder(self.client).system_prompt(
+            self.system_prompt
+                .unwrap_or_else(|| DEFAULT_SYSTEM_PROMPT.to_string()),
+        );
+        if let Some(cfg) = self.parser_config {
+            builder = builder.parser_config(cfg);
+        }
+        FactExtractor {
+            inner: builder.build(),
+        }
+    }
+}
+
+#[async_trait]
+impl Runnable<FactExtractionInput, Vec<Fact>> for FactExtractor {
+    async fn invoke(
+        &self,
+        input: FactExtractionInput,
+        config: RunnableConfig,
+    ) -> Result<Vec<Fact>> {
+        let max = input.max_facts;
+        let user_msg = Self::render_user_message(&input);
+        let facts = match self.inner.invoke(user_msg, config).await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(error = %e, "fact_extractor: extraction failed, returning empty vec");
+                vec![]
+            }
+        };
+        Ok(facts.into_iter().take(max).collect())
+    }
+
+    fn name(&self) -> &str {
+        "FactExtractor"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cognis_core::RunnableStream;
+    use cognis_llm::chat::{ChatOptions, ChatResponse, HealthStatus, StreamChunk};
+    use cognis_llm::provider::LLMProvider;
+    use cognis_llm::{Client, Provider};
+
+    /// Test provider that returns a fixed response string.
+    struct CannedProvider {
+        response: String,
+    }
+
+    #[async_trait]
+    impl LLMProvider for CannedProvider {
+        fn name(&self) -> &str {
+            "canned"
+        }
+        fn provider_type(&self) -> Provider {
+            Provider::Ollama
+        }
+        async fn chat_completion(
+            &self,
+            _messages: Vec<Message>,
+            _opts: ChatOptions,
+        ) -> Result<ChatResponse> {
+            Ok(ChatResponse {
+                message: Message::ai(self.response.clone()),
+                usage: None,
+                finish_reason: "stop".into(),
+                model: "canned".into(),
+            })
+        }
+        async fn chat_completion_stream(
+            &self,
+            _: Vec<Message>,
+            _: ChatOptions,
+        ) -> Result<RunnableStream<StreamChunk>> {
+            unimplemented!()
+        }
+        async fn health_check(&self) -> Result<HealthStatus> {
+            Ok(HealthStatus::Healthy { latency_ms: 0 })
+        }
+    }
+
+    fn canned_client(response: impl Into<String>) -> Arc<Client> {
+        Arc::new(Client::new(Arc::new(CannedProvider {
+            response: response.into(),
+        })))
+    }
+
+    // --- LlmExtractor ---
+
+    #[tokio::test]
+    async fn llm_extractor_parses_structured_output() {
+        #[derive(Debug, Deserialize, JsonSchema, PartialEq)]
+        struct Sentiment {
+            label: String,
+            score: f32,
+        }
+
+        let json = r#"{"label":"positive","score":0.95}"#;
+        let extractor = LlmExtractor::<Sentiment>::builder(canned_client(json))
+            .system_prompt("Classify sentiment.")
+            .build();
+
+        let result = extractor
+            .invoke("I love this product!".into(), Default::default())
+            .await
+            .unwrap();
+
+        assert_eq!(result.label, "positive");
+        assert!((result.score - 0.95).abs() < 1e-4);
+    }
+
+    #[tokio::test]
+    async fn llm_extractor_extracts_json_from_prose() {
+        #[derive(Deserialize, JsonSchema)]
+        struct Answer {
+            value: i32,
+        }
+
+        // Model wraps JSON in prose — parser should still find it.
+        let response = r#"Sure! Here is the answer: {"value": 42} Hope that helps."#;
+        let extractor = LlmExtractor::<Answer>::builder(canned_client(response)).build();
+        let out = extractor
+            .invoke("What is 6×7?".into(), Default::default())
+            .await
+            .unwrap();
+        assert_eq!(out.value, 42);
+    }
+
+    #[tokio::test]
+    async fn llm_extractor_propagates_parse_error() {
+        #[derive(Deserialize, JsonSchema)]
+        struct Answer {
+            _value: i32,
+        }
+
+        // Not JSON at all.
+        let extractor =
+            LlmExtractor::<Answer>::builder(canned_client("not json")).build();
+        let result = extractor
+            .invoke("input".into(), Default::default())
+            .await;
+        assert!(result.is_err());
+    }
+
+    // --- FactExtractor ---
+
+    #[tokio::test]
+    async fn fact_extractor_parses_facts() {
+        let json = r#"[
+            {"content":"Use monolithic architecture for the API","kind":"rule","importance":0.9},
+            {"content":"Prefer Rust for performance-critical paths","kind":"preference","importance":0.7}
+        ]"#;
+
+        let extractor = FactExtractor::new(canned_client(json));
+        let facts = extractor
+            .invoke(
+                FactExtractionInput::new("Chose monolithic architecture."),
+                Default::default(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(facts.len(), 2);
+        assert_eq!(facts[0].kind, FactKind::Rule);
+        assert_eq!(facts[1].kind, FactKind::Preference);
+    }
+
+    #[tokio::test]
+    async fn fact_extractor_returns_empty_vec_on_parse_failure() {
+        let extractor = FactExtractor::new(canned_client("this is not json at all"));
+        let facts = extractor
+            .invoke(FactExtractionInput::new("some text"), Default::default())
+            .await
+            .unwrap();
+        assert!(facts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn fact_extractor_respects_max_facts() {
+        // Model returns 5 facts but caller requested max 2.
+        let json = r#"[
+            {"content":"A","kind":"rule","importance":1.0},
+            {"content":"B","kind":"context","importance":0.8},
+            {"content":"C","kind":"decision","importance":0.6},
+            {"content":"D","kind":"observation","importance":0.4},
+            {"content":"E","kind":"preference","importance":0.2}
+        ]"#;
+        let extractor = FactExtractor::new(canned_client(json));
+        let facts = extractor
+            .invoke(
+                FactExtractionInput::new("lots of info").with_max_facts(2),
+                Default::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(facts.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn fact_extractor_returns_empty_on_model_empty_array() {
+        let extractor = FactExtractor::new(canned_client("[]"));
+        let facts = extractor
+            .invoke(FactExtractionInput::new("no useful info"), Default::default())
+            .await
+            .unwrap();
+        assert!(facts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn render_user_message_includes_context_hints() {
+        let input = FactExtractionInput::new("output text")
+            .with_hint("project: billing-v2")
+            .with_hint("user: alice");
+        let rendered = FactExtractor::render_user_message(&input);
+        assert!(rendered.contains("project: billing-v2"));
+        assert!(rendered.contains("user: alice"));
+        assert!(rendered.contains("output text"));
+    }
+
+    #[tokio::test]
+    async fn render_user_message_omits_context_section_when_no_hints() {
+        let input = FactExtractionInput::new("plain text");
+        let rendered = FactExtractor::render_user_message(&input);
+        assert!(!rendered.contains("Context:"));
+        assert!(rendered.contains("plain text"));
+    }
+
+    #[tokio::test]
+    async fn fact_extraction_input_builder_chain() {
+        let input = FactExtractionInput::new("text")
+            .with_hint("hint1")
+            .with_hint("hint2")
+            .with_max_facts(3);
+        assert_eq!(input.context_hints.len(), 2);
+        assert_eq!(input.max_facts, 3);
+    }
+}

--- a/crates/cognis/src/agent/mod.rs
+++ b/crates/cognis/src/agent/mod.rs
@@ -7,6 +7,7 @@
 pub mod agent;
 pub mod builder;
 pub mod default_graph;
+pub mod fact_extractor;
 pub mod health;
 pub mod lifecycle;
 pub mod memory;
@@ -19,6 +20,10 @@ pub mod workflow;
 
 pub use agent::{Agent, AgentResponse, ConversationMode};
 pub use builder::AgentBuilder;
+pub use fact_extractor::{
+    Fact, FactExtractionInput, FactExtractor, FactExtractorBuilder, FactKind, LlmExtractor,
+    LlmExtractorBuilder,
+};
 pub use default_graph::{default_react_graph, default_react_graph_with_limits};
 pub use health::AgentHealth;
 pub use lifecycle::{AgentLifecycle, OnStart};

--- a/crates/cognis/src/agent/mod.rs
+++ b/crates/cognis/src/agent/mod.rs
@@ -20,11 +20,11 @@ pub mod workflow;
 
 pub use agent::{Agent, AgentResponse, ConversationMode};
 pub use builder::AgentBuilder;
+pub use default_graph::{default_react_graph, default_react_graph_with_limits};
 pub use fact_extractor::{
     Fact, FactExtractionInput, FactExtractor, FactExtractorBuilder, FactKind, LlmExtractor,
     LlmExtractorBuilder,
 };
-pub use default_graph::{default_react_graph, default_react_graph_with_limits};
 pub use health::AgentHealth;
 pub use lifecycle::{AgentLifecycle, OnStart};
 pub use memory::{

--- a/crates/cognis/src/lib.rs
+++ b/crates/cognis/src/lib.rs
@@ -39,11 +39,12 @@ pub use cognis_rag::OllamaEmbeddings;
 #[cfg(feature = "openai")]
 pub use cognis_rag::OpenAIEmbeddings;
 pub use cognis_rag::{
-    CachingRetriever, CompressorPipeline, CrossEncoder, CrossEncoderReranker, Distance, Docstore,
-    Document, Embeddings, FakeEmbeddings, Filter, FnCrossEncoder, InMemoryDocstore,
-    InMemoryRecordManager, InMemoryVectorStore, IncrementalReport, LongContextReorder,
-    MultiVectorIndexer, MultiVectorRetriever, ParentDocumentRetriever, QueryTranslatorRetriever,
-    RecordManager, SearchResult, VectorStore,
+    normalized_fingerprint, CachingRetriever, CompressorPipeline, CrossEncoder,
+    CrossEncoderReranker, DedupVectorStore, Distance, Docstore, Document, Embeddings,
+    FakeEmbeddings, Filter, FnCrossEncoder, InMemoryDocstore, InMemoryRecordManager,
+    InMemoryVectorStore, IncrementalReport, LongContextReorder, MultiVectorIndexer,
+    MultiVectorRetriever, ParentDocumentRetriever, QueryTranslatorRetriever, RecordManager,
+    SearchResult, VectorStore,
 };
 
 // New stage-5 modules.
@@ -69,10 +70,12 @@ pub mod tools;
 pub use agent::{
     default_react_graph, default_react_graph_with_limits, Agent, AgentBuilder, AgentHealth,
     AgentLifecycle, AgentPlugin, AgentResponse, AgentState, AgentStateUpdate, Buffer,
-    ClosurePlugin, ConversationMode, EntityExtractor, EntityFact, EntityMemory, FnPlugin,
-    HybridMemory, KnowledgeGraphMemory, LifecyclePlugin, Memory, OnStart, PluginRegistry,
-    SummaryBufferMemory, SummaryMemory, ThinkNode, TokenBufferMemory, ToolDispatchNode, Triple,
-    TripleExtractor, VectorMemory, Window, Workflow, WorkflowState, WorkflowStateUpdate,
+    ClosurePlugin, ConversationMode, EntityExtractor, EntityFact, EntityMemory, Fact,
+    FactExtractionInput, FactExtractor, FactExtractorBuilder, FactKind, FnPlugin, HybridMemory,
+    KnowledgeGraphMemory, LifecyclePlugin, LlmExtractor, LlmExtractorBuilder, Memory, OnStart,
+    PluginRegistry, SummaryBufferMemory, SummaryMemory, ThinkNode, TokenBufferMemory,
+    ToolDispatchNode, Triple, TripleExtractor, VectorMemory, Window, Workflow, WorkflowState,
+    WorkflowStateUpdate,
 };
 pub use agent_bus::{AgentBus, SubscribeError, Subscription};
 pub use agent_events::{AgentEvent, AgentEventBus, EventSubscription, DEFAULT_EVENTS_TOPIC};

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -182,3 +182,8 @@ path = "../../examples/parsers/fixing_parser.rs"
 [[example]]
 name = "parsers_retry"
 path = "../../examples/parsers/retry_parser.rs"
+
+# memory/ — memory variants and extraction.
+[[example]]
+name = "memory_fact_extraction"
+path = "../../examples/memory/fact_extraction.rs"

--- a/examples/memory/fact_extraction.rs
+++ b/examples/memory/fact_extraction.rs
@@ -1,0 +1,290 @@
+//! What you'll learn:
+//!   How to use [`FactExtractor`] to distil raw agent output into typed
+//!   atomic facts, and how to combine it with [`DedupVectorStore`] so
+//!   repeated observations never bloat the memory index.
+//!   Also shows [`LlmExtractor`] — the generic building block underneath
+//!   `FactExtractor` — for any custom structured-output type.
+//!
+//! Why this matters:
+//!   Agents working on the same codebase or project will surface the
+//!   same facts across many turns ("use PostgreSQL", "prefer async",
+//!   "monorepo layout"). Without deduplication that noise accumulates
+//!   in the vector index, degrading retrieval quality over time. The two
+//!   primitives here are the write-time pair every persistent-memory
+//!   system needs: extract first, then store without duplicates.
+//!
+//! Scenario:
+//!   A backend team runs an AI agent for two planning sessions on the
+//!   same service.  Both sessions surface overlapping architecture facts.
+//!   We extract facts from each session, store them in a
+//!   `DedupVectorStore`, and show that the second session adds only the
+//!   genuinely new information — the rest is silently skipped.
+//!
+//! Run with (Ollama — no API key needed):
+//!   COGNIS_PROVIDER=ollama COGNIS_OLLAMA_MODEL=qwen2.5:3b \
+//!     cargo run -p cognis-examples --example memory_fact_extraction
+//!
+//! Run with (Anthropic):
+//!   COGNIS_PROVIDER=anthropic COGNIS_ANTHROPIC_API_KEY=sk-ant-… \
+//!     cargo run -p cognis-examples --example memory_fact_extraction
+//!
+//! Run with (OpenAI):
+//!   COGNIS_PROVIDER=openai COGNIS_OPENAI_API_KEY=sk-… \
+//!     cargo run -p cognis-examples --example memory_fact_extraction
+//!
+//! Note: smaller Ollama models (1b, 3b) sometimes emit prose instead of
+//! JSON.  `FactExtractor` handles that gracefully — it returns an empty
+//! Vec and logs a warning rather than propagating an error.  For reliable
+//! JSON output use qwen2.5:3b, llama3.1:8b, or any hosted provider.
+//!
+//! Sample output (against ollama / qwen2.5:3b):
+//!   Backend: ollama
+//!
+//!   ── Session 1: initial planning ──────────────────────────────────────
+//!   Extracted 6 fact(s):
+//!     [Decision]    (0.90)  The team decided to keep all services in a single Rust workspace (monorepo).
+//!     [Observation] (0.80)  The main reason was that the overhead of cross-repo dependency management …
+//!     [Rule]        (0.90)  Engineers must always run `cargo fmt --all` and `cargo clippy` before pushing.
+//!     [Preference]  (0.80)  The team prefers async-first code using tokio.
+//!     [Observation] (0.70)  We use PostgreSQL for persistent storage and Redis for caching hot data.
+//!     [Observation] (0.60)  The billing service will be a new crate inside the existing workspace.
+//!   Stored 6 fact(s) in the memory index.
+//!
+//!   ── In-session dedup demo ─────────────────────────────────────────────
+//!   Re-adding the same 6 facts verbatim …
+//!   Skipped 6/6 — already in the index.
+//!
+//!   ── Session 2: follow-up ─────────────────────────────────────────────
+//!   Extracted 3 fact(s):
+//!     [Context]     (0.50)  PostgreSQL will store all billing records in the billing service.
+//!     [Context]     (0.50)  gRPC is being used for inter-service communication.
+//!     [Rule]        (0.70)  The team follows cargo fmt and clippy before every push.
+//!   Added 3 new fact(s), skipped 0 duplicate(s).   ← new phrasing → new fingerprints
+//!   Memory index: 6 → 9 unique document(s).
+//!
+//!   ── Generic LlmExtractor<TechStack> ──────────────────────────────────
+//!   runtime:   tokio
+//!   languages: Rust
+//!   databases: PostgreSQL, Redis
+//!
+//!   ── Dedup persistence across restarts ───────────────────────────────
+//!   Fingerprints to persist: 9
+//!   After restore: 9/9 facts correctly skipped as duplicates.
+
+use std::sync::Arc;
+
+use cognis::prelude::*;
+use cognis::agent::{Fact, FactExtractionInput, FactExtractor, LlmExtractor};
+use cognis::{DedupVectorStore, FakeEmbeddings, InMemoryVectorStore};
+use cognis_core::schemars::{self, JsonSchema};
+use serde::Deserialize;
+
+// ── two planning-session outputs ───────────────────────────────────────────
+
+const SESSION_1: &str = "\
+After evaluating several approaches the team decided to keep all services in a \
+single Rust workspace (monorepo) rather than splitting into separate repositories. \
+The main reason was that the overhead of cross-repo dependency management \
+outweighed any isolation benefit at current scale.
+
+Engineers must always run `cargo fmt --all` and `cargo clippy` before pushing. \
+The team prefers async-first code using tokio. We use PostgreSQL for persistent \
+storage and Redis for caching hot data. The billing service will be a new crate \
+inside the existing workspace.";
+
+// The second session overlaps on most facts (fmt rule, postgres, async preference)
+// but introduces one genuinely new fact: gRPC for inter-service comms.
+const SESSION_2: &str = "\
+Follow-up on the billing service design. The billing service is a crate inside \
+the existing Rust workspace. We confirmed that PostgreSQL will store all billing \
+records. The team is adopting gRPC for inter-service communication because it \
+gives us typed contracts across teams. Code quality: run cargo fmt and clippy \
+before every push — this is non-negotiable.";
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+fn print_facts(facts: &[Fact]) {
+    if facts.is_empty() {
+        println!("  (no facts extracted — model may not have returned JSON)");
+        return;
+    }
+    for fact in facts {
+        println!(
+            "  [{:12?}] ({:.2})  {}",
+            fact.kind, fact.importance, fact.content
+        );
+    }
+}
+
+// ── main ───────────────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Arc::new(Client::from_env()?);
+
+    // Show which backend we resolved from the environment.
+    println!("Backend: {}\n", client.provider().name());
+
+    // --------------------------------------------------------------------------
+    // 1. FactExtractor — two sessions, overlapping facts
+    // --------------------------------------------------------------------------
+
+    let extractor = FactExtractor::new(Arc::clone(&client));
+
+    // Session 1 ─────────────────────────────────────────────────────────────
+    println!("── Session 1: initial planning ──────────────────────────────────────");
+    let session1_facts: Vec<Fact> = extractor
+        .invoke(
+            FactExtractionInput::new(SESSION_1)
+                .with_hint("project: billing-service")
+                .with_hint("team: backend")
+                .with_max_facts(7),
+            Default::default(),
+        )
+        .await?;
+
+    println!("Extracted {} fact(s):", session1_facts.len());
+    print_facts(&session1_facts);
+
+    // Store session-1 facts in the dedup store.
+    // FakeEmbeddings is used here because this demo is about deduplication,
+    // not semantic search. In production wire up OllamaEmbeddings or
+    // OpenAIEmbeddings so similarity_search returns meaningful results.
+    let embedder = Arc::new(FakeEmbeddings::new(16));
+    let mut memory: DedupVectorStore<InMemoryVectorStore> =
+        DedupVectorStore::new(InMemoryVectorStore::new(embedder));
+
+    for fact in &session1_facts {
+        memory.add_texts(vec![fact.content.clone()], None).await?;
+    }
+    println!("\nStored {} fact(s) in the memory index.", memory.len());
+
+    // In-session dedup: re-adding the same facts verbatim must all be skipped.
+    println!("\n── In-session dedup demo ─────────────────────────────────────────────");
+    println!("Re-adding the same {} facts verbatim …", session1_facts.len());
+    let mut in_session_skipped = 0usize;
+    for fact in &session1_facts {
+        let ids = memory.add_texts(vec![fact.content.clone()], None).await?;
+        if ids[0].starts_with("dedup:skipped:") {
+            in_session_skipped += 1;
+        }
+    }
+    println!(
+        "Skipped {in_session_skipped}/{} — already in the index.\n",
+        session1_facts.len()
+    );
+
+    // Session 2 ─────────────────────────────────────────────────────────────
+    println!("── Session 2: follow-up ─────────────────────────────────────────────");
+    let session2_facts: Vec<Fact> = extractor
+        .invoke(
+            FactExtractionInput::new(SESSION_2)
+                .with_hint("project: billing-service")
+                .with_hint("team: backend")
+                .with_max_facts(7),
+            Default::default(),
+        )
+        .await?;
+
+    println!("Extracted {} fact(s):", session2_facts.len());
+    print_facts(&session2_facts);
+    println!();
+
+    let before = memory.len();
+    let mut stored = 0usize;
+    let mut skipped = 0usize;
+
+    for fact in &session2_facts {
+        let ids = memory
+            .add_texts(vec![fact.content.clone()], None)
+            .await?;
+        if ids[0].starts_with("dedup:skipped:") {
+            skipped += 1;
+        } else {
+            stored += 1;
+        }
+    }
+    let after = memory.len();
+
+    println!("Added {stored} new fact(s), skipped {skipped} duplicate(s).");
+    println!(
+        "Memory index: {} → {} unique document(s).\n",
+        before, after
+    );
+
+    // --------------------------------------------------------------------------
+    // 2. LlmExtractor<T> — generic extraction with a custom output type
+    //    Shows that any DeserializeOwned + JsonSchema type works as O.
+    // --------------------------------------------------------------------------
+
+    #[derive(Debug, Deserialize, JsonSchema)]
+    struct TechStack {
+        /// Primary programming language(s) mentioned.
+        languages: Vec<String>,
+        /// Database systems mentioned.
+        databases: Vec<String>,
+        /// Async runtime or web framework mentioned, or "unknown".
+        runtime: String,
+    }
+
+    println!("── Generic LlmExtractor<TechStack> ─────────────────────────────────");
+    let stack_extractor = LlmExtractor::<TechStack>::builder(Arc::clone(&client))
+        .system_prompt(
+            "Extract the technology stack from the provided text. \
+             If a field has no value use an empty list or \"unknown\".",
+        )
+        .build();
+
+    match stack_extractor
+        .invoke(SESSION_1.to_string(), Default::default())
+        .await
+    {
+        Ok(stack) => {
+            println!("runtime:   {}", stack.runtime);
+            println!("languages: {}", stack.languages.join(", "));
+            println!("databases: {}", stack.databases.join(", "));
+        }
+        Err(e) => {
+            // Smaller models sometimes don't produce valid JSON even with
+            // format instructions.  Surface the error rather than panicking.
+            println!("(parse failed — model did not return JSON: {e})");
+            println!("Tip: try a larger model such as qwen2.5:7b or llama3.1:8b");
+        }
+    }
+
+    // --------------------------------------------------------------------------
+    // 3. Fingerprint persistence — show how to restore seen-set across restarts
+    // --------------------------------------------------------------------------
+
+    println!("\n── Dedup persistence across restarts ───────────────────────────────");
+
+    // Collect fingerprints from the in-memory store — in production you'd
+    // persist these to a DB or file and reload them on startup.
+    let persisted: Vec<String> = memory.seen_fingerprints().map(str::to_owned).collect();
+    println!("Fingerprints to persist: {}", persisted.len());
+
+    // Simulate restart: new store pre-seeded with saved fingerprints.
+    let fresh_embedder = Arc::new(FakeEmbeddings::new(16));
+    let mut restored: DedupVectorStore<InMemoryVectorStore> = DedupVectorStore::with_seen(
+        InMemoryVectorStore::new(fresh_embedder),
+        persisted,
+    );
+
+    // Re-inserting any already-seen fact must be skipped, even in a fresh process.
+    let all_facts: Vec<&Fact> = session1_facts.iter().chain(&session2_facts).collect();
+    let mut still_skipped = 0usize;
+    for fact in &all_facts {
+        let ids = restored
+            .add_texts(vec![fact.content.clone()], None)
+            .await?;
+        if ids[0].starts_with("dedup:skipped:") {
+            still_skipped += 1;
+        }
+    }
+    println!(
+        "After restore: {still_skipped}/{} facts correctly skipped as duplicates.",
+        all_facts.len()
+    );
+
+    Ok(())
+}

--- a/examples/memory/fact_extraction.rs
+++ b/examples/memory/fact_extraction.rs
@@ -73,8 +73,8 @@
 
 use std::sync::Arc;
 
-use cognis::prelude::*;
 use cognis::agent::{Fact, FactExtractionInput, FactExtractor, LlmExtractor};
+use cognis::prelude::*;
 use cognis::{DedupVectorStore, FakeEmbeddings, InMemoryVectorStore};
 use cognis_core::schemars::{self, JsonSchema};
 use serde::Deserialize;
@@ -161,7 +161,10 @@ async fn main() -> Result<()> {
 
     // In-session dedup: re-adding the same facts verbatim must all be skipped.
     println!("\n── In-session dedup demo ─────────────────────────────────────────────");
-    println!("Re-adding the same {} facts verbatim …", session1_facts.len());
+    println!(
+        "Re-adding the same {} facts verbatim …",
+        session1_facts.len()
+    );
     let mut in_session_skipped = 0usize;
     for fact in &session1_facts {
         let ids = memory.add_texts(vec![fact.content.clone()], None).await?;
@@ -195,9 +198,7 @@ async fn main() -> Result<()> {
     let mut skipped = 0usize;
 
     for fact in &session2_facts {
-        let ids = memory
-            .add_texts(vec![fact.content.clone()], None)
-            .await?;
+        let ids = memory.add_texts(vec![fact.content.clone()], None).await?;
         if ids[0].starts_with("dedup:skipped:") {
             skipped += 1;
         } else {
@@ -207,10 +208,7 @@ async fn main() -> Result<()> {
     let after = memory.len();
 
     println!("Added {stored} new fact(s), skipped {skipped} duplicate(s).");
-    println!(
-        "Memory index: {} → {} unique document(s).\n",
-        before, after
-    );
+    println!("Memory index: {} → {} unique document(s).\n", before, after);
 
     // --------------------------------------------------------------------------
     // 2. LlmExtractor<T> — generic extraction with a custom output type
@@ -265,18 +263,14 @@ async fn main() -> Result<()> {
 
     // Simulate restart: new store pre-seeded with saved fingerprints.
     let fresh_embedder = Arc::new(FakeEmbeddings::new(16));
-    let mut restored: DedupVectorStore<InMemoryVectorStore> = DedupVectorStore::with_seen(
-        InMemoryVectorStore::new(fresh_embedder),
-        persisted,
-    );
+    let mut restored: DedupVectorStore<InMemoryVectorStore> =
+        DedupVectorStore::with_seen(InMemoryVectorStore::new(fresh_embedder), persisted);
 
     // Re-inserting any already-seen fact must be skipped, even in a fresh process.
     let all_facts: Vec<&Fact> = session1_facts.iter().chain(&session2_facts).collect();
     let mut still_skipped = 0usize;
     for fact in &all_facts {
-        let ids = restored
-            .add_texts(vec![fact.content.clone()], None)
-            .await?;
+        let ids = restored.add_texts(vec![fact.content.clone()], None).await?;
         if ids[0].starts_with("dedup:skipped:") {
             still_skipped += 1;
         }


### PR DESCRIPTION
## Summary

Implements issues #40 and #41 as a single integrated feature pair — the two primitives that every persistent-memory system needs at write time.

- **`DedupVectorStore<S, F>`** (`cognis-rag`) — content-fingerprinting decorator over any `VectorStore`. Silently drops documents whose normalised text has already been seen. Generic over both the inner store and the fingerprint function so callers can supply a custom key at zero runtime cost.

- **`LlmExtractor<O>`** (`cognis`) — generic `Runnable<String, O>` for any `O: DeserializeOwned + JsonSchema`. Derives format instructions from the JSON Schema automatically. The reusable building block underneath `FactExtractor`.

- **`FactExtractor`** (`cognis`) — ready-to-use specialisation of `LlmExtractor` that maps `FactExtractionInput → Vec<Fact>`. Parse failures are swallowed (`Ok(vec![])` + WARN log) so the memory write path never stalls on a badly-formatted model response.

## What's new

| File | What |
|---|---|
| `crates/cognis-rag/src/vectorstore/dedup.rs` | `DedupVectorStore<S,F>`, `normalized_fingerprint` — 15 tests |
| `crates/cognis/src/agent/fact_extractor.rs` | `LlmExtractor<O>`, `FactExtractor`, `Fact`, `FactKind`, `FactExtractionInput` — 10 tests |
| `examples/memory/fact_extraction.rs` | End-to-end demo (Ollama-verified) |

All types re-exported from `cognis::agent` and `cognis` top-level.

## Design decisions

**Generic fingerprint function** — `DedupVectorStore<S, F>` uses a type parameter for the fingerprint function rather than `Arc<dyn Fn>` so there is no heap allocation or vtable call on the hot add path. `DedupVectorStore::new` default-types `F` to `fn(&str) -> String` with `normalized_fingerprint` as the value, keeping the simple case ergonomic.

**Restart persistence** — the seen-set is in-memory only. `DedupVectorStore::with_seen` and the public `normalized_fingerprint` function let callers pre-seed hashes from storage on startup; `seen_fingerprints()` exposes the set for serialisation on shutdown.

**Error-swallowing on `FactExtractor`** — intentional. The write path to a memory store must not block because of a chatty model response. `LlmExtractor` propagates errors normally; only `FactExtractor` swallows them.

**`LlmExtractor` as public primitive** — any extraction task (sentiment, entity, classification, custom schema) uses it directly without going through `FactExtractor`. This was the generic-at-library-level requirement from the issue.

## Test plan

- [x] `cargo test -p cognis-rag --lib vectorstore::dedup` — 15/15
- [x] `cargo test -p cognis --lib agent::fact_extractor` — 10/10
- [x] `cargo build --workspace` — clean
- [x] `COGNIS_PROVIDER=ollama COGNIS_OLLAMA_MODEL=qwen2.5:3b cargo run -p cognis-examples --example memory_fact_extraction` — verified end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds write-time memory deduplication and a generic LLM-based extractor to prevent duplicate index entries and enable schema-driven extraction. Implements #40 and #41.

- **New Features**
  - `cognis-rag`: `DedupVectorStore<S, F>` — drops duplicate documents by a content fingerprint; default `normalized_fingerprint` (lowercase + whitespace collapse + FNV-1a); supports custom keys; `with_seen`/`seen_fingerprints()` for restart persistence; preserves output length by returning `dedup:skipped:{fingerprint}` for skipped items.
  - `cognis`: `LlmExtractor<O>` — `Runnable<String, O>` that derives JSON Schema format instructions and parses prose-wrapped JSON; builder for prompt and parser config.
  - `cognis`: `FactExtractor` — `Runnable<FactExtractionInput, Vec<Fact>>` producing `Fact { content, kind, importance }`; swallows parse errors (returns `[]`) to keep memory writes non-blocking.
  - Re-exports from `cognis::agent` and crate root; adds example `memory_fact_extraction` showing `FactExtractor` + `DedupVectorStore`.

<sup>Written for commit 9ade2ab1e54b7f7834ad0ab74fd67b05a9cba99c. Summary will update on new commits. <a href="https://cubic.dev/pr/0xvasanth/cognis/pull/42?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

